### PR TITLE
(Chore) Use RESULTS_PER_PAGE when querying Marklogic

### DIFF
--- a/marklogic/api_client.py
+++ b/marklogic/api_client.py
@@ -122,7 +122,10 @@ class MarklogicApiClient:
     def get_judgments_index(self, page: str) -> requests.Response:
         start = (int(page) - 1) * RESULTS_PER_PAGE + 1
         headers = {"Accept": "multipart/mixed"}
-        return self.GET("LATEST/search/?view=results&start=" + str(start), headers)
+        return self.GET(
+            f"LATEST/search/?view=results&start={start}&pageLength={RESULTS_PER_PAGE}",
+            headers,
+        )
 
     def save_judgment_xml(self, uri: str, judgment_xml: Element) -> requests.Response:
         xml = etree.tostring(judgment_xml)
@@ -137,7 +140,10 @@ class MarklogicApiClient:
     def search_judgments(self, query: str, page: str) -> requests.Response:
         start = (int(page) - 1) * RESULTS_PER_PAGE + 1
         headers = {"Accept": "text/xml"}
-        return self.GET("LATEST/search/?start=" + str(start) + "&q=" + query, headers)
+        return self.GET(
+            f"LATEST/search/?start={start}&q={query}&pageLength={RESULTS_PER_PAGE}",
+            headers,
+        )
 
 
 class MockAPIClient:

--- a/marklogic/tests.py
+++ b/marklogic/tests.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 from lxml import etree
 
+import marklogic.api_client
 from marklogic import xml_tools
 from marklogic.api_client import MarklogicApiClient
 from marklogic.xml_tools import JudgmentMissingMetadataError
@@ -165,11 +166,13 @@ class TestApiClient(TestCase):
         )
 
     def test_get_judgments_index(self):
+        page_length = marklogic.api_client.RESULTS_PER_PAGE
         mock_api_client = MarklogicApiClient("a", "b", "c", True)
         mock_api_client.GET = MagicMock()
         mock_api_client.get_judgments_index("1")
         mock_api_client.GET.assert_called_with(
-            "LATEST/search/?view=results&start=1", {"Accept": "multipart/mixed"}
+            "LATEST/search/?view=results&start=1&pageLength=" + str(page_length),
+            {"Accept": "multipart/mixed"},
         )
 
     def test_save_judgment_xml(self):


### PR DESCRIPTION
The Marklogic REST endpoints take a `pageLength` param. We will need to set
the number of items per page eventually, so start using this variable now.