### PR TITLE
Add XQuery script to publish all Judgments and instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ The XSLT which transforms the LegalDocML documents into HTML needs to be stored 
 4. Once the script has run, click `Explore` to ensure the XSLT is in place, it should be called
    `/judgments/xslts/judgment2.xsl`
 
+### Publish all Judgments
+
+By default, Judgments are not marked as published and therefore not visible in the app. To publish all Judgments locally:
+
+1. Open the Marklogic Query console at http://localhost:8000/
+2. Copy the text in `judgments/xquery/publish_all_judgments.xqy` and paste it into the XQuery console
+3. Run it against the database `Judgments` using the `XQuery` query type (see the dropdown options in the UI to configure
+   these), the XQuery will take a few minutes to run
+4. Once the script has run, all Judgments should be visible in the front-end UI
+
 ### Marklogic URL Guide
 
 - http://localhost:8000/ this is the query interface where you can browse documents in the `Judgments` database.

--- a/judgments/xquery/publish_all_judgments.xqy
+++ b/judgments/xquery/publish_all_judgments.xqy
@@ -1,0 +1,4 @@
+xquery version "1.0-ml";
+let $props := ( <published>true</published> )
+for $uri in cts:uris()
+  return xdmp:document-set-properties($uri, $props)


### PR DESCRIPTION
By default, all Judgments are treated as unpublished unless they have a
`published` property set to `true`. Therefore, by default the app will not show
any Judgments.

If this script is run against the `Judgments` database it will mark all Judgments
as published, and therefore visible.