### PR TITLE
Ensure `page` param is never an empty string

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -79,6 +79,7 @@ def advanced_search(request):
         "to": params.get("to"),
     }
     page = params.get("page", 1)
+    page = page if page else 1
     context = {}
 
     try:


### PR DESCRIPTION
When an empty string is passed through to the search XQuery it causes the
following Rollbar error: https://rollbar.com/dxw/tna-caselaw-public-ui/items/28/?item_page=0&#traceback

Ensure `page` is NEVER an empty string. If it is passed as one from the UI,
assume page 1 is required.