### PR TITLE
Manage most recent judgments

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -91,9 +91,9 @@ INSTALLED_APPS += ["anymail"]  # noqa F405
 # https://anymail.readthedocs.io/en/stable/esps/mailgun/
 EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
 ANYMAIL = {
-     "MAILGUN_API_KEY": env("MAILGUN_API_KEY"),
-     "MAILGUN_SENDER_DOMAIN": env("MAILGUN_DOMAIN"),
-     "MAILGUN_API_URL": env("MAILGUN_API_URL", default="https://api.mailgun.net/v3"),
+    "MAILGUN_API_KEY": env("MAILGUN_API_KEY"),
+    "MAILGUN_SENDER_DOMAIN": env("MAILGUN_DOMAIN"),
+    "MAILGUN_API_URL": env("MAILGUN_API_URL", default="https://api.mailgun.net/v3"),
 }
 
 

--- a/judgments/xquery/manage_judgments.xqy
+++ b/judgments/xquery/manage_judgments.xqy
@@ -3,6 +3,6 @@ import module namespace dls = "http://marklogic.com/xdmp/dls"
       at "/MarkLogic/dls.xqy";
 
 
-for $uri in cts:uris("", xs:string("limit=100"))
+for $uri in cts:uris("", xs:string("limit=100"),xs:string("descending"))
   where fn:not(dls:document-is-managed($uri))
     return dls:document-manage($uri, fn:true())

--- a/judgments/xquery/publish_all_judgments.xqy
+++ b/judgments/xquery/publish_all_judgments.xqy
@@ -4,4 +4,4 @@ import module namespace dls="http://marklogic.com/xdmp/dls"
 
 let $props := ( <published>true</published> )
 for $uri in cts:uris("", (), dls:documents-query())
-  return dls:document-set-properties($uri, $props)
+  return dls:document-set-property($uri, $props)


### PR DESCRIPTION
The XQuery was previously only marking the 100 oldest Judgments as managed
but the more recent ones are probably more relevant. Mark the 100 most recent
Judgments as managed.