### PR TITLE
Create a search endpoint and basic search results

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgment_text_source.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_source.html
@@ -1,5 +1,5 @@
 <div class="judgment-text-source">
     <div class="judgment-text-source__container">
-        <p>This judgment has been provided to The National Archives by <a href="{% url 'source' %}">[Name of source]</a></p>
+        <p>This judgment has been provided to The National Archives by <a href="{% url 'sources' %}">[Name of source]</a></p>
     </div>
 </div>

--- a/ds_judgements_public_ui/templates/includes/results_list.html
+++ b/ds_judgements_public_ui/templates/includes/results_list.html
@@ -1,17 +1,23 @@
 <h2>Search results</h2>
-<p class="results__results-intro">We found 760 judgments</p>
+<p class="results__results-intro">We found {{ context.total }} judgments</p>
 <ul class="results__results-list">
-  {% for result in search_results %}
+  {% for result in context.search_results %}
     <li>
       <dl class="results__result-terms">
         <dt class="results__result-term-sr">Title</dt>
         <dd>
-          <a class="results__result-title" href="{# {{ url_for('judgment', origin='results', return_link=request.url) }} #}">{{ result.title | safe }}</a>
+          <a class="results__result-title" href="{% url 'detail' result.uri %}">
+            {{ result.uri | safe }}
+          </a>
         </dd>
         <dt class="results__result-term-sr">Neutral citation</dt>
-        <dd class="results__result-neutral-citation">{{ result.neutral_citation }}</dd>
+        <dd class="results__result-neutral-citation">[Not yet implemented]</dd>
         <dt class="results__result-term-matching">Matching text sample</dt>
-        <dd>{{ result.snippet | safe }}</dd>
+        <dd>
+          {% for snippet in result.matches %}
+            <p>{{ snippet | safe }}</p>
+          {% endfor %}
+        </dd>
       </dl>
     </li>
   {% endfor %}

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -3,10 +3,9 @@ from django.urls import path, re_path
 from . import views
 
 urlpatterns = [
-    path("", views.index, name="index"),
-    re_path("(?P<page>\\d)", views.index, name="index"),
     re_path("(?P<judgment_uri>.*/.*/.*)", views.detail, name="detail"),
-    path("source", views.source, name="source"),
-    path("structured_search", views.structured_search, name="structured_search"),
+    re_path("(?P<page>\\d)", views.index, name="index"),
+    path("search", views.search, name="search"),
     path("results", views.results, name="results"),
+    path("", views.index, name="index"),
 ]

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -23,7 +23,7 @@ def detail(request, judgment_uri):
 def index(request, page=1):
     context = {"page": page, "prev_page": int(page) - 1, "next_page": int(page) + 1}
     try:
-        results = api_client.get_judgment_search_results(page)
+        results = api_client.get_judgments_index(page)
         if type(results) == str:
             xml_results = xmltodict.parse(results)
             total = xml_results["search:response"]["@total"]

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -7,7 +7,11 @@ from lxml import etree
 from requests_toolbelt.multipart import decoder
 
 from marklogic import xml_tools
-from marklogic.api_client import MarklogicResourceNotFoundError, api_client
+from marklogic.api_client import (
+    MarklogicAPIError,
+    MarklogicResourceNotFoundError,
+    api_client,
+)
 from marklogic.xml_tools import JudgmentMissingMetadataError
 
 
@@ -42,33 +46,8 @@ def index(request, page=1):
 
             search_metadata = xmltodict.parse(multipart_data.parts[0].text)
             total = search_metadata["search:response"]["@total"]
+            search_results = format_index_results(multipart_data)
 
-            search_results = []
-
-            for part in multipart_data.parts[1::]:
-                metadata = part.headers
-                content_disposition = metadata[b"Content-Disposition"].decode("utf-8")
-                filename = re.search('filename="([^"]*)"', content_disposition).group(1)
-                filename = filename.split(".xml")[0]
-                xml = etree.XML(bytes(part.text, encoding="utf8"))
-
-                try:
-                    neutral_citation = xml_tools.get_neutral_citation(xml)
-                except JudgmentMissingMetadataError:
-                    neutral_citation = filename
-
-                try:
-                    name = xml_tools.get_metadata_name_value(xml)
-                except JudgmentMissingMetadataError:
-                    name = "Untitled Judgment"
-
-                search_results.append(
-                    {
-                        "uri": trim_leading_slash(filename),
-                        "neutral_citation": neutral_citation,
-                        "name": name,
-                    }
-                )
         context["total"] = total
         context["search_results"] = search_results
 
@@ -78,12 +57,63 @@ def index(request, page=1):
     return HttpResponse(template.render({"context": context}, request))
 
 
-def source():
-    return
+def search(request):
+    context = {}
+    try:
+        params = request.GET
+        query = params["query"]
+        page = params.get("page") if params.get("page") else "1"
+        results = api_client.search_judgments(query, page)
+        xml = etree.XML(bytes(results.text, encoding="utf8"))
+        context["total"] = xml_tools.get_search_total(xml)
+
+        chunked_results = xml_tools.get_search_results(xml)
+        search_results = [
+            {
+                "uri": trim_leading_slash(result.xpath("@uri")[0]).split(".xml")[0],
+                "matches": xml_tools.get_search_matches(result),
+            }
+            for result in chunked_results
+        ]
+        context["search_results"] = search_results
+    except MarklogicAPIError:
+        raise Http404("Search error")  # TODO: This should be something else!
+    template = loader.get_template("judgment/results.html")
+    return HttpResponse(template.render({"context": context}, request))
 
 
-def structured_search():
-    return
+def format_index_results(multipart_data):
+    search_results = []
+
+    for part in multipart_data.parts[1::]:
+        metadata = part.headers
+        content_disposition = metadata[b"Content-Disposition"].decode("utf-8")
+        filename = re.search('filename="([^"]*)"', content_disposition).group(1)
+        filename = filename.split(".xml")[0]
+        xml = etree.XML(bytes(part.text, encoding="utf8"))
+
+        try:
+            neutral_citation = xml_tools.get_neutral_citation(xml)
+        except JudgmentMissingMetadataError:
+            neutral_citation = filename
+
+        try:
+            name = xml_tools.get_metadata_name_value(xml)
+        except JudgmentMissingMetadataError:
+            name = "Untitled Judgment"
+
+        search_results.append(
+            {
+                "uri": trim_leading_slash(filename),
+                "neutral_citation": neutral_citation,
+                "name": name,
+            }
+        )
+    return search_results
+
+
+def format_search_results(xml):
+    return xml_tools.get_search_matches(xml)
 
 
 def trim_leading_slash(uri):

--- a/marklogic/api_client.py
+++ b/marklogic/api_client.py
@@ -134,6 +134,11 @@ class MarklogicApiClient:
             body=xml,
         )
 
+    def search_judgments(self, query: str, page: str) -> requests.Response:
+        start = (int(page) - 1) * RESULTS_PER_PAGE + 1
+        headers = {"Accept": "text/xml"}
+        return self.GET("LATEST/search/?start=" + str(start) + "&q=" + query, headers)
+
 
 class MockAPIClient:
 

--- a/marklogic/api_client.py
+++ b/marklogic/api_client.py
@@ -119,7 +119,7 @@ class MarklogicApiClient:
         headers = {"Accept": "text/xml"}
         return self.GET(f"LATEST/documents/?uri=/{uri.lstrip('/')}.xml", headers).text
 
-    def get_judgment_search_results(self, page: str) -> requests.Response:
+    def get_judgments_index(self, page: str) -> requests.Response:
         start = (int(page) - 1) * RESULTS_PER_PAGE + 1
         headers = {"Accept": "multipart/mixed"}
         return self.GET("LATEST/search/?view=results&start=" + str(start), headers)
@@ -147,7 +147,7 @@ class MockAPIClient:
         except FileNotFoundError:
             raise MarklogicResourceNotFoundError
 
-    def get_judgment_search_results(self, page: int) -> str:
+    def get_judgments_index(self, page: int) -> str:
         filepath = os.path.join(
             self.fixtures_dir, "search", "results" + str(page) + ".xml"
         )

--- a/marklogic/tests.py
+++ b/marklogic/tests.py
@@ -101,6 +101,58 @@ class TestXmlTools(TestCase):
             JudgmentMissingMetadataError, xml_tools.get_neutral_citation, xml
         )
 
+    def test_search_total(self):
+        xml_string = """
+            <search:response xmlns:search="http://marklogic.com/appservices/search" total="40784">
+            </search:response>
+        """
+        xml = etree.fromstring(xml_string)
+        result = xml_tools.get_search_total(xml)
+        self.assertEqual(result, "40784")
+
+    def test_search_results(self):
+        xml_string = """
+            <search:response xmlns:search="http://marklogic.com/appservices/search" total="40784">
+                <search:result index="11"
+                               uri="/ewhc/admin/2013/2575.xml"
+                               path="fn:doc('/ewhc/admin/2013/2575.xml')"
+                               href="/v1/documents?uri=%2Fewhc%2Fadmin%2F2013%2F2575.xml"
+                               mimetype="application/xml"
+                               format="xml">
+                    <search:snippet>
+                        <search:match
+                            path="fn:doc('/ewhc/admin/2013/2575.xml')/*:akomaNtoso/*:judgment/*:header/*:p[9]/*:span">
+                            HH <search:highlight>Judge</search:highlight> Anthony Thornton QC
+                        </search:match>
+                    </search:snippet>
+                </search:result>
+            </search:response>
+        """
+        xml = etree.fromstring(xml_string)
+        result = xml_tools.get_search_results(xml)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(type(result[0]).__name__, "_Element")
+
+    def test_search_matches(self):
+        xml_string = """
+            <search:result index="11" xmlns:search="http://marklogic.com/appservices/search"
+                uri="/ewhc/admin/2013/2575.xml"
+                path="fn:doc('/ewhc/admin/2013/2575.xml')"
+                href="/v1/documents?uri=%2Fewhc%2Fadmin%2F2013%2F2575.xml"
+                mimetype="application/xml"
+                format="xml">
+                <search:snippet>
+                    <search:match
+                        path="fn:doc('/ewhc/admin/2013/2575.xml')/*:akomaNtoso/*:judgment/*:header/*:p[9]/*:span">
+                        HH <search:highlight>Judge</search:highlight> Anthony Thornton QC
+                    </search:match>
+                </search:snippet>
+            </search:result>
+        """
+        xml = etree.fromstring(xml_string)
+        result = xml_tools.get_search_matches(xml)
+        self.assertEqual(result, ["HH Judge Anthony Thornton QC"])
+
 
 class TestApiClient(TestCase):
     def test_get_judgment_xml(self):

--- a/marklogic/tests.py
+++ b/marklogic/tests.py
@@ -112,10 +112,10 @@ class TestApiClient(TestCase):
             "LATEST/documents/?uri=/ewca/civ/2004/632.xml", {"Accept": "text/xml"}
         )
 
-    def test_get_judgment_search_results(self):
+    def test_get_judgments_index(self):
         mock_api_client = MarklogicApiClient("a", "b", "c", True)
         mock_api_client.GET = MagicMock()
-        mock_api_client.get_judgment_search_results("1")
+        mock_api_client.get_judgments_index("1")
         mock_api_client.GET.assert_called_with(
             "LATEST/search/?view=results&start=1", {"Accept": "multipart/mixed"}
         )

--- a/marklogic/xml_tools.py
+++ b/marklogic/xml_tools.py
@@ -1,6 +1,9 @@
 from xml.etree.ElementTree import Element
 
+from lxml import etree
+
 akn_namespace = {"akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"}
+search_namespace = {"search": "http://marklogic.com/appservices/search"}
 
 
 class JudgmentMissingMetadataError(IndexError):
@@ -38,3 +41,20 @@ def get_neutral_citation(xml) -> str:
     except IndexError:
         raise JudgmentMissingMetadataError
     return neutral_citation
+
+
+def get_search_total(xml) -> str:
+    return xml.xpath("//search:response/@total", namespaces=search_namespace)[0]
+
+
+def get_search_results(xml) -> [Element]:
+    return xml.xpath("//search:response/search:result", namespaces=search_namespace)
+
+
+def get_search_matches(element) -> [str]:
+    nodes = element.xpath("//search:match", namespaces=search_namespace)
+    results = []
+    for node in nodes:
+        text = etree.tostring(node, method="text", encoding="UTF-8")
+        results.append(text.decode("UTF-8").strip())
+    return results


### PR DESCRIPTION
Create a search endpoint (`judgments/search?q=query`) in the Marklogic API Client.

Format the search results in a very basic way (see screenshot) and link to the full judgment in each search result.

<img width="1222" alt="Screenshot 2022-02-21 at 12 24 54" src="https://user-images.githubusercontent.com/1089521/154954936-9ad3770e-4f4f-4085-8846-a7b00fdd243a.png">

TODO: Add neutral citation to search result. Add pagination.