### PR TITLE
(Spike) Search with XQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ machine in `docker/db/backup`
 Once Marklogic is set up, change `MARKLOGIC_MOCK_REQUESTS` to False and the application will read data from Marklogic
 instead of the file system.
 
+### Adding indexes
+
+In theory the restore from backup should create indexes in the database. If it does not, you will need to create them
+manually.
+
+In the Marklogic admin interface, first create a namespace for the index. Go to `Databases -> Judgments -> Path namespaces`
+and create a new namespace with the prefix `akn` and url `http://docs.oasis-open.org/legaldocml/ns/akn/3.0`
+
+Then, go to `Databases -> Judgments -> Path Range indexes` and create a new index with the scalar type of `date` and
+the path expression of `akn:FRBRWork/akn:FRBRdate/@date`. You can leave the other options as the defaults.
+
 ### Marklogic URL Guide
 
 - http://localhost:8000/ this is the query interface where you can browse documents in the `Judgments` database.

--- a/ds_judgements_public_ui/templates/includes/pagination.html
+++ b/ds_judgements_public_ui/templates/includes/pagination.html
@@ -4,7 +4,7 @@
     <li class="pagination__list-item">
       {% if context.paginator.has_prev_page %}
         <a class="pagination__page-chevron-previous"
-           href="{{request.path}}?{% if context.query %}query={{context.query}}&{% endif %}page={{context.paginator.prev_page}}">
+           href="{{request.path}}?{% if context.query_string %}{{context.query_string}}&{% endif %}page={{context.paginator.prev_page}}">
         <span>Previous page</span>
       </a>
       {% else %}
@@ -17,7 +17,7 @@
       <ol>
         <li class="pagination__list-item">
           <a class="pagination__page-link-current"
-             href="{{request.path}}?{% if context.query %}query={{context.query}}&{% endif %}page={{context.paginator.current_page}}"
+             href="{{request.path}}?{% if context.query_string %}{{context.query_string}}&{% endif %}page={{context.paginator.current_page}}"
              aria-label="Current page, Page {{ context.paginator.current_page }}"
              aria-current="true">
               <span>Current page </span>{{ context.paginator.current_page }}
@@ -26,7 +26,7 @@
         {% for page in context.paginator.next_pages %}
           <li class="pagination__list-item">
             <a class="pagination__page-link"
-               href="{{request.path}}?{% if context.query %}query={{context.query}}&{% endif %}page={{page}}"
+               href="{{request.path}}?{% if context.query_string %}{{context.query_string}}&{% endif %}page={{page}}"
                aria-label="Go to page {{page}}">
               <span>Page </span>{{page}}
             </a>
@@ -37,7 +37,7 @@
     <li class="pagination__list-item">
       {% if context.paginator.has_next_page %}
         <a class="pagination__page-chevron-next"
-           href="{{request.path}}?{% if context.query %}query={{context.query}}&{% endif %}&page={{context.paginator.next_page}}">
+           href="{{request.path}}?{% if context.query_string %}{{context.query_string}}&{% endif %}&page={{context.paginator.next_page}}">
           <span>Next page</span>
       </a>
       {% else %}

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -21,5 +21,6 @@ urlpatterns = [
     re_path("(?P<judgment_uri>.*/.*/.*)/data.html", views.detail, name="detail"),
     re_path("(?P<judgment_uri>.*/.*/.*)", views.detail, name="detail"),
     path("judgments/results", views.results, name="results"),
+    path("judgments/eval", views.eval, name="eval"),
     path("", views.index, name="home"),
 ]

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -21,6 +21,6 @@ urlpatterns = [
     re_path("(?P<judgment_uri>.*/.*/.*)/data.html", views.detail, name="detail"),
     re_path("(?P<judgment_uri>.*/.*/.*)", views.detail, name="detail"),
     path("judgments/results", views.results, name="results"),
-    path("judgments/eval", views.eval, name="eval"),
+    path("judgments/advanced_search", views.advanced_search, name="advanced_search"),
     path("", views.index, name="home"),
 ]

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -135,7 +135,7 @@ def results(request):
         query = params.get("query")
         page = params.get("page") if params.get("page") else "1"
         if query:
-            results = api_client.search_judgments(query, page)
+            results = api_client.basic_search(query, page)
             if type(results) == str:  # Mocked WebLogic response
                 xml_results = xmltodict.parse(results)
                 total = xml_results["search:response"]["@total"]

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -67,7 +67,7 @@ def detail(request, judgment_uri):
     return HttpResponse(template.render({"xml": judgment_xml}, request))
 
 
-def eval(request):
+def advanced_search(request):
     params = request.GET
     query = params.get("query")
     court = params.get("court")
@@ -76,7 +76,7 @@ def eval(request):
     page = params.get("page", 1)
     context = {}
     try:
-        results = api_client.search_with_eval(
+        results = api_client.advanced_search(
             q=query, court=court, judge=judge, party=party, page=page
         )
         multipart_data = decoder.MultipartDecoder.from_response(results)

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -74,11 +74,20 @@ def advanced_search(request):
     judge = params.get("judge")
     party = params.get("party")
     order = params.get("order")
+    date_from = params.get("from")
+    date_to = params.get("to")
     page = params.get("page", 1)
     context = {}
     try:
         results = api_client.advanced_search(
-            q=query, court=court, judge=judge, party=party, page=page, order=order
+            q=query,
+            court=court,
+            judge=judge,
+            party=party,
+            page=page,
+            order=order,
+            date_from=date_from,
+            date_to=date_to,
         )
         multipart_data = decoder.MultipartDecoder.from_response(results)
         model = SearchResults.create_from_string(multipart_data.parts[0].text)

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -73,11 +73,12 @@ def advanced_search(request):
     court = params.get("court")
     judge = params.get("judge")
     party = params.get("party")
+    order = params.get("order")
     page = params.get("page", 1)
     context = {}
     try:
         results = api_client.advanced_search(
-            q=query, court=court, judge=judge, party=party, page=page
+            q=query, court=court, judge=judge, party=party, page=page, order=order
         )
         multipart_data = decoder.MultipartDecoder.from_response(results)
         model = SearchResults.create_from_string(multipart_data.parts[0].text)

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -87,10 +87,9 @@ def eval(request):
         ]
         context["total"] = model.total
         context["paginator"] = paginator(int(page), model.total)
-        context["query"] = query
-        context["court"] = court
-        context["judge"] = judge
-        context["party"] = party
+        context[
+            "query_string"
+        ] = f'query={str(query or "")}&court={str(court or "")}&party={str(party or "")}&judge={str(judge or "")}'
     except MarklogicResourceNotFoundError:
         raise Http404("Search failed")  # TODO: This should be something else!
     template = loader.get_template("judgment/results.html")
@@ -151,7 +150,7 @@ def results(request):
                 ]
                 context["total"] = model.total
                 context["paginator"] = paginator(int(page), model.total)
-                context["query"] = query
+                context["query_string"] = f"query={query}"
         else:
             results = api_client.get_judgments_index(page)
             if type(results) == str:  # Mocked WebLogic response

--- a/judgments/xquery.xqy
+++ b/judgments/xquery.xqy
@@ -1,0 +1,61 @@
+xquery version "1.0-ml";
+
+import module namespace search = "http://marklogic.com/appservices/search" at "/MarkLogic/appservices/search/search.xqy";
+
+declare variable $q as xs:string? external;
+declare variable $party as xs:string? external;
+declare variable $court as xs:string? external;
+declare variable $judge as xs:string? external;
+declare variable $page as xs:integer external;
+declare variable $page-size as xs:integer external;
+let $start as xs:integer := ($page - 1) * $page-size + 1
+
+let $params := map:map()
+    => map:with('q', $q)
+    => map:with('party', $party)
+    => map:with('court', $court)
+    => map:with('judge', $judge)
+    => map:with('page', $page)
+    => map:with('page-size', $page-size)
+
+let $query1 := if ($q) then cts:word-query($q) else ()
+let $query2 := if ($party) then
+    cts:or-query((
+        cts:element-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'party'), $party),
+        cts:element-attribute-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'FRBRname'), fn:QName('', 'value'), $party)
+    ))
+else ()
+let $query4 := if ($court) then cts:or-query((
+    cts:element-value-query(fn:QName('https:/judgments.gov.uk/', 'court'), $court, ('case-insensitive')),
+    cts:element-value-query(fn:QName('https://caselaw.nationalarchives.gov.uk/akn', 'court'), $court, ('case-insensitive'))
+)) else ()
+let $query5 := if ($judge) then cts:element-word-query(fn:QName('http://docs.oasis-open.org/legaldocml/ns/akn/3.0', 'judge'), $judge) else ()
+let $queries := ( $query1, $query2, $query4, $query5 )
+let $query := cts:and-query($queries)
+
+let $show-snippets as xs:boolean := exists(( $query1, $query2, $query5 ))
+
+let $transform-results := if ($show-snippets) then
+    <transform-results apply="snippet">
+        <preferred-matches>
+            <element name="p" ns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0"/>
+        </preferred-matches>
+    </transform-results>
+else
+    <transform-results apply="empty-snippet" />
+
+let $search-options := <options xmlns="http://marklogic.com/appservices/search">
+    <extract-document-data xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+        <extract-path>//akn:FRBRWork/akn:FRBRname</extract-path>
+        <extract-path>//akn:neutralCitation</extract-path>
+        <extract-path>//akn:FRBRWork/akn:FRBRdate</extract-path>
+    </extract-document-data>
+    { $transform-results }
+</options>
+
+let $results := search:resolve($query, $search-options, $start, $page-size)
+let $total as xs:integer := xs:integer($results/@total)
+let $pages as xs:integer := if ($total mod $page-size eq 0) then $total idiv $page-size else $total idiv $page-size + 1
+let $params := $params => map:with('pages', $pages)
+
+return $results

--- a/judgments/xquery.xqy
+++ b/judgments/xquery.xqy
@@ -6,6 +6,7 @@ declare variable $q as xs:string? external;
 declare variable $party as xs:string? external;
 declare variable $court as xs:string? external;
 declare variable $judge as xs:string? external;
+declare variable $order as xs:string? external;
 declare variable $page as xs:integer external;
 declare variable $page-size as xs:integer external;
 let $start as xs:integer := ($page - 1) * $page-size + 1
@@ -17,6 +18,7 @@ let $params := map:map()
     => map:with('judge', $judge)
     => map:with('page', $page)
     => map:with('page-size', $page-size)
+    => map:with('order', $order)
 
 let $query1 := if ($q) then cts:word-query($q) else ()
 let $query2 := if ($party) then
@@ -35,6 +37,17 @@ let $query := cts:and-query($queries)
 
 let $show-snippets as xs:boolean := exists(( $query1, $query2, $query5 ))
 
+let $sort-order := if ($order = 'date') then
+    <sort-order xmlns="http://marklogic.com/appservices/search" direction="ascending">
+        <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">akn:FRBRWork/akn:FRBRdate/@date</path-index>
+    </sort-order>
+else if ($order = '-date') then
+    <sort-order xmlns="http://marklogic.com/appservices/search" direction="descending">
+        <path-index xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">akn:FRBRWork/akn:FRBRdate/@date</path-index>
+    </sort-order>
+else
+    ()
+
 let $transform-results := if ($show-snippets) then
     <transform-results apply="snippet">
         <preferred-matches>
@@ -45,6 +58,7 @@ else
     <transform-results apply="empty-snippet" />
 
 let $search-options := <options xmlns="http://marklogic.com/appservices/search">
+    { $sort-order }
     <extract-document-data xmlns:akn="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
         <extract-path>//akn:FRBRWork/akn:FRBRname</extract-path>
         <extract-path>//akn:neutralCitation</extract-path>

--- a/marklogic/api_client.py
+++ b/marklogic/api_client.py
@@ -145,7 +145,7 @@ class MarklogicApiClient:
             headers,
         )
 
-    def search_with_eval(
+    def advanced_search(
         self, q=None, court=None, judge=None, party=None, page=1
     ) -> requests.Response:
         headers = {

--- a/marklogic/api_client.py
+++ b/marklogic/api_client.py
@@ -137,7 +137,7 @@ class MarklogicApiClient:
             body=xml,
         )
 
-    def search_judgments(self, query: str, page: str) -> requests.Response:
+    def basic_search(self, query: str, page: str) -> requests.Response:
         start = (int(page) - 1) * RESULTS_PER_PAGE + 1
         headers = {"Accept": "text/xml"}
         return self.GET(

--- a/marklogic/api_client.py
+++ b/marklogic/api_client.py
@@ -145,6 +145,28 @@ class MarklogicApiClient:
             headers,
         )
 
+    def search_with_eval(
+        self, q=None, court=None, judge=None, party=None, page=1
+    ) -> requests.Response:
+        headers = {
+            "Content-type": "application/x-www-form-urlencoded",
+            "Accept": "multipart/mixed",
+        }
+        xquery_path = os.path.join(settings.ROOT_DIR, "judgments", "xquery.xqy")
+        vars = f'{{"court":"{str(court or "")}","judge":"{str(judge or "")}",\
+        "page":{page},"page-size":{RESULTS_PER_PAGE},"q":"{str(q or "")}","party":"{str(party or "")}"}}'
+        data = {
+            "xquery": Path(xquery_path).read_text(),
+            "vars": vars,
+        }
+        path = "LATEST/eval?database=Judgments"
+        response = self.session.request(
+            "POST", url=self._path_to_request_url(path), headers=headers, data=data
+        )
+        # Raise relevant exception for an erroneous response
+        self._raise_for_status(response)
+        return response
+
 
 class MockAPIClient:
 

--- a/marklogic/api_client.py
+++ b/marklogic/api_client.py
@@ -146,7 +146,7 @@ class MarklogicApiClient:
         )
 
     def advanced_search(
-        self, q=None, court=None, judge=None, party=None, page=1
+        self, q=None, court=None, judge=None, party=None, order=None, page=1
     ) -> requests.Response:
         headers = {
             "Content-type": "application/x-www-form-urlencoded",
@@ -154,7 +154,8 @@ class MarklogicApiClient:
         }
         xquery_path = os.path.join(settings.ROOT_DIR, "judgments", "xquery.xqy")
         vars = f'{{"court":"{str(court or "")}","judge":"{str(judge or "")}",\
-        "page":{page},"page-size":{RESULTS_PER_PAGE},"q":"{str(q or "")}","party":"{str(party or "")}"}}'
+        "page":{page},"page-size":{RESULTS_PER_PAGE},"q":"{str(q or "")}","party":"{str(party or "")}",\
+        "order":"{str(order or "")}"}}'
         data = {
             "xquery": Path(xquery_path).read_text(),
             "vars": vars,

--- a/marklogic/api_client.py
+++ b/marklogic/api_client.py
@@ -146,7 +146,15 @@ class MarklogicApiClient:
         )
 
     def advanced_search(
-        self, q=None, court=None, judge=None, party=None, order=None, page=1
+        self,
+        q=None,
+        court=None,
+        judge=None,
+        party=None,
+        order=None,
+        date_from=None,
+        date_to=None,
+        page=1,
     ) -> requests.Response:
         headers = {
             "Content-type": "application/x-www-form-urlencoded",
@@ -155,7 +163,7 @@ class MarklogicApiClient:
         xquery_path = os.path.join(settings.ROOT_DIR, "judgments", "xquery.xqy")
         vars = f'{{"court":"{str(court or "")}","judge":"{str(judge or "")}",\
         "page":{page},"page-size":{RESULTS_PER_PAGE},"q":"{str(q or "")}","party":"{str(party or "")}",\
-        "order":"{str(order or "")}"}}'
+        "order":"{str(order or "")}","from":"{str(date_from or "")}","to":"{str(date_to or "")}"}}'
         data = {
             "xquery": Path(xquery_path).read_text(),
             "vars": vars,


### PR DESCRIPTION
Add an `advanced search` endpoint to search Marklogic with XQuery

Example search: `http://localhost:3000/judgments/advanced_search?query=&court=uksc&party=&judge=&page=1&order=-date&to=2020-01-01`

`order` can be `date` or `-date` (ascending & descending). If no order is passed the results come back in a rank order.
`from` and `to` should be in `YYYY-mm-dd` format

Note there's an update to the README showing how to add indexes to Marklogic, which is needed for the sorting & date search to work. 