### PR TITLE
Update search results routes & template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,8 @@ typings/
 # Optional npm cache directory
 .npm
 
+.sass-cache/
+
 # Optional eslint cache
 .eslintcache
 

--- a/ds_judgements_public_ui/templates/includes/pagination.html
+++ b/ds_judgements_public_ui/templates/includes/pagination.html
@@ -26,7 +26,7 @@
         {% for page in context.paginator.next_pages %}
           <li class="pagination__list-item">
             <a class="pagination__page-link"
-               href="{{request.path}}?{% if context.query %}query={{context.query}}&{% endif %}&page={{page}}"
+               href="{{request.path}}?{% if context.query %}query={{context.query}}&{% endif %}page={{page}}"
                aria-label="Go to page {{page}}">
               <span>Page </span>{{page}}
             </a>

--- a/ds_judgements_public_ui/templates/includes/results_list.html
+++ b/ds_judgements_public_ui/templates/includes/results_list.html
@@ -12,12 +12,14 @@
         </dd>
         <dt class="results__result-term-sr">Neutral citation</dt>
         <dd class="results__result-neutral-citation">{{ result.neutral_citation }}</dd>
-        <dt class="results__result-term-matching">Matching text sample</dt>
-        <dd>
-          {% autoescape off %}
-            {{ result.matches }}
-          {% endautoescape %}
-        </dd>
+        {% if result.matches %}
+          <dt class="results__result-term-matching">Matching text sample</dt>
+          <dd>
+            {% autoescape off %}
+              {{ result.matches }}
+            {% endautoescape %}
+          </dd>
+        {% endif %}
       </dl>
     </li>
   {% endfor %}

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -4,7 +4,6 @@ from . import views
 
 urlpatterns = [
     re_path("(?P<judgment_uri>.*/.*/.*)", views.detail, name="detail"),
-    path("judgments/search", views.search, name="search"),
     path("judgments/results", views.results, name="results"),
     path("judgments/", views.index, name="index"),
 ]


### PR DESCRIPTION
After merging https://github.com/nationalarchives/ds-caselaw-public-ui/pull/42 we need to update the search results page route from `search` to `results`. 

Also amend the view & template, so that if no search query is passed to the `results` page it returns a list of judgments, and if a query is passed then it does a search as normal. 