### PR TITLE
Add an XML route to get the Judgment XML as a download

### DIFF
--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -3,6 +3,8 @@ from django.urls import path, re_path
 from . import views
 
 urlpatterns = [
+    re_path("(?P<judgment_uri>.*/.*/.*)/data.xml", views.detail_xml, name="detail"),
+    re_path("(?P<judgment_uri>.*/.*/.*)/data.html", views.detail, name="detail"),
     re_path("(?P<judgment_uri>.*/.*/.*)", views.detail, name="detail"),
     path("judgments/search", views.search, name="search"),
     path("judgments/results", views.results, name="results"),

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -24,6 +24,16 @@ def detail(request, judgment_uri):
     return HttpResponse(template.render({"xml": judgment_xml}, request))
 
 
+def detail_xml(_request, judgment_uri):
+    try:
+        judgment_xml = api_client.get_judgment_xml(judgment_uri)
+    except MarklogicResourceNotFoundError:
+        raise Http404("Judgment was not found")
+    response = HttpResponse(judgment_xml, content_type="application/xml")
+    response["Content-Disposition"] = f"attachment; filename={judgment_uri}.xml"
+    return response
+
+
 def index(request):
     context = {}
     params = request.GET


### PR DESCRIPTION
As per the URI scheme, judgments should be accessible at `uri/data.html` and
`uri/data.xml`, and serve the LegalDocXML at the latter address.