### PR TITLE
Change PDF font size to 12px rather than 16

### DIFF
--- a/ds_judgements_public_ui/sass/judgmentpdf.scss
+++ b/ds_judgements_public_ui/sass/judgmentpdf.scss
@@ -3,7 +3,7 @@
 @import "includes/judgment_text";
 
 html {
-  font-size: 16px;
+  font-size: 12px;
 }
 
 .judgment {


### PR DESCRIPTION
Based on the "normal" font size in the docx sample I had, I've gone for a smaller font size in the PDFs of 12px. Not sure if it's correct, @gtvj what do you think?