### PR TITLE
Temporarily remove source footer until we can wire this in properly

### DIFF
--- a/ds_judgements_public_ui/templates/layout_judgment_html.html
+++ b/ds_judgements_public_ui/templates/layout_judgment_html.html
@@ -39,7 +39,6 @@
     {% endblock %}
     <a id="js-back-to-top-link" class="back-to-top-link" href="#js-phase-banner">Back to top</a>
 </main>
-{% include 'includes/judgment_text_source.html' %}
 {% include 'includes/footer.html' %}
 </body>
 </html>


### PR DESCRIPTION
Trello: https://trello.com/c/PH7mBW0v/443-newly-published-judgments-still-have-provided-by-bailii-in-the-footer

All Judgments currently have "provided by BAILII" in the footer, even if the
judgment was not provided by them. Until we wire up something in the back end
to show where a judgment is from, we need to remove it.