### PR TITLE
Tidy up Judgment page

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgment_text_source.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_source.html
@@ -1,5 +1,8 @@
+{% load i18n %}
 <div class="judgment-text-source">
     <div class="judgment-text-source__container">
-        <p>This judgment has been provided to The National Archives by <a href="{% url 'sources' %}">[Name of source]</a></p>
+        <p>{% translate "judgment.source_by" %}
+          <a href="{% url 'sources' %}">{% translate "judgment.bailii" %}</a>
+        </p>
     </div>
 </div>

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -1,14 +1,13 @@
+{% load i18n %}
 <div class="judgment-toolbar">
     <div class="judgment-toolbar__container">
         <div class="judgment-toolbar__return-link">
             {% if request.args.origin == 'results' %}
-                <a href="{{ request.args.return_link }}">Back to search results</a>
+                <a href="{{ request.args.return_link }}">{% translate "judgment.back" %}</a>
             {% endif %}
         </div>
         <div class="judgment-toolbar__download">
-            <span class="judgment-toolbar__download-intro">Download this judgment as </span>
-            <a class="judgment-download__option--pdf" href="">PDF</a> or
-            <a class="judgment-download__option--xml" href="">XML</a>
+            <a class="judgment-download__option--xml" href="{% url 'detail_xml' context.judgment_uri %}">{% translate "judgment.downloadasxml" %}</a>
         </div>
     </div>
 </div>

--- a/ds_judgements_public_ui/templates/judgment/detail.html
+++ b/ds_judgements_public_ui/templates/judgment/detail.html
@@ -1,8 +1,8 @@
 {% extends "layout_judgment_html.html" %}
 {% block content %}
-  {% if xml %}
+  {% if context.judgment %}
     {% autoescape off %}
-      {{ xml }}
+      {{ context.judgment }}
     {% endautoescape %}
   {% else %}
     {{ content }}

--- a/ds_judgements_public_ui/templates/layout_judgment_html.html
+++ b/ds_judgements_public_ui/templates/layout_judgment_html.html
@@ -1,24 +1,41 @@
-{% load static i18n %}<!DOCTYPE html>
-<html lang="en">
+{% load static i18n %}
+{% get_current_language as LANGUAGE_CODE %}
+<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link rel="shortcut icon" href="{% static 'images/favicons/favicon.png' %}">
+    <title>{% if context.page_title %}{{ context.page_title }} - {% endif %}{% translate "common.findcaselaw" %}</title>
+
+    <link rel="icon" href="{% static 'images/favicons/favicon.png' %}">
+
     {% block css %}
+      <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&amp;family=Roboto:wght@400;600;700&amp;display=swap" rel="stylesheet">
       <link href="{% static 'css/main.css' %}" rel="stylesheet">
     {% endblock %}
-    <title>{% block title %}{% endblock title %}</title>
+
+    {% block javascript %}
+      <script defer src="{% static 'js/dist/app.js' %}"></script>
+    {% endblock javascript %}
+
     {% include 'includes/gtm/gtm_head.html' %}
 </head>
 <body>
+<a id="skip-to-main-content" href="#main-content">{% translate "skiplink" %}</a>
 {% include 'includes/gtm/gtm_body.html' %}
-<a id="skip-to-main-content" href="#main-content">Skip to Main Content</a>
+{% include 'includes/phase_banner.html' %}
+<header class="page-header">
+  {% include 'includes/breadcrumbs.html' with current=context.page_title title=context.page_title link=request.path %}
+  {% include 'includes/logo.html' %}
+</header>
 {% include 'includes/judgment_text_toolbar.html' %}
 {% include 'includes/judgment_text_source.html' %}
 <main id="main-content">
     {% block content %}
     {% endblock %}
 </main>
+{% include 'includes/footer.html' %}
 </body>
 </html>

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -8,7 +8,6 @@ register_converter(converters.CourtConverter, "court")
 register_converter(converters.SubdivisionConverter, "subdivision")
 
 urlpatterns = [
-    path("judgments/xslt", views.xslt, name="xslt"),
     path("<court:court>", views.browse, name="browse"),
     path("<yyyy:year>", views.browse, name="browse"),
     path("<court:court>/<yyyy:year>", views.browse, name="browse"),

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
         views.browse,
         name="browse",
     ),
-    re_path("(?P<judgment_uri>.*/.*/.*)/data.xml", views.detail_xml, name="detail"),
+    re_path("(?P<judgment_uri>.*/.*/.*)/data.xml", views.detail_xml, name="detail_xml"),
     re_path("(?P<judgment_uri>.*/.*/.*)/data.html", views.detail, name="detail"),
     re_path("(?P<judgment_uri>.*/.*/.*)", views.detail, name="detail"),
     path("judgments/results", views.results, name="results"),

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -58,8 +58,7 @@ def browse(request, court=None, subdivision=None, year=None):
 def detail(request, judgment_uri):
     context = {}
     try:
-        full_uri = f"/{judgment_uri}.xml"
-        results = api_client.eval_xslt(full_uri)
+        results = api_client.eval_xslt(judgment_uri)
         xml_results = api_client.get_judgment_xml(judgment_uri)
         multipart_data = decoder.MultipartDecoder.from_response(results)
         judgment = multipart_data.parts[0].text

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -16,10 +16,6 @@ from marklogic.api_client import (
 )
 
 
-def detail_new(request, court, year, judgment_date, subdivision=None):
-    return HttpResponse(court + subdivision + str(year) + judgment_date)
-
-
 def browse(request, court=None, subdivision=None, year=None):
     context = {"page_title": gettext("results.search.title")}
     queries = []
@@ -75,17 +71,6 @@ def detail(request, judgment_uri):
         raise Http404("Judgment was not found")
     template = loader.get_template("judgment/detail.html")
     return HttpResponse(template.render({"context": context}, request))
-
-
-def xslt(request):
-    params = request.GET
-    judgment_uri = params.get("judgment_uri")
-    try:
-        judgment_xml = api_client.eval_xslt(judgment_uri)
-    except MarklogicResourceNotFoundError:
-        raise Http404("Judgment was not found")
-    template = loader.get_template("judgment/detail.html")
-    return HttpResponse(template.render({"xml": judgment_xml.text}, request))
 
 
 def advanced_search(request):

--- a/locale/en_gb/LC_MESSAGES/django.po
+++ b/locale/en_gb/LC_MESSAGES/django.po
@@ -84,3 +84,19 @@ msgstr "Terms of use"
 #~| msgid "common.findcaselaw"
 #~ msgid "findcaselaw"
 #~ msgstr "Find case law"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html:9
+msgid "judgment.downloadasxml"
+msgstr "Download as XML"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html:5
+msgid "judgment.back"
+msgstr "Back to search results"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_source.html:3
+msgid "judgment.source_by"
+msgstr "This judgment has been provided to The National Archives by "
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_source.html:4
+msgid "judgment.bailii"
+msgstr "The British and Irish Legal Information Institute"

--- a/marklogic/api_client.py
+++ b/marklogic/api_client.py
@@ -177,6 +177,7 @@ class MarklogicApiClient:
         return response
 
     def eval_xslt(self, judgment_uri) -> requests.Response:
+        uri = f"/{judgment_uri.lstrip('/')}.xml"
         headers = {
             "Content-type": "application/x-www-form-urlencoded",
             "Accept": "application/xml",
@@ -184,7 +185,7 @@ class MarklogicApiClient:
         xquery_path = os.path.join(settings.ROOT_DIR, "judgments", "xslt.xqy")
         data = {
             "xquery": Path(xquery_path).read_text(),
-            "vars": f'{{"uri":"{judgment_uri}"}}',
+            "vars": f'{{"uri":"{uri}"}}',
         }
         path = "LATEST/eval?database=Judgments"
         response = self.session.request(


### PR DESCRIPTION
Add in some missing furniture for the Judgment page. 
Add some translations.
Remove some unused methods.
Refactor the `eval_xslt` method so that it takes a `judgment_uri` in the same format as `get_judgment_xml`