### PR TITLE
Accessibility fixes / statement

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     path(
         "accessibility-statement",
         views.AccessibilityStatement.as_view(),
-        name="accessibility_statement"
+        name="accessibility_statement",
     ),
     path(
         "open-justice-licence",

--- a/config/urls.py
+++ b/config/urls.py
@@ -8,6 +8,11 @@ from . import views
 
 urlpatterns = [
     path(
+        "accessibility-statement",
+        views.AccessibilityStatement.as_view(),
+        name="accessibility_statement"
+    ),
+    path(
         "open-justice-licence",
         views.OpenJusticeLicenceView.as_view(),
         name="open_justice_licence",

--- a/config/views.py
+++ b/config/views.py
@@ -13,6 +13,11 @@ class TemplateViewWithContext(TemplateView):
         }
 
 
+class AccessibilityStatement(TemplateViewWithContext):
+    template_name = "pages/accessibility_statement.html"
+    page_title = "accessibilitystatement.title"
+
+
 class OpenJusticeLicenceView(TemplateViewWithContext):
     template_name = "pages/open_justice_licence.html"
     page_title = "openjusticelicence.title"

--- a/ds_judgements_public_ui/sass/includes/_footer.scss
+++ b/ds_judgements_public_ui/sass/includes/_footer.scss
@@ -11,8 +11,15 @@
   &__links {
     padding: 0;
     list-style-type: none;
-    display: flex;
-    justify-content: space-between;
+    @media (min-width: $grid__breakpoint-large) {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    li {
+      padding-right: 1rem;
+      padding-bottom: 1rem;
+    }
   }
 
   &__link {

--- a/ds_judgements_public_ui/sass/includes/_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_search.scss
@@ -23,6 +23,10 @@
 
   &__more-options {
     margin-top: calc($spacer__unit * 2);
+
+    a {
+      color: darken($color__link-blue, 10);
+    }
   }
 
   input[type=submit] {

--- a/ds_judgements_public_ui/templates/includes/basic_search_form.html
+++ b/ds_judgements_public_ui/templates/includes/basic_search_form.html
@@ -3,7 +3,7 @@
     <h2 class="search-component__header--sr-only">Search by keyword or neutral citation</h2>
     <form action="{% url 'results' %}" role="search" aria-label="Search by keyword or neutral citation" id="analytics-basic-search">
 
-      <label for="search_term" class="search-component__search-term-label">{# {{ form.search_term.label }} #}</label>
+      <label for="search_term" class="search-component__search-term-label">Search</label>
       <input class="search-component__search-term-input" id="search_term" name="query" type="text" value="" placeholder="Enter a keyword or neutral citation">
       {{ form.search_term }}
       <input type="submit" value="Search">

--- a/ds_judgements_public_ui/templates/includes/footer.html
+++ b/ds_judgements_public_ui/templates/includes/footer.html
@@ -7,10 +7,10 @@
         except where otherwise stated.
       </li>
       <li>
-        <a class="judgments-footer__link" href="{% url 'terms_of_use' %}">Terms of use</a>
+        <a class="judgments-footer__link" href="{% url 'terms_of_use' %}">Terms of use (Placeholder) </a>
       </li>
       <li>
-        <a class="judgments-footer__link" href="{% url 'accessibility_statement' %}">Accessibility statement</a>
+        <a class="judgments-footer__link" href="{% url 'accessibility_statement' %}">Accessibility statement (Draft)</a>
       </li>
     </ul>
   </div>

--- a/ds_judgements_public_ui/templates/includes/footer.html
+++ b/ds_judgements_public_ui/templates/includes/footer.html
@@ -9,6 +9,9 @@
       <li>
         <a class="judgments-footer__link" href="{% url 'terms_of_use' %}">Terms of use</a>
       </li>
+      <li>
+        <a class="judgments-footer__link" href="{% url 'accessibility_statement' %}">Accessibility statement</a>
+      </li>
     </ul>
   </div>
 </footer>

--- a/ds_judgements_public_ui/templates/includes/recent_judgments.html
+++ b/ds_judgements_public_ui/templates/includes/recent_judgments.html
@@ -12,6 +12,7 @@
               </a>
             </span>
             <span class="recent-judgments__neutralcitation">
+              Neutral citation:
               {{ item.neutral_citation }}
             </span>
           </span>

--- a/ds_judgements_public_ui/templates/includes/results_search_field.html
+++ b/ds_judgements_public_ui/templates/includes/results_search_field.html
@@ -1,5 +1,5 @@
 <div class="results-search-component__full-text-panel">
-  <label for="full_text" class="results-search-component__full-text-label">Search</label>
+  <label for="search_term" class="results-search-component__full-text-label">Search</label>
   <input class="search-component__search-term-input" id="search_term" name="query" type="text" value="" placeholder="Enter a keyword or neutral citation">
   {{ form.search_term }}
   <input type="submit" value="Search" class="results-search-component__search-submit-button">

--- a/ds_judgements_public_ui/templates/includes/results_search_field.html
+++ b/ds_judgements_public_ui/templates/includes/results_search_field.html
@@ -1,5 +1,5 @@
 <div class="results-search-component__full-text-panel">
-  <label for="full_text" class="results-search-component__full-text-label">{{ form.search_term.label }}</label>
+  <label for="full_text" class="results-search-component__full-text-label">Search</label>
   <input class="search-component__search-term-input" id="search_term" name="query" type="text" value="" placeholder="Enter a keyword or neutral citation">
   {{ form.search_term }}
   <input type="submit" value="Search" class="results-search-component__search-submit-button">

--- a/ds_judgements_public_ui/templates/pages/accessibility_statement.html
+++ b/ds_judgements_public_ui/templates/pages/accessibility_statement.html
@@ -1,0 +1,95 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}
+  {{ page_title }} - {% translate "common.findcaselaw" %}
+{% endblock title %}
+
+{% block content %}
+  {% translate "accessibilitystatement.title" as page_title %}
+  <header class="page-header">
+    {% include 'includes/breadcrumbs.html' with current=page_title title=page_title link=request.path %}
+    {% include 'includes/logo.html' %}
+  </header>
+
+  <div class="standard-text-template">
+  <h1>{{ page_title }}</h1>
+  <div class="entry-content clearfix">
+    <p>This accessibility statement applies to the Case Law service provided by The National Archives.</p>
+    <p>Accessibility and inclusion are important to everyone at The National Archives and we want as many people
+      as possible to be able to use the Case Law service. The text should be
+      clear and easy to understand. You should be able to:</p>
+    <ul>
+      <li>Change colours, contrast levels and fonts.</li>
+      <li>Zoom in up to 400% without the text spilling off the screen.</li>
+      <li>Navigate most of the website using just a keyboard.</li>
+      <li>Navigate most of the website using speech recognition software.</li>
+      <li>Listen to most of the website using a screen reader (including the most recent versions of JAWS,
+        NVDA and VoiceOver).
+      </li>
+    </ul>
+    <p>We are continually working to improve the accessibility of our digital services, and to develop our
+      skills in relevant standards and techniques. See our current <a
+              href="https://github.com/nationalarchives/front-end-development-guide/blob/master/development-guide.md">development
+        standards</a>.</p>
+    <p>As well as working with third-party accessibility specialists, most of our accessibility
+      testing is conducted in-house using automated tools and the best professional judgment of our digital
+      teams. We acknowledge that this approach is not perfect and recognise that we may get some things wrong,
+    </p>
+    <h2>How accessible is this website?</h2>
+    <p>Some parts of this website are not fully accessible:</p>
+    <ul>
+      <li>...</li>
+    </ul>
+    <p>Specific non-compliances are listed <a href=#Non-Compliances">below</a>.</p>
+    <h2>Feedback, contact information and reporting accessibility problems</h2>
+    <p>If you need information on this website in a different format, for example accessible PDF, large print,
+      easy read, audio recording or Braille, email <a href="mailto:webmaster@nationalarchives.gov.uk">webmaster@nationalarchives.gov.uk</a>
+      or call 020 8876 3444. We will respond to your request within 10 working days.</p>
+    <p>You can also use these contact details to report accessibility problems with this website.</p>
+    <p>If you have an accessibility need and would like to participate in user testing as we make improvements
+      to our website, email <a href="mailto:uxresearch@nationalarchives.gov.uk">uxresearch@nationalarchives.gov.uk</a>.
+    </p>
+    <h2>Enforcement procedure</h2>
+    <p>The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies
+      (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility
+      regulations’). If you are not happy with how we respond to your complaint, <a
+              href="https://www.equalityadvisoryservice.com/">contact the Equality Advisory and Support
+        Service (EASS)</a>.</p>
+    <h2>Contacting us or visiting in person</h2>
+    <p>You can <a href="https://www.nationalarchives.gov.uk/contact-us/">contact us</a> by phone, email or Live
+      chat. We provide information about <a href="https://www.nationalarchives.gov.uk/about/visit-us/">visiting
+        in person</a>. People with health conditions or impairments that may impact their visit can <a
+              href="https://www.nationalarchives.gov.uk/about/visit-us/information-for-disabled-visitors/">find
+        out more</a>.</p>
+    <h2>Technical information about this website’s accessibility</h2>
+    <p>The National Archives is committed to making its website accessible, in accordance with the Public Sector
+      Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
+    <h2>Compliance status</h2>
+    <p>This website is partially compliant with the <a href="https://www.w3.org/TR/WCAG21/">Web Content
+      Accessibility Guidelines version 2.1</a> AA standard, due to the non-compliances and exemptions listed
+      below:</p>
+    <h3>Non-accessible content</h3>
+    <p>Based on sample testing of pages selected by our user experience and metrics teams, we know that the
+      content listed below is non-compliant with the accessibility regulations for the following reasons:</p>
+    <h3 id="Non-Compliances">Non-compliance with the accessibility regulations</h3>
+    <ol>
+      <li>...</li>
+    </ol>
+    <h2>Disproportionate burden</h2>
+    <p>Not applicable.</p>
+    <h2>Content that’s not within the scope of the accessibility regulations</h2>
+    <ul>
+      <li>PDFs or other documents published before 23 September 2018.</li>
+      <li>Live video.</li>
+    </ul>
+    <p>While reproductions of items in heritage collections are <a
+            href="http://www.legislation.gov.uk/uksi/2018/952/regulation/4/made">exempt from meeting the
+      accessibility regulations</a>, we are investigating ways to use emerging technology to improve the data
+      and accessibility of our heritage collections.</p>
+    <h2>Preparation of this accessibility statement</h2>
+    <p>This statement was prepared on [Date prepared].
+    </p>
+
+  </div>
+{% endblock %}

--- a/locale/en_gb/LC_MESSAGES/django.po
+++ b/locale/en_gb/LC_MESSAGES/django.po
@@ -94,6 +94,10 @@ msgstr ""
 "Improve your search results by removing filters, double-checking your "
 "spelling, using fewer keywords or searching for something less specific."
 
+#: ds_judgments_public_ui/templates/pages/accessibility_statement.html:5
+msgid "accessibilitystatement.title"
+msgstr "Accessibility statement"
+
 #: ds_judgements_public_ui/templates/pages/open_justice_licence.html:5
 msgid "openjusticelicence.title"
 msgstr "Open Justice Licence"


### PR DESCRIPTION
This PR addresses the accessibility fixes identified in internal testing and introduces the accessibility statement page. 

- [x] Fix search field labels (and association)
- [x] Fix link contrast
- [x] Add accessibility page (including footer link)

There is one additional change that's necessary (providing a fill colour to the TNA logo SVG but I'll need some help from MB for this, so will pick it up later. 