### PR TITLE
(Fix) Correct `judgment_uri` signature in `detail_xml`

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -104,8 +104,7 @@ def advanced_search(request):
 
 def detail_xml(_request, judgment_uri):
     try:
-        uri = f"/{judgment_uri}.xml"
-        judgment_xml = api_client.get_judgment_xml(uri)
+        judgment_xml = api_client.get_judgment_xml(judgment_uri)
     except MarklogicResourceNotFoundError:
         raise Http404("Judgment was not found")
     response = HttpResponse(judgment_xml, content_type="application/xml")


### PR DESCRIPTION
In f78522ee9b8f423d446154401eeadbbf4161550f we harmonised the format of
`judgment_uri` as passed to `get_judgment_xml`, but forgot to correct it
in `detail_xml` as well as `detail`