### PR TITLE
Field changes

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -56,11 +56,11 @@
 
   }
 
-  &__name-label {
+  &__limit-to-label {
     font-size: 1.1rem;
   }
 
-  &__name-input {
+  &__limit-to-input {
     @include text_field;
     width: 70%;
   }
@@ -109,7 +109,7 @@
     }
   }
 
-  &__name-container {
+  &__specific-field-container {
     background-color: $color__yellow;
     padding: calc($spacer__unit * 2) calc($spacer__unit * 3);
     margin-bottom: $spacer__unit;

--- a/ds_judgements_public_ui/templates/includes/basic_search_form.html
+++ b/ds_judgements_public_ui/templates/includes/basic_search_form.html
@@ -7,10 +7,6 @@
       <input class="search-component__search-term-input" id="search_term" name="query" type="text" value="" placeholder="Enter a party name or neutral citation">
       {{ form.search_term }}
       <input type="submit" value="Search">
-      <div>
-        <input id="neutral_citation" name="neutral_citation" type="checkbox" value="y">
-        <label for="neutral_citation">I'm using a neutral citation, for example [2021] EWCA Crim 1785</label>
-      </div>
 
     </form>
 

--- a/ds_judgements_public_ui/templates/includes/structured_search_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/structured_search_inputs.html
@@ -5,21 +5,30 @@
       <fieldset>
         <legend>Search specific fields</legend>
         <div class="structured-search__multi-fields-panel">
-          <div class="structured-search__name-container">
-            <label for="party_name" class="structured-search__name-label">Party name</label>
+          <div class="structured-search__specific-field-container">
+            <label for="party_name" class="structured-search__limit-to-label">Party name</label>
             <p class="structured-search__help-text" id="party_name-help-text">For example a claimant, defendant or prosecutor</p>
-            <input class="structured-search__name-input" id="party_name" name="party" type="text" value="" aria-describedby="party_name-help-text">
+            <input class="structured-search__limit-to-input" id="party_name" name="party" type="text" value="" aria-describedby="party_name-help-text">
           </div>
-          <div class="structured-search__name-container">
-            <label for="judge_name" class="structured-search__name-label">Judge name</label>
+          <div class="structured-search__specific-field-container">
+            <label for="judge_name" class="structured-search__limit-to-label">Judge name</label>
             <p class="structured-search__help-text" id="judge_name-help-text">For example 'Smith', 'Judge Smith' or 'Lord Justice Smith'</p>
-            <input class="structured-search__name-input" id="judge_name" name="judge" type="text" value="" aria-describedby="judge_name-help-text">
+            <input class="structured-search__limit-to-input" id="judge_name" name="judge" type="text" value="" aria-describedby="judge_name-help-text">
+          </div>
+          <div class="structured-search__specific-field-container">
+            <label for="neutral_citation" class="structured-search__limit-to-label">Neutral citation</label>
+            <p class="structured-search__help-text" id="neutral_citation-help-text">For example [2021] EWCA Crim 1785</p>
+            <input class="structured-search__limit-to-input" id="neutral_citation" name="judge" type="text" value="" aria-describedby="neutral_citation-help-text">
           </div>
         </div>
       </fieldset>
       <fieldset>
         <legend>Only include results</legend>
         <div class="structured-search__multi-fields-panel">
+          <div class="structured-search__limit-to-container">
+            <label for="specific_keywords" class="structured-search__limit-to-label">Containing specific keywords</label>
+            <input class="structured-search__limit-to-input" id="specific_keywords" name="judge" type="text" value="">
+          </div>
           <div class="structured-search__limit-to-container">
             <label for="court" class="structured-search__limit-to-label">From a specific court or tribunal</label>
             <select class="structured-search__select" id="court" name="court">

--- a/ds_judgements_public_ui/templates/includes/structured_search_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/structured_search_inputs.html
@@ -6,14 +6,12 @@
         <legend>Search specific fields</legend>
         <div class="structured-search__multi-fields-panel">
           <div class="structured-search__name-container">
-            <label for="party_name" class="structured-search__name-label"><label for="party_name">Party
-              name</label></label>
+            <label for="party_name" class="structured-search__name-label">Party name</label>
             <p class="structured-search__help-text">For example a claimant, defendant or prosecutor</p>
             <input class="structured-search__name-input" id="party_name" name="party" type="text" value="">
           </div>
           <div class="structured-search__name-container">
-            <label for="judge_name" class="structured-search__name-label"><label for="judge_name">Judge
-              name</label></label>
+            <label for="judge_name" class="structured-search__name-label">Judge name</label>
             <p class="structured-search__help-text">For example 'Smith', 'Judge Smith' or 'Lord Justice Smith'</p>
             <input class="structured-search__name-input" id="judge_name" name="judge" type="text" value="">
           </div>
@@ -23,8 +21,7 @@
         <legend>Only include results</legend>
         <div class="structured-search__multi-fields-panel">
           <div class="structured-search__limit-to-container">
-            <label for="court" class="structured-search__limit-to-label"><label for="court">From a specific court or
-              tribunal</label></label>
+            <label for="court" class="structured-search__limit-to-label">From a specific court or tribunal</label>
             <select class="structured-search__select" id="court" name="court">
               <option value="">All courts</option>
               <option value="uksc">United Kingdom Supreme Court</option>
@@ -54,13 +51,12 @@
         <legend>During the period</legend>
         <div class="structured-search__multi-fields-panel">
           <div class="structured-search__limit-to-container">
-            <label for="from_date" class="structured-search__limit-to-label"><label for="from_date">From
-              date</label></label>
+            <label for="from_date" class="structured-search__limit-to-label">From date</label>
             <input class="structured-search__date-input" id="from_date" max="3-3-2022" min="02-01-2003" name="from"
                    placeholder="DD-MM-YYYY" type="date" value=""/>
           </div>
           <div class="structured-search__limit-to-container">
-            <label for="to_date" class="structured-search__limit-to-label"><label for="to_date">To date</label></label>
+            <label for="to_date" class="structured-search__limit-to-label">To date</label>
             <input class="structured-search__date-input" id="to_date" max="3-3-2022" min="02-01-2003" name="to"
                    placeholder="DD-MM-YYYY" type="date" value="">
           </div>

--- a/ds_judgements_public_ui/templates/includes/structured_search_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/structured_search_inputs.html
@@ -7,13 +7,13 @@
         <div class="structured-search__multi-fields-panel">
           <div class="structured-search__name-container">
             <label for="party_name" class="structured-search__name-label">Party name</label>
-            <p class="structured-search__help-text">For example a claimant, defendant or prosecutor</p>
-            <input class="structured-search__name-input" id="party_name" name="party" type="text" value="">
+            <p class="structured-search__help-text" id="party_name-help-text">For example a claimant, defendant or prosecutor</p>
+            <input class="structured-search__name-input" id="party_name" name="party" type="text" value="" aria-describedby="party_name-help-text">
           </div>
           <div class="structured-search__name-container">
             <label for="judge_name" class="structured-search__name-label">Judge name</label>
-            <p class="structured-search__help-text">For example 'Smith', 'Judge Smith' or 'Lord Justice Smith'</p>
-            <input class="structured-search__name-input" id="judge_name" name="judge" type="text" value="">
+            <p class="structured-search__help-text" id="judge_name-help-text">For example 'Smith', 'Judge Smith' or 'Lord Justice Smith'</p>
+            <input class="structured-search__name-input" id="judge_name" name="judge" type="text" value="" aria-describedby="judge_name-help-text">
           </div>
         </div>
       </fieldset>


### PR DESCRIPTION
This PR introduces three changes: 

- [x] Fixes a duplicate label issue present on advanced search 
- [x] Introduced 'keyword' and 'neutral citation' fields within structured search (and the additional options on search results)
- [x] Removes the neutral citation checkbox on the home page