### PR TITLE
Fix Judgment routes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ You can then access the site in your browser as usual:
 
 ### Available Judgments
 
-- <http://127.0.0.1:3000/judgments/ewca/civ/2004/632>
-- <http://127.0.0.1:3000/judgments/ewca/civ/2004/811>
-- <http://127.0.0.1:3000/judgments/ewca/civ/2006/392>
-- <http://127.0.0.1:3000/judgments/ewca/civ/2007/214>
+- <http://127.0.0.1:3000/ewca/civ/2004/632>
+- <http://127.0.0.1:3000/ewca/civ/2004/811>
+- <http://127.0.0.1:3000/ewca/civ/2006/392>
+- <http://127.0.0.1:3000/ewca/civ/2007/214>
 
 ### Running tests
 


### PR DESCRIPTION
We have lost the `judgments` part of the route, but hadn't updated the README
to reflect this