### PR TITLE
Improve 404 page

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_standard_text_template.scss
+++ b/ds_judgements_public_ui/sass/includes/_standard_text_template.scss
@@ -9,7 +9,7 @@
 
   margin-top: calc($spacer__unit * 5);
   margin-bottom: calc($spacer__unit * 8);
-  min-height: 40rem;
+  min-height: 18rem;
 
   h1, h2, h3 {
     font-family: $font__roboto;

--- a/ds_judgements_public_ui/templates/404.html
+++ b/ds_judgements_public_ui/templates/404.html
@@ -3,7 +3,10 @@
 {% block title %}Page not found{% endblock %}
 
 {% block content %}
-<h1>Page not found</h1>
+  <div class="standard-text-template">
+    <h1>Page not found</h1>
 
-<p>{% if exception %}{{ exception }}{% else %}Sorry, this page could not be found.{% endif %}</p>
+    <p>If you typed the web address, check it is correct.</p>
+    <p>If you pasted the web address, check you copied the entire address.</p>
+  </div>
 {% endblock content %}


### PR DESCRIPTION
This introduces text as copied from the 404 page on nationalarchives.gov.uk and uses the same styles as the standard text template (amended slightly to fix unnecessarily generous height).

This is an interim fix pending a full content and design review.