### PR TITLE
Update XQuery that publishes all documents to use the `dls` namespace…

### DIFF
--- a/judgments/xquery/publish_all_judgments.xqy
+++ b/judgments/xquery/publish_all_judgments.xqy
@@ -1,4 +1,7 @@
 xquery version "1.0-ml";
+import module namespace dls="http://marklogic.com/xdmp/dls"
+              at "/MarkLogic/dls.xqy";
+
 let $props := ( <published>true</published> )
-for $uri in cts:uris()
-  return xdmp:document-set-properties($uri, $props)
+for $uri in cts:uris("", (), dls:documents-query())
+  return dls:document-set-properties($uri, $props)


### PR DESCRIPTION
…d properties

We will be updating all documents to be managed under Library Services. The
documents need their properties set under the dls namespace.