### PR TITLE
Run Marklogic docker task as part of `fab run`

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -69,6 +69,7 @@ def start(c, container_name=None):
 @task
 def run(c):
     start(c, "django")
+    start(c, "marklogic")
     django_exec("pip install -r requirements/local.txt -U")
     django_exec("DJANGO_SETTINGS_MODULE= django-admin compilemessages")
     django_exec("python manage.py migrate")


### PR DESCRIPTION
Previously, we were not running Marklogic as part of the "lightweight"
`fab run` task, as it was possible to run the application without Marklogic
(using the Mocked Marklogic client)

Now that we have removed the mocked Marklogic client, we always want to run
Marklogic when running the application.