### PR TITLE
Add content for 'What to expect' page

### DIFF
--- a/ds_judgements_public_ui/templates/pages/what_to_expect.html
+++ b/ds_judgements_public_ui/templates/pages/what_to_expect.html
@@ -12,8 +12,550 @@
   </header>
 
   <div class="standard-text-template">
-  <h1>What to expect from this new service</h1>
-  <div class="entry-content">
-    <p>...</p>
+    <h1>What to expect from this new service</h1>
+    <p><small>Last updated on 13th April 2022</small></p>
+    <p>The Find Case Law service provides public access to Court Judgments and Tribunal decisions.</p>
+    <p>From April 2022, court judgments from the England and Wales High Court, the Court of Appeal, the Supreme Court
+      and tribunal decisions from the Upper Tribunals are being sent to the National Archives so that they can be
+      preserved and made available to the public.</p>
+    <p>It only contains judgments and decisions that have been handed down and made public. This does not include
+      settlements made outside of court.</p>
+    <section>
+      <h2>About this service</h2>
+      <h3>Alpha service</h3>
+      <p>The Find Case Law service is in the very early stages of development, referred to as Alpha. This means that
+        this
+        is the first version of the Find Case Law service.</p>
+      <p>This service will develop and improve over the next few months and years. <a
+              href="https://corexmsnp4n42lf2kht3.qualtrics.com/jfe/form/SV_0lyyYAzfv9bGcyW">You can help contribute to
+        the
+        development of the service by giving us feedback.</a></p>
+      <h3>What is Case law?</h3>
+      <p>Case law is the law which is created through court judgments and tribunal decisions. This is sometimes known as
+        common law. Judges will follow the 'precedent' or the principles used in previous judgments and decisions when
+        deciding on a case. Case law can be used to clarify Legislation if it is unclear how it applies in a particular
+        context.</p>
+      <p>Legislation is law written by Members of Parliament (<abbr title="Members of Parliament">MPs</abbr>) and is
+        sometimes known as statutory law or the
+        statute.
+        <a href="https://www.legislation.gov.uk/">You can find Legislation here.</a></p>
+      <h3>Our legal basis for archiving and publishing case law</h3>
+      <p><a href="https://www.legislation.gov.uk/ukpga/Eliz2/6-7/51/contents">The Public Records Act 1958</a> provides
+        the
+        legal basis for the Find Case Law service.</p>
+      <p>Court judgments and tribunal decisions are public records. They fall within the scope of court records, defined
+        by the <a
+                href="https://www.legislation.gov.uk/ukpga/Eliz2/6-7/51/schedule/FIRST/crossheading/records-of-courts-and-tribunals">First
+          Schedule</a> of the Public Records Act 1958. The judgments that are published through the Find Case Law
+        service
+        have been selected for permanent preservation and have been transferred to The National Archives in accordance
+        with <a href="https://www.legislation.gov.uk/ukpga/Eliz2/6-7/51/section/3">Section 3</a>, or have been acquired
+        under <a href="https://www.legislation.gov.uk/ukpga/Eliz2/6-7/51/section/2/4/h">Section 2(4)(h)</a>.</p>
+      <p>Judgments and tribunal decisions are being preserved and made available to the public. The Keeper of Public
+        Records at The National Archives is required to <q>take all practicable steps for the preservation of records
+          under
+          his charge</q> under <a href="https://www.legislation.gov.uk/ukpga/Eliz2/6-7/51/section/2/3">Section 2(3)</a>,
+        and
+        to
+        <q>arrange that reasonable facilities are available to the public for inspecting and obtaining copies of those
+          public records in the Public Records Office which fall to be disclosed in accordance with the Freedom of
+          Information Act 2000.</q> under <a href="https://www.legislation.gov.uk/ukpga/Eliz2/6-7/51/section/5/3">Section
+          5(3)</a>. The Find Case Law service fulfils these statutory duties.</p>
+
+      <h3>We do not provide legal advice</h3>
+      <p>This service is designed to help you find court judgments or tribunal decisions. The National Archives do not
+        provide legal advice, interpretation or support. You can find advice and support at:</p>
+
+      <ul>
+        <li><a href="http://www.citizensadvice.org.uk">Citizens Advice Bureau</a></li>
+        <li><a href="http://www.lawcentres.org.uk">The Law Centres Network</a></li>
+        <li><a href="https://www.supportthroughcourt.org/">Support Through Court</a></li>
+        <li><a href="https://weareadvocate.org.uk/">Advocate</a></li>
+      </ul>
+    </section>
+    <section>
+      <h2>Find a Judgment or Decision</h2>
+      <p>You can search across the full text of every judgment and decision. You can also search and browse judgments,
+        by
+        neutral citation, court, party, judge and within a date range. These options can be combined on <a
+                href="https://caselaw.nationalarchives.gov.uk/structured_search">the 'More Options Search' page</a>.</p>
+      <p>You can find the latest published judgments and decisions as a list on <a
+              href="https://caselaw.nationalarchives.gov.uk/">the Find Case Law page.</a> Alternatively you can browse
+        by
+        court and filter results.</p>
+      <h3>Search across the text of every judgment and decision</h3>
+      <p>The search box on <a href="https://caselaw.nationalarchives.gov.uk/">the Find Case Law page </a>allows you to
+        search using any search terms including a neutral citation, name(s) and keyword(s). This will search the full
+        text
+        of every judgment or decision we have.</p>
+      <p>You do not need to do a boolean search. Spaces in between words will act as an 'and'. Results where the words
+        are closest together will be most relevant at the top of the search results.</p>
+      <h3>Search specific fields</h3>
+      <p>Alternatively you can search using one or more specific search terms on the<a
+              href="https://caselaw.nationalarchives.gov.uk/structured_search"> 'more search options' page</a>. The
+        search
+        boxes search particular fields. You can use multiple search boxes at the same time to help narrow down your
+        search
+        results. With the exception of Keyword, these boxes do not search the full text of judgments and decisions.</p>
+      <h4>Neutral citation</h4>
+      <p>The courts allocate a 'neutral citation' to judgments and decisions. This is a unique number and reference for
+        each judgment and decision. The neutral citation is at the top of the judgment or decision. They are the
+        official
+        way to cite a judgment or decision.</p>
+      <p>Examples of a neutral citation include:</p>
+      <ul>
+        <li>[2021] EWCA Civ 1847</li>
+        <li>[2009] EWHC 2500 (Mercantile)</li>
+        <li>[2013] EWHC 46 (Ch)</li>
+        <li>[2021] EWCOP 18 [2019] UKSC 38</li>
+      </ul>
+      <p>They typically include:</p>
+      <ul>
+        <li>
+          the year the judgment or decision was handed down. For example: [2009]
+        </li>
+        <li>
+          the standard court acronym. For example: EWCA is England and Wales Court of Appeal
+        </li>
+        <li>
+          The standard acronym for the division of court. For example: Civ is Civil division
+        </li>
+        <li>
+          A unique number allocated by the individual court within a given year. For example: '1847' will be the unique
+          number for the Court of Appeal civil division in 2021
+        </li>
+      </ul>
+      <p>If you are struggling to find a judgment or decision using a neutral citation first check:</p>
+      <ul>
+        <li>
+          you have written the neutral citation in full
+        </li>
+        <li>
+          there are no typos
+        </li>
+        <li>
+          the spaces are in the appropriate places
+        </li>
+        <li>
+          this is the neutral citation allocated by the court rather than the case number or a reference number
+          issued
+          by a publisher
+        </li>
+      </ul>
+      <p>You can also use neutral citations allocated by the British and Irish Legal Information Institute (<abbr
+              title="British and Irish Legal Information Institute">BAILII</abbr>) for judgments and decisions that do
+        not have neutral
+        citations allocated by the courts.</p>
+      <p>If you are confident that the neutral citation is correct but are struggling to find it, it may be that we
+        don't
+        have that judgment within our collection. You can read more about our limited coverage of judgments and
+        decisions.</p>
+      <h4>Party Name</h4>
+      <p>This is the name of someone involved in the case, such as the claimant or defendant. There are often multiple
+        party names listed at the top of the judgment or decision.</p>
+      <p>You can use the 'party name' search box on the 'more search options' page to only search against judgments or
+        decisions where the name is listed as a party. This will not search for the name within the text of all
+        judgments
+        and decisions.</p>
+      <p>There may be multiple results if the name is listed as a party in multiple judgments or decisions.</p>
+      <p>You can search using multiple party names at once. This means you can use this search to search by case name.
+        The
+        case name is made from some (or all) of the parties listed as the appellant and defendant.</p>
+      <p>For example: Cape Intermediate Holdings Ltd v Dring</p>
+      <p>If you see a name that has been struck through on a judgment this means that the person has withdrawn from the
+        case before it was decided.</p>
+      <h4>Keyword</h4>
+      <p>You can search the full text of every judgment and decision using a specific word or short phrase.</p>
+      <p>Spaces between words will act as an 'and'. Quotation marks will search using that exact phrase only.</p>
+      <h4>Judges Name</h4>
+      <p>The Judge(s) who decided a case will be at the top of the judgment or decision.</p>
+      <p>You can search by the name of the judge who has decided a case by using the 'Judge's name' box on the 'more
+        search options' page. This will mean that it will only search for judges that have given a judgment or decision
+        on
+        a case instead of searching every reference to the name of the judge within the full text of every judgment or
+        decision.</p>
+      <p>You can use a part of the name, the whole name, or the whole name and judicial titles.</p>
+      <h4>Court / Chamber</h4>
+      <p>The court or chamber where the case was decided will be at the top of the judgment or decision.</p>
+      <p>You can browse by court or chamber division to see all the judgments and decisions we have received from that
+        court.</p>
+      <p><a href="https://www.judiciary.uk/about-the-judiciary/the-justice-system/court-structure/">You can find more
+        information about courts and tribunals here.</a></p>
+      <h4>Date</h4>
+      <p>The date the judgment or decision was handed down on will be at the top of the judgment or decision.</p>
+      <p>You can search by date range to look for judgments and decisions within a particular time frame.</p>
+      <h3>Search results</h3>
+      <p>The search results are ordered by relevance. Judgments and decisions that contain the search terms within their
+        'metadata' will be listed above other judgments that only contain the search terms within the full text of the
+        judgment or decision. Search terms within the text will be ordered by how many times that search term is used
+        and
+        the proximity between each search term.</p>
+      <p>For example: if you searched for " Jones theft " then the Judgments with 'Jones' listed as a party name or
+        Judges name will
+        be at the top of the search results followed by judgments that use 'Jones' and 'theft' within the text of the
+        judgment.</p>
+      <p>You can filter results by date range, courts/chamber, party name, judges name.</p>
+    </section>
+    <section>
+      <h2>Limited coverage of Judgments and Decisions</h2>
+      <p>The Find case law service is an Alpha service. We are starting to receive judgments and decisions that have
+        been
+        handed down from the English and Welsh courts and tribunals.</p>
+      <p>The initial collection of judgments and decisions totals to around 50,000 documents that date back to 2003 for
+        Court Judgments, and to 2016 for Tribunal Decisions.</p>
+      <p>The collection includes:</p>
+      <ul>
+        <li>
+          All judgments and tribunal decisions from the Upper Tribunals, High Court, Court of Appeal and Supreme
+            Court
+            from 19th April 2022
+        </li>
+        <li>
+          Judgments and decisions provided by <abbr
+                  title="British and Irish Legal Information Institute">BAILII</abbr>, that have been published under
+            its contract with Her Majesty's Courts and Tribunals Service (<abbr
+                    title="Her Majesty's Courts and Tribunals Service">HMCTS</abbr>) / Ministry of Justice (<abbr
+                    title="Ministry of Justice">MoJ</abbr>),
+        </li>
+        <li>
+          Judgments provided directly by the Supreme Court and the Upper Tribunals.
+        </li>
+      </ul>
+      <p>To widen the coverage of the service, we have bought digital copies of other judgments and decisions.We are
+        currently working through these judgments and decisions to get them ready for publication and expand our
+        collection.</p>
+      <p>To begin with only judgments and decisions with neutral citations will be available. We are working to assign
+        identifiers to judgments and decisions without neutral citations. You can find more information on our Uniform
+        resource identifier (<abbr title="Uniform resource identifier">URI</abbr>).</p>
+      <h3>Date ranges for our coverage of courts and tribunals:</h3>
+      <ul>
+        <li>
+          United Kingdom Supreme Court 2014-2022
+        </li>
+        <li>
+          Privy Council 2014-2022
+        </li>
+      </ul>
+      <p>Court of Appeal</p>
+      <ul>
+        <li>
+          Court of Appeal (Civil Division) 2003-2022
+        </li>
+        <li>
+          Court of Appeal (Criminal Division) 2003-2022
+        </li>
+      </ul>
+      <p>High Court</p>
+      <ul>
+        <li>
+          High Court (Administrative Court) 2003-2022
+        </li>
+        <li>
+          High Court (Admiralty Division) 2003-2022
+        </li>
+        <li>
+          High Court (Chancery Division) 2003-2022
+        </li>
+        <li>
+          High Court (Commercial Court) 2003-2022
+        </li>
+        <li>
+          High Court (Senior Court Costs Office) 2003-2022
+        </li>
+        <li>
+          High Court (Family Division) 2003-2022
+        </li>
+        <li>
+          Intellectual Property Enterprise Court 2013-2022
+        </li>
+        <li>
+          High Court (Mercantile Court) 2008-2014
+        </li>
+        <li>
+          High Court (Patents Court) 2003-2022
+        </li>
+        <li>
+          High Court (Queen's Bench Division) 2003-2022
+        </li>
+        <li>
+          High Court (Technology and Construction Court) 2003-2022
+        </li>
+        <li>
+          Court of Protection 2009-2022
+        </li>
+        <li>
+          Family Court 2014-2022
+        </li>
+      </ul>
+      <p>Upper Tribunal</p>
+      <ul>
+        <li>
+          Upper Tribunal (Immigration and Asylum Chamber) 2010-2022
+        </li>
+        <li>
+          Upper Tribunal (Lands Chamber) 2015-2022
+        </li>
+        <li>
+          Upper Tribunal (Tax and Chancery Chamber) 2017-2022
+        </li>
+      </ul>
+      <p>We do not yet have decisions from:</p>
+      <ul>
+        <li>
+          Upper Tribunal (Administrative Appeals Chamber)
+        </li>
+        <li>
+          United Kingdom Employment Tribunal
+        </li>
+        <li>
+          United Kingdom Competition Appeals Tribunal
+        </li>
+        <li>
+          First-tier Tribunal (Tax Chamber)
+        </li>
+        <li>
+          First-tier Tribunal (Health, Education and Social Care Chamber)
+        </li>
+        <li>
+          First-tier Tribunal (General Regulatory Chamber)
+        </li>
+        <li>
+          United Kingdom Employment Appeal Tribunal
+        </li>
+      </ul>
+    </section>
+    <section>
+      <h2>Understanding a Judgment or Decision</h2>
+      <p>A judgment is the decision a court has made after hearing a case. Written judgments are also known as handed
+        down
+        judgments and can be very long.</p>
+      <p>The National Archives do not provide summaries, interpretation or advice on any judgments or decisions.</p>
+      <p>Every judgment or decision will start with a 'Header' or title page which contains the important information
+        about the judgment or decision such as: the neutral citation, the case number, the court or chamber, the judges
+        names, the parties' names.</p>
+      <p>The way the text of each judgment or decision is written is up to the judge. Typically, judgments will
+        summarise
+        'the facts' of the case, the law that applies to those facts, the arguments presented in court, the decision the
+        court has given and the reasons for the decision. The decision made by the judge is normally towards the end of
+        the judgment or decision.</p>
+      <p>You may find that some judgments and decisions have reporting restrictions. In these cases the relevant parts
+        of
+        the judgment will be obscured.</p>
+    </section>
+    <section>
+      <h2>Transferring Judgments and Decisions from the courts to The National Archives</h2>
+      <p>The National Archives is receiving a publication version of the judgment or decision. That means any redactions
+        or anonymization needed for publication, should already have been made by the court.</p>
+      <p>The Judges and clerks send us judgments and decisions as word documents using a service called Transfer Digital
+        Records (<abbr title="Transfer Digital Records">TDR</abbr>). Only registered users can use this service.</p>
+      <p>If you are a judge or clerk looking to for information about transfer digital records please email:
+        <a href="mailto:caselaw@nationalarchives.gov.uk">caselaw@nationalarchives.gov.uk</a></p>
+    </section>
+    <section>
+      <h2>How we publish Judgments and Decisions</h2>
+      <p>It is important that court judgments and tribunal decisions are published, unless the Courts decide there is a
+        strong reason to withhold a judgment or decision from the public.</p>
+      <p>Judgments and decisions are sent to The National Archives ready for publication. We will never change a
+        judgment
+        or decision. Each judgment is published as a single web page. The styling of the original record is retained in
+        the web page version, as much as possible.</p>
+      <h3>Revisions</h3>
+      <p>Over time we may receive several publication versions of the same judgment from the court. We will keep the
+        digital record of all the versions, but only publish the latest version authorised by the court. Changes,
+        refinements or corrections to the text of the currently published judgment can only be made by the court by
+        sending a replacement version of the judgment through the <abbr title="Transfer Digital Records">TDR</abbr>
+        service.</p>
+      <h3>Our due diligence</h3>
+      <p>We have a dedicated team who are experienced with legal information who check every judgment and decision
+        before
+        we publish them on the Case Law service.</p>
+      <p>We know that speedy publication is important for many of our users so for most judgments and decisions this
+        means
+        they will be published within twenty minutes of us receiving them.</p>
+      <p>For judgments and decisions that contain highly sensitive information this may take up to 24 hours. Very
+        occasionally we may need to double check the judgment or decision with the judge. In these cases the judgment or
+        decision may take longer to be published while we wait for confirmation that we have received the correct
+        publication version of the judgment or decision. We will not make any amendments to a judgment or decision on
+        the
+        court's behalf.</p>
+      <p>If you spot an error within a judgment or decision you can email: <a
+              href="mailto:caselaw@nationalarchives.gov.uk">caselaw@nationalarchives.gov.uk</a></p>
+      <h3>Take down Requests</h3>
+      <p>Once a judgment has been published, we will only withdraw it from publication if we are instructed to do so by
+        the judge / court.</p>
+      <p>We have developed this publishing policy in consultation with the Judicial Data Working group that is advising
+        us.</p>
+      <p>For more information on our publishing policy please email: <a href="mailto:caselaw@nationalarchives.gov.uk">caselaw@nationalarchives.gov.uk</a>
+      </p>
+    </section>
+    <section>
+      <h2>Judgments and Decisions as data</h2>
+      <p>We have made judgments and decisions available as data in order to facilitate transparency of the
+        administration
+        of justice and enable innovation. We have adopted the international standard Legal Document Mark-up Language
+        (<abbr title="Legal Document Mark-up Language">LegalDocML</abbr>).</p>
+      <p>Judgments and decisions are sent to us as Word documents using the <abbr
+              title="Transfer Digital Records">TDR</abbr> service. This is
+        the
+        digital record of the publication version of the judgment. We then create a digital surrogate of the record for
+        publication and re-use. This is the <abbr title="Legal Document Mark-up Language">LegalDocML</abbr> version from
+        which we create the
+        <abbr title="Hypertext Markup Language">HTML</abbr> and <abbr title="Portable Document Format">PDF</abbr>
+        documents. <a
+                href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=legaldocml">You can read more about
+          <abbr title="Legal Document Mark-up Language">LegalDocML</abbr> here.</a></p>
+      <p>This process allows us to have consistent data about judgments and decisions. This includes:</p>
+      <ul>
+        <li>Neutral citation</li>
+        <li>Court / Chamber</li>
+        <li>Party Names</li>
+        <li>Judges Name</li>
+        <li>Date</li>
+      </ul>
+      <p>Data about new judgments can also be consumed as a data feed.</p>
+      <h3>Uniform Resource Identifier (<abbr title="Uniform resource identifier">URI</abbr>)</h3>
+      <p>In most cases we will use the neutral citation as the basis for how we uniquely identify judgments and
+        decisions.</p>
+      <p>For example:</p>
+      <p>https://caselaw.nationalarchives.gov.uk/id/{court}[/{sub-division}/]{year}/{neutral-citation-number}</p>
+      <p>We have a dedicated team who will check that all new judgments and decisions we receive have a neutral
+        citation.</p>
+      <p>Neutral citations were adopted in 2001. Where a judgment doesn't have a neutral citation we will create an
+        identifier using the standard court abbreviation, the judgment date and an ordinal sequence number assigned by
+        The National Archives
+        (assigned in order the judgments were received)</p>
+      <p>For example:</p>
+      <p>https://caselaw.nationalarchives.gov.uk/id/{court}[/{sub-division}/]{year}/{judgment-date}/num/{tna-ordinal-number}</p>
+      <p>In the case where a judgment or decision has had a neutral citation issued by <abbr
+              title="British and Irish Legal Information Institute">BAILII</abbr>, we will make the The National
+        Archives'
+        ordinal number the same as the one issued by <abbr
+                title="British and Irish Legal Information Institute">BAILII</abbr>. This means that there is 1-1
+        mapping of judgments between
+        <abbr title="British and Irish Legal Information Institute">BAILII</abbr> and Find Case Law (when the header is
+        replaced).</p>
+      <h3>Enrichment</h3>
+      <p>This is where we automatically find and hyperlink neutral citations and titles of legislation within the text
+        of
+        a judgment or decision.</p>
+      <p>Neutral citation links will take you to the original judgment or decision if we have it as part of our
+        collection
+        of judgments and decisions. You can read more about our coverage of judgments and decisions.</p>
+      <p>Links to acts of legislation will take you to the legislation as it stands today. You can use the legislation
+        'point in time' feature to find legislation as it stood on a particular date or the original legislation passed
+        by
+        parliament.</p>
+      <p>The National Archives are working to further enrich these judgments and decisions.</p>
+      <h3><abbr title="Application Programming Interface">API</abbr></h3>
+      <p>The <abbr title="Legal Document Mark-up Language">LegalDocML</abbr> data for the judgments is available through
+        the <abbr title="Application Programming Interface">API</abbr>.</p>
+      <p>You can read our documentation for the <abbr title="Application Programming Interface">API</abbr></p>
+      <p>In order to re-use the data you must be compliant with the terms set out in our data licences.</p>
+    </section>
+    <section>
+      <h2>Data Licensing arrangements</h2>
+      <p>The goals with licensing court judgments and tribunal decisions for re-use are to facilitate open justice,
+        enable
+        innovation, while protecting the proper administration of justice.</p>
+      <h3>The Open Government Licence does not apply</h3>
+      <p>Judgments and decisions contain personal data. This means the Open Government Licence cannot apply as it
+        excludes
+        personal data.</p>
+      <p>The National Archives has been working in consultation with the Ministry of Justice and the Judicial Executive
+        Board (chaired by the Lord Chief Justice) to develop two licences that permit the re-use of judgments and
+        decisions. Both licences are free to use.</p>
+      <ul>
+        <li>
+          <a href="https://caselaw.nationalarchives.gov.uk/open-justice-licence">The Open Justice Licence,</a> that
+            permits re-use but excludes computational analysis. You do not need to apply for this licence.
+        </li>
+        <li>
+          A transactional licence that permits re-use including computational analysis. You will need to apply for
+            this
+            licence.
+        </li>
+      </ul>
+      <p>The personal information within judgments varies but it can be very extensive and contain distressing
+        content.</p>
+      <p>It is for the court to decide whether reporting restrictions should apply. It is therefore possible for these
+        decisions to be overruled in court and retrospective reporting restrictions be applied. It is therefore
+        important
+        you are aware of your obligations and are compliant with the licence terms when re-using the data to avoid being
+        in contempt of court.</p>
+      <h3>Personal data and <abbr title="General Data Protection Regulation">GDPR</abbr></h3>
+      <p>Judgments and decisions contain personal data.</p>
+      <p>Neither type of licence is a data sharing agreement or a processing agreement for personal data. Re-users are
+        recipients of the judgments and decisions published by The National Archives. As a Data Controller, re-users
+        will
+        need to satisfy themselves that they have a legal basis and valid purpose for processing personal data. The
+        licences and application process has been carefully designed so as not to create a Data Controller / Data
+        Processor arrangement between The National Archives and the re-users (unlike the commercial licences we issue
+        for
+        digital surrogates of paper records).</p>
+      <p>The courts are not subject to data protection regulation when acting in their judicial capacity. The National
+        Archives is subject to data protection regulation. The Public Records Act 1958 provides the legal basis for our
+        processing of personal data in judgments under UK <abbr title="General Data Protection Regulation">GDPR</abbr>.
+      </p>
+      <p>It is important that you are aware of the legal obligations and that your re-use of the data is consistent with
+        the administration of justice.</p>
+      <h3>Open justice licence</h3>
+      <p>You can use this licence to re-publish judgments or decisions on your own website. For example in a blog post.
+        Computational analysis of judgments including basic search indexing is not permitted under this licence.</p>
+      <p>You do not need to apply for this licence however you should be aware of the responsibilities you have. <a
+              href="https://caselaw.nationalarchives.gov.uk/open-justice-licence">You can read the terms of the Open
+        Justice Licence here</a></p>
+      <p>If you are unsure you are within the terms of the Open Justice Licence please apply for the transactional
+        licence.</p>
+      <h3>Transactional licence</h3>
+      <p>You need to apply for this licence if you intend to use court judgments and tribunal decisions in a way that is
+        outside the terms of the Open Justice licence. For example, to run computational analysis across judgments and
+        decisions including basic search indexing.</p>
+      <p>You can apply for the licence at no cost by completing and submitting an application form. You can download the
+        application form.</p>
+      <p>The application form is designed to allow you to explain your purpose including: how you intend to re-use the
+        data in a way that is consistent with the administration of justice</p>
+      <p>We are assessing applications using<a href="https://en.wikipedia.org/wiki/Five_safes"> the "five safes"
+        framework:</a></p>
+      <ol>
+        <li>
+          Safe People
+        </li>
+        <li>
+          Safe Projects
+        </li>
+        <li>
+          Safe Data
+        </li>
+        <li>
+          Safe Settings
+        </li>
+        <li>
+          Safe Outputs.
+        </li>
+      </ol>
+      <p>We work in accordance with <a href="https://www.legislation.gov.uk/uksi/2015/1415/contents">The Re-use of
+        Public
+        Sector Information Regulation 2015</a>. We will respond to your application within 20 working days <a
+              href="https://www.legislation.gov.uk/uksi/2015/1415/regulation/8">(Section 8)</a>.</p>
+      <p>We do not discriminate against applicants <a
+              href="https://www.legislation.gov.uk/uksi/2015/1415/regulation/13">(Section
+        13)</a>. Therefore if we have already granted a licence for the same purpose as described in your application
+        then
+        it will be granted within 20 working days.</p>
+      <p>However, if your application describes an intended re-use that we have not previously considered this may take
+        longer. Where we are uncertain that an application is consistent with the administration of justice we will ask
+        for clarification from the Ministry of Justice and the Judiciary</p>
+      <p>Once your licence is granted you can be confident that your re-use of the data is consistent with the proper
+        administration of justice. The term of the licence is 1 calendar year from the date the licence has been
+        granted.</p>
+      <p>If you are unsure please apply.</p>
+      <p>If your application is unsuccessful you can find more information about <a
+              href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/complaints-about-re-use/">
+        making a complaint against re-use of public sector information here.</a></p>
+    </section>
+    <section>
+      <h2>Contact us</h2>
+      <p><a href="mailto:caselaw@nationalarchives.gov.uk">caselaw@nationalarchives.gov.uk</a></p>
+    </section>
   </div>
 {% endblock %}

--- a/ds_judgements_public_ui/templates/pages/what_to_expect.html
+++ b/ds_judgements_public_ui/templates/pages/what_to_expect.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block title %}
-  {{ page_title }} - {% translate "common.findcaselaw" %}
+  {% translate "whattoexpect.title" %} - {% translate "common.findcaselaw" %}
 {% endblock title %}
 
 {% block content %}
@@ -12,7 +12,7 @@
   </header>
 
   <div class="standard-text-template">
-    <h1>What to expect from this new service</h1>
+    <h1>{% translate "whattoexpect.title" %}</h1>
     <p><small>Last updated on 13th April 2022</small></p>
     <p>The Find Case Law service provides public access to Court Judgments and Tribunal decisions.</p>
     <p>From April 2022, court judgments from the England and Wales High Court, the Court of Appeal, the Supreme Court
@@ -27,7 +27,7 @@
         this
         is the first version of the Find Case Law service.</p>
       <p>This service will develop and improve over the next few months and years. <a
-              href="https://corexmsnp4n42lf2kht3.qualtrics.com/jfe/form/SV_0lyyYAzfv9bGcyW">You can help contribute to
+              href="{% translate "survey.link" %}">You can help contribute to
         the
         development of the service by giving us feedback.</a></p>
       <h3>What is Case law?</h3>
@@ -78,13 +78,13 @@
       <p>You can search across the full text of every judgment and decision. You can also search and browse judgments,
         by
         neutral citation, court, party, judge and within a date range. These options can be combined on <a
-                href="https://caselaw.nationalarchives.gov.uk/structured_search">the 'More Options Search' page</a>.</p>
+                href="{% url "structured_search" %}">the 'More Options Search' page</a>.</p>
       <p>You can find the latest published judgments and decisions as a list on <a
-              href="https://caselaw.nationalarchives.gov.uk/">the Find Case Law page.</a> Alternatively you can browse
+              href="{% url "home" %}">the Find Case Law page.</a> Alternatively you can browse
         by
         court and filter results.</p>
       <h3>Search across the text of every judgment and decision</h3>
-      <p>The search box on <a href="https://caselaw.nationalarchives.gov.uk/">the Find Case Law page </a>allows you to
+      <p>The search box on <a href="{% url "home" %}">the Find Case Law page </a>allows you to
         search using any search terms including a neutral citation, name(s) and keyword(s). This will search the full
         text
         of every judgment or decision we have.</p>
@@ -92,7 +92,7 @@
         are closest together will be most relevant at the top of the search results.</p>
       <h3>Search specific fields</h3>
       <p>Alternatively you can search using one or more specific search terms on the<a
-              href="https://caselaw.nationalarchives.gov.uk/structured_search"> 'more search options' page</a>. The
+              href="{% url "structured_search" %}"> 'more search options' page</a>. The
         search
         boxes search particular fields. You can use multiple search boxes at the same time to help narrow down your
         search
@@ -349,7 +349,7 @@
       <p>The Judges and clerks send us judgments and decisions as word documents using a service called Transfer Digital
         Records (<abbr title="Transfer Digital Records">TDR</abbr>). Only registered users can use this service.</p>
       <p>If you are a judge or clerk looking to for information about transfer digital records please email:
-        <a href="mailto:caselaw@nationalarchives.gov.uk">caselaw@nationalarchives.gov.uk</a></p>
+        <a href="mailto:{% translate "contact.email" %}">{% translate "contact.email" %}</a></p>
     </section>
     <section>
       <h2>How we publish Judgments and Decisions</h2>
@@ -379,13 +379,13 @@
         the
         court's behalf.</p>
       <p>If you spot an error within a judgment or decision you can email: <a
-              href="mailto:caselaw@nationalarchives.gov.uk">caselaw@nationalarchives.gov.uk</a></p>
+              href="mailto:{% translate "contact.email" %}">{% translate "contact.email" %}</a></p>
       <h3>Take down Requests</h3>
       <p>Once a judgment has been published, we will only withdraw it from publication if we are instructed to do so by
         the judge / court.</p>
       <p>We have developed this publishing policy in consultation with the Judicial Data Working group that is advising
         us.</p>
-      <p>For more information on our publishing policy please email: <a href="mailto:caselaw@nationalarchives.gov.uk">caselaw@nationalarchives.gov.uk</a>
+      <p>For more information on our publishing policy please email: <a href="mailto:{% translate "contact.email" %}">{% translate "contact.email" %}</a>
       </p>
     </section>
     <section>
@@ -555,7 +555,7 @@
     </section>
     <section>
       <h2>Contact us</h2>
-      <p><a href="mailto:caselaw@nationalarchives.gov.uk">caselaw@nationalarchives.gov.uk</a></p>
+      <p><a href="mailto:{% translate "contact.email" %}">{% translate "contact.email" %}</a></p>
     </section>
   </div>
 {% endblock %}

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-21 15:18+0000\n"
+"POT-Creation-Date: 2022-04-14 09:43+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,23 +18,105 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ds_judgements_public_ui/templates/base.html:8
+#: ds_judgements_public_ui/templates/base.html:9
 #: ds_judgements_public_ui/templates/includes/breadcrumbs.html:7
 #: ds_judgements_public_ui/templates/judgment/results.html:5
-#: ds_judgements_public_ui/templates/layout_judgment_html.html:10
+#: ds_judgements_public_ui/templates/layout_judgment_html.html:11
+#: ds_judgements_public_ui/templates/pages/accessibility_statement.html:5
 #: ds_judgements_public_ui/templates/pages/home.html:14
 #: ds_judgements_public_ui/templates/pages/terms_of_use.html:5
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:5
 msgid "common.findcaselaw"
 msgstr "Find case law"
 
-#: ds_judgements_public_ui/templates/base.html:26
-#: ds_judgements_public_ui/templates/layout_judgment_html.html:26
+#: ds_judgements_public_ui/templates/base.html:29
+#: ds_judgements_public_ui/templates/layout_judgment_html.html:29
 msgid "skiplink"
 msgstr "Skip to Main Content"
 
-#: ds_judgements_public_ui/templates/includes/breadcrumbs.html:6
-msgid "common.home"
-msgstr "Home"
+#: ds_judgements_public_ui/templates/includes/footer.html:7
+msgid "footer.websites"
+msgstr "Websites"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:9
+msgid "footer.legislation.link"
+msgstr "https://www.legislation.gov.uk/"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:9
+msgid "footer.legislation"
+msgstr "Legislation"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:10
+msgid "footer.gazette.link"
+msgstr "https://www.thegazette.co.uk/"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:10
+msgid "footer.gazette"
+msgstr "The Gazette"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:11
+msgid "footer.judiciary.link"
+msgstr "https://www.judiciary.uk"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:11
+msgid "footer.judiciary"
+msgstr "Judiciary"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:15
+msgid "footer.sitehelp"
+msgstr "Site help"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:17
+#: ds_judgements_public_ui/templates/pages/accessibility_statement.html:9
+msgid "accessibilitystatement.title"
+msgstr "Accessibility statement"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:18
+msgid "footer.contact.link"
+msgstr "https://www.nationalarchives.gov.uk/contact-us/"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:18
+msgid "footer.contact"
+msgstr "Contact us"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:22
+msgid "footer.legal"
+msgstr "Legal"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:24
+#: ds_judgements_public_ui/templates/pages/terms_of_use.html:9
+msgid "terms.title"
+msgstr "Terms of use"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:25
+msgid "footer.cookies.link"
+msgstr "https://www.nationalarchives.gov.uk/legal/cookies/"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:25
+msgid "footer.cookies"
+msgstr "Cookies"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:26
+msgid "footer.privacy.link"
+msgstr "https://www.nationalarchives.gov.uk/legal/privacy-policy/"
+
+#: ds_judgements_public_ui/templates/includes/footer.html:26
+msgid "footer.privacy"
+msgstr "Privacy"
+
+#: ds_judgements_public_ui/templates/includes/how_can_this_service_be_improved.html:4
+msgid "service.improved"
+msgstr "How can this service be improved?"
+
+#: ds_judgements_public_ui/templates/includes/how_can_this_service_be_improved.html:5
+#: ds_judgements_public_ui/templates/includes/phase_banner.html:8
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:30
+msgid "survey.link"
+msgstr "https://corexmsnp4n42lf2kht3.qualtrics.com/jfe/form/SV_0lyyYAzfv9bGcyW"
+
+#: ds_judgements_public_ui/templates/includes/how_can_this_service_be_improved.html:5
+msgid "survey.link.text"
+msgstr "Fill out our short survey"
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_source.html:4
 msgid "judgment.source_by"
@@ -56,21 +138,23 @@ msgstr "Download as XML"
 msgid "judgment.downloadaspdf"
 msgstr "Download as PDF"
 
-#: ds_judgements_public_ui/templates/includes/recent_judgments.html:20
+#: ds_judgements_public_ui/templates/includes/recent_judgments.html:21
+#: ds_judgements_public_ui/templates/includes/results_list.html:23
 msgid "judgments.date"
 msgstr "Date:"
 
-#: ds_judgements_public_ui/templates/includes/recent_judgments.html:23
+#: ds_judgements_public_ui/templates/includes/recent_judgments.html:24
+#: ds_judgements_public_ui/templates/includes/results_list.html:26
 msgid "judgments.court"
 msgstr "Court:"
 
-#: ds_judgements_public_ui/templates/includes/recent_judgments.html:29
+#: ds_judgements_public_ui/templates/includes/recent_judgments.html:30
 msgid "judgments.allrecent"
 msgstr "See all recent judgments"
 
 #: ds_judgements_public_ui/templates/judgment/results.html:5
 #: ds_judgements_public_ui/templates/judgment/results.html:9
-#: judgments/views.py:208
+#: judgments/views.py:163
 msgid "results.search.title"
 msgstr "Search results"
 
@@ -94,17 +178,9 @@ msgstr ""
 "Improve your search results by removing filters, double-checking your "
 "spelling, using fewer keywords or searching for something less specific."
 
-#: ds_judgments_public_ui/templates/pages/accessibility_statement.html:5
-msgid "accessibilitystatement.title"
-msgstr "Accessibility statement"
-
 #: ds_judgements_public_ui/templates/pages/open_justice_licence.html:5
 msgid "openjusticelicence.title"
 msgstr "Open Justice Licence"
-
-#: ds_judgements_public_ui/templates/pages/sources.html:5
-msgid "judgmentsources.title"
-msgstr "Judgment Sources"
 
 #: ds_judgements_public_ui/templates/pages/structured_search.html:5
 #: ds_judgements_public_ui/templates/pages/structured_search.html:9
@@ -115,68 +191,23 @@ msgstr "Search"
 msgid "commom.findcaselaw"
 msgstr "Find case law"
 
-#: ds_judgements_public_ui/templates/pages/terms_of_use.html:9
-msgid "terms.title"
-msgstr "Terms of use"
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:5
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:15
+msgid "whattoexpect.title"
+msgstr "What to expect from this new service"
 
-#: ds_judgments_public_ui/templates/includes/how_can_this_service_be_improved:4
-msgid "service.improved"
-msgstr "How can this service be improved?"
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:352
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:382
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:388
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:558
+msgid "contact.email"
+msgstr "caselaw@nationalarchives.gov.uk"
 
-#: ds_judgments_public_ui/templates/includes/how_can_this_service_be_improved:5
-#: ds_judgments_public_ui/templates/includes/phase_banner:8
-msgid "survey.link"
-msgstr "https://corexmsnp4n42lf2kht3.qualtrics.com/jfe/form/SV_0lyyYAzfv9bGcyW"
+#~ msgid "common.home"
+#~ msgstr "Home"
 
-#: ds_judgments_public_ui/templates/includes/how_can_this_service_be_improved:5
-msgid "survey.link.text"
-msgstr "Fill out our short survey"
-
-#: ds_judgments_public_ui/templates/includes/footer
-msgid "footer.websites"
-msgstr "Websites"
-
-msgid "footer.sitehelp"
-msgstr "Site help"
-
-msgid "footer.legal"
-msgstr "Legal"
-
-msgid "footer.legislation"
-msgstr "Legislation"
-
-msgid "footer.legislation.link"
-msgstr "https://www.legislation.gov.uk/"
-
-msgid "footer.gazette"
-msgstr "The Gazette"
-
-msgid "footer.gazette.link"
-msgstr "https://www.thegazette.co.uk/"
-
-msgid "footer.cookies"
-msgstr "Cookies"
-
-msgid "footer.cookies.link"
-msgstr "https://www.nationalarchives.gov.uk/legal/cookies/"
-
-msgid "footer.privacy"
-msgstr "Privacy"
-
-msgid "footer.privacy.link"
-msgstr "https://www.nationalarchives.gov.uk/legal/privacy-policy/"
-
-msgid "footer.judiciary"
-msgstr "Judiciary"
-
-msgid "footer.judiciary.link"
-msgstr "https://www.judiciary.uk"
-
-msgid "footer.contact"
-msgstr "Contact us"
-
-msgid "footer.contact.link"
-msgstr "https://www.nationalarchives.gov.uk/contact-us/"
+#~ msgid "judgmentsources.title"
+#~ msgstr "Judgment Sources"
 
 #, fuzzy
 #~| msgid "common.findcaselaw"


### PR DESCRIPTION
This PR brings introduces the changes from #167 with some changes to the HTML, including: 

- [x] Introduction of `<section>` elements and some changes to structure and semantics
- [x] Changes to heading hierarchy
- [x] Introduction of additional semantic elements, such as `<q>` and `<abbr>`
- [x] Uses `translate` for common strings (such as email addresses) and `url` for routes

I've initially introduced this as HTML rather than via Django translations for the following reasons: 

1. This is a long page comprising: 111 paragraphs, 58 list items, 29 links, 24 abbreviations - which will generate a huge number (likely hundreds) of necessary translations. I suspect the benefit of these translations may never outweigh the effort necessary for them to be produced and maintained (it seems this content is best suited to a CMS rather than locale files)
2. The page is likely to need ongoing editing and refinement, which will be more straightforward to achieve if it is in HTML 

I'm happy for the page to use translations if others have a strong view on this but, for the time being, it seems most sensible to include the HTML. 