### PR TITLE
(Chore) Bring Mocked Marklogic responses up to date with current APIClient

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -38,20 +38,8 @@ def index(request):
     context = {}
     try:
         results = api_client.get_judgments_index(1)
-        if type(results) == str:
-            xml_results = xmltodict.parse(results)
-            search_results = xml_results["search:response"]["search:result"]
-
-            search_results = [
-                SearchResult(
-                    uri=trim_leading_slash(result["@uri"]),
-                    neutral_citation=result["@uri"].split(".xml")[0],
-                    name="Fake Judgment name",
-                    court="Fake court",
-                    date="2021-01-01",
-                )
-                for result in search_results
-            ]
+        if type(results) == str:  # Mocked WebLogic response
+            search_results = render_mocked_results(results)
         else:
             multipart_data = decoder.MultipartDecoder.from_response(results)
 
@@ -75,30 +63,66 @@ def results(request):
         page = params.get("page") if params.get("page") else "1"
         if query:
             results = api_client.search_judgments(query, page)
+            if type(results) == str:  # Mocked WebLogic response
+                xml_results = xmltodict.parse(results)
+                total = xml_results["search:response"]["@total"]
+                search_results = render_mocked_results(results, with_matches=True)
+                context["search_results"] = search_results
+                context["total"] = total
+                context["paginator"] = paginator(int(page), total)
+            else:
+                model = SearchResults.create_from_string(results.text)
 
-            model = SearchResults.create_from_string(results.text)
-
-            context["search_results"] = [
-                SearchResult.create_from_node(result) for result in model.results
-            ]
-            context["total"] = model.total
-            context["paginator"] = paginator(int(page), model.total)
-            context["query"] = query
+                context["search_results"] = [
+                    SearchResult.create_from_node(result) for result in model.results
+                ]
+                context["total"] = model.total
+                context["paginator"] = paginator(int(page), model.total)
+                context["query"] = query
         else:
             results = api_client.get_judgments_index(page)
-            multipart_data = decoder.MultipartDecoder.from_response(results)
+            if type(results) == str:  # Mocked WebLogic response
+                xml_results = xmltodict.parse(results)
+                total = xml_results["search:response"]["@total"]
+                search_results = render_mocked_results(results)
+                context["search_results"] = search_results
+                context["total"] = total
+                context["paginator"] = paginator(int(page), total)
+            else:
+                multipart_data = decoder.MultipartDecoder.from_response(results)
 
-            search_metadata = xmltodict.parse(multipart_data.parts[0].text)
-            total = search_metadata["search:response"]["@total"]
-            search_results = format_index_results(multipart_data)
+                search_metadata = xmltodict.parse(multipart_data.parts[0].text)
+                total = search_metadata["search:response"]["@total"]
+                search_results = format_index_results(multipart_data)
 
-            context["total"] = total
-            context["search_results"] = search_results
-            context["paginator"] = paginator(int(page), total)
+                context["total"] = total
+                context["search_results"] = search_results
+                context["paginator"] = paginator(int(page), total)
     except MarklogicAPIError:
         raise Http404("Search error")  # TODO: This should be something else!
     template = loader.get_template("judgment/results.html")
     return HttpResponse(template.render({"context": context}, request))
+
+
+def render_mocked_results(results, with_matches=False):
+    xml_results = xmltodict.parse(results)
+    search_results = xml_results["search:response"]["search:result"]
+    matches = ""
+    if with_matches:
+        matches = "<p>A test <mark>matching</mark> search result</p>"
+
+    search_results = [
+        SearchResult(
+            uri=trim_leading_slash(result["@uri"]),
+            neutral_citation="Fake neutral citation",
+            name="Fake Judgment name",
+            court="Fake court",
+            date="2021-01-01",
+            matches=matches,
+        )
+        for result in search_results
+    ]
+    return search_results
 
 
 def format_index_results(multipart_data):

--- a/marklogic/api_client.py
+++ b/marklogic/api_client.py
@@ -167,6 +167,15 @@ class MockAPIClient:
         except FileNotFoundError:
             raise MarklogicResourceNotFoundError
 
+    def search_judgments(self, query: str, page: str):
+        filepath = os.path.join(
+            self.fixtures_dir, "search", "results" + str(page) + ".xml"
+        )
+        try:
+            return Path(filepath).read_text()
+        except FileNotFoundError:
+            raise MarklogicResourceNotFoundError
+
 
 if env.bool("MARKLOGIC_MOCK_REQUESTS", default=False):
     api_client = MockAPIClient()


### PR DESCRIPTION


We have added a Search Results call to the API client but has not kept the
Mocked ML Client up to date with it. This PR adds the search endpoint and
brings the search results page in line with the "real" ML responses.