### PR TITLE
Remove border colour from judgment header

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text.scss
@@ -30,6 +30,13 @@
 
 .judgment-header {
 
+  table {
+
+    td {
+      border-color: transparent;
+    }
+  }
+
   &__logo {
     padding-top: $spacer__unit * 3;
 


### PR DESCRIPTION
This PR addresses an issue with table borders appearing in the Judgment header. It does this by making them transparent. I'm currently unable to run the code locally so the rules are somewhat overqualified, but we can review this at a later date (I've made a note of this).