### PR TITLE
Add Atom feeds to judgment browse URLs

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -1,0 +1,55 @@
+import datetime
+
+from django.contrib.syndication.views import Feed
+from django.urls import reverse
+from django.utils.feedgenerator import Atom1Feed
+
+from .models import SearchResult
+from .utils import perform_advanced_search
+
+
+class LatestJudgmentsFeed(Feed):
+    feed_type = Atom1Feed
+
+    def get_object(self, request, court=None, subdivision=None, year=None):
+        return {"court": court, "subdivision": subdivision, "year": year}
+
+    def title(self, obj):
+        return (
+            f'Latest judgments for /{obj["court"]}/{obj["subdivision"]}/{obj["year"]}'
+        )
+
+    def link(self, obj):
+        return "/" + "/".join(
+            filter(
+                lambda x: x is not None,
+                [obj["court"], obj["subdivision"], str(obj["year"])],
+            )
+        )
+
+    def items(self, obj):
+        court = obj["court"]
+        subdivision = obj["subdivision"]
+        year = obj["year"]
+
+        court_query = "/".join(filter(lambda x: x is not None, [court, subdivision]))
+        model = perform_advanced_search(
+            court=court_query if court_query else None,
+            date_from=datetime.date(year=year, month=1, day=1).strftime("%Y-%m-%d")
+            if year
+            else None,
+            date_to=datetime.date(year=year, month=12, day=31).strftime("%Y-%m-%d")
+            if year
+            else None,
+        )
+
+        return [SearchResult.create_from_node(result) for result in model.results]
+
+    def item_description(self, item: SearchResult) -> str:
+        return ""
+
+    def item_title(self, item: SearchResult):
+        return item.name
+
+    def item_link(self, item: SearchResult) -> str:
+        return reverse("detail", kwargs={"judgment_uri": item.uri})

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, re_path, register_converter
 
-from . import converters, views
+from . import converters, feeds, views
 
 register_converter(converters.YearConverter, "yyyy")
 register_converter(converters.DateConverter, "date")
@@ -16,6 +16,21 @@ urlpatterns = [
         "<court:court>/<subdivision:subdivision>/<yyyy:year>",
         views.browse,
         name="browse",
+    ),
+    path("<court:court>/atom.xml", feeds.LatestJudgmentsFeed(), name="feed"),
+    path("<yyyy:year>/atom.xml", feeds.LatestJudgmentsFeed(), name="feed"),
+    path(
+        "<court:court>/<yyyy:year>/atom.xml", feeds.LatestJudgmentsFeed(), name="feed"
+    ),
+    path(
+        "<court:court>/<subdivision:subdivision>/atom.xml",
+        feeds.LatestJudgmentsFeed(),
+        name="feed",
+    ),
+    path(
+        "<court:court>/<subdivision:subdivision>/<yyyy:year>/atom.xml",
+        feeds.LatestJudgmentsFeed(),
+        name="feed",
     ),
     re_path(
         "(?P<judgment_uri>.*/.*/.*)/data.pdf",

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -1,5 +1,10 @@
 from datetime import datetime
 
+from caselawclient.Client import api_client
+from requests_toolbelt.multipart import decoder
+
+from .models import SearchResults
+
 
 def format_date(date):
     if date == "" or date is None:
@@ -7,3 +12,27 @@ def format_date(date):
 
     time = datetime.strptime(date, "%Y-%m-%d")
     return time.strftime("%d-%m-%Y")
+
+
+def perform_advanced_search(
+    query=None,
+    court=None,
+    judge=None,
+    party=None,
+    order=None,
+    date_from=None,
+    date_to=None,
+    page=1,
+):
+    response = api_client.advanced_search(
+        q=query,
+        court=court,
+        judge=judge,
+        party=party,
+        page=page,
+        order=order,
+        date_from=date_from,
+        date_to=date_to,
+    )
+    multipart_data = decoder.MultipartDecoder.from_response(response)
+    return SearchResults.create_from_string(multipart_data.parts[0].text)

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -17,7 +17,9 @@ from django.views.generic import TemplateView
 from django_weasyprint import WeasyTemplateResponseMixin
 from requests_toolbelt.multipart import decoder
 
-from judgments.models import Judgment, SearchResult, SearchResults
+from judgments.models import Judgment, SearchResult
+
+from .utils import perform_advanced_search
 
 
 def browse(request, court=None, subdivision=None, year=None):
@@ -204,27 +206,3 @@ def paginator(current_page, total):
 
 def trim_leading_slash(uri):
     return re.sub("^/|/$", "", uri)
-
-
-def perform_advanced_search(
-    query=None,
-    court=None,
-    judge=None,
-    party=None,
-    order=None,
-    date_from=None,
-    date_to=None,
-    page=1,
-):
-    response = api_client.advanced_search(
-        q=query,
-        court=court,
-        judge=judge,
-        party=party,
-        page=page,
-        order=order,
-        date_from=date_from,
-        date_to=date_to,
-    )
-    multipart_data = decoder.MultipartDecoder.from_response(response)
-    return SearchResults.create_from_string(multipart_data.parts[0].text)


### PR DESCRIPTION
Adds an Atom XML feed for each of the browse urls. You can access the atom feeds by appending "/feed.xml" to the url, e.g. /ewca/civ/2017/feed.xml