### PR TITLE
Temporarily run whitenoise live in production so we can see assets

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -58,7 +58,10 @@ SECURE_CONTENT_TYPE_NOSNIFF = env.bool(
 
 # STATIC
 # ------------------------
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+# STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+# TEMPORARILY run whitenoise in production to live-serve assets, until
+# we work out what we need to add to our build pipeline
+INSTALLED_APPS = ["whitenoise.runserver_nostatic"] + INSTALLED_APPS  # noqa F405
 # MEDIA
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
This will be reverted as soon as we learn how we should be doing it properly from http://whitenoise.evans.io/en/latest/django.html. I suspect `python manage.py collectstatic` is involved.