### PR TITLE
Correct the url for the `uk` namespace

### DIFF
--- a/judgments/models.py
+++ b/judgments/models.py
@@ -10,7 +10,7 @@ class Judgment(xmlmodels.XmlModel):
     class Meta:
         namespaces = {
             "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
-            "uk": "https:/judgments.gov.uk/",
+            "uk": "https://caselaw.nationalarchives.gov.uk/akn",
         }
 
     metadata_name = xmlmodels.XPathTextField("//akn:FRBRname/@value")

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -33,7 +33,8 @@ class TestJudgmentModel(TestCase):
                             <FRBRdate date="2004-06-10" name="judgment"/>
                             <FRBRname value="My Judgment Name"/>
                         </identification>
-                        <proprietary source="ewca/civ/2004/811/eng/docx" xmlns:uk="https:/judgments.gov.uk/">
+                        <proprietary source="ewca/civ/2004/811/eng/docx"
+                            xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
                             <uk:court>EWCA-Civil</uk:court>
                         </proprietary>
                     </meta>


### PR DESCRIPTION
Previousy, the documents had the URL `https:/judgments.gov.uk/` for the `uk`
namespace. In a recent refresh of the data, this URL has chnged to
`https://caselaw.nationalarchives.gov.uk/akn`

This change had stopped the value for the elements within the `proprietary`
element from being retrieved properly.