### PR TITLE
Amend URL for Judgment detail page

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -35,7 +35,7 @@ urlpatterns = [
     # Django Admin, use {% url 'admin:index' %}
     path(settings.ADMIN_URL, admin.site.urls),
     # Your stuff: custom urls includes go here
-    path("judgments/", include("judgments.urls")),
+    path("", include("judgments.urls")),
     path("judgments_admin/", include("judgments_admin.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -4,7 +4,7 @@ from . import views
 
 urlpatterns = [
     re_path("(?P<judgment_uri>.*/.*/.*)", views.detail, name="detail"),
-    path("search", views.search, name="search"),
-    path("results", views.results, name="results"),
-    path("", views.index, name="index"),
+    path("judgments/search", views.search, name="search"),
+    path("judgments/results", views.results, name="results"),
+    path("judgments/", views.index, name="index"),
 ]


### PR DESCRIPTION
The URL for judgments should be `host/uri`, not `host/judgments/uri` as
per the URI scheme