### PR TITLE
Add neutral citation checkbox to homepage

### DIFF
--- a/ds_judgements_public_ui/templates/includes/basic_search_form.html
+++ b/ds_judgements_public_ui/templates/includes/basic_search_form.html
@@ -8,8 +8,8 @@
       {{ form.search_term }}
       <input type="submit" value="Search">
       <div>
-        {# {{ form.neutral_citation }} #}
-        {# {{ form.neutral_citation.label }} #}
+        <input id="neutral_citation" name="neutral_citation" type="checkbox" value="y">
+        <label for="neutral_citation">I'm using a neutral citation, e.g. [2021] EWCA Crim 1785</label>
       </div>
 
     </form>


### PR DESCRIPTION
Hi @LewisDaleUK - during the backlog catchup I was asked to add the neutral citation checkbox to the homepage. This PR adds a HTML only version. I expect it needs to be linked up to the Django form.