### PR TITLE
Install curl to our Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libpq-dev \
   # Translations dependencies
   gettext \
+  curl \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Dalmatian needs curl to be installed so that it can instal aws-env on
start up so that environment variables can be set.