### PR TITLE
Show the correct (editable) Neutral Citation in the search results

### DIFF
--- a/judgments/models.py
+++ b/judgments/models.py
@@ -17,7 +17,7 @@ class Judgment(xmlmodels.XmlModel):
         "//akn:FRBRname/@value", ignore_extra_nodes=True
     )
     neutral_citation = xmlmodels.XPathTextField(
-        "//akn:neutralCitation", ignore_extra_nodes=True
+        "//akn:proprietary/uk:cite", ignore_extra_nodes=True
     )
     date = xmlmodels.XPathTextField(
         "//akn:FRBRdate[@name='judgment']/@date", ignore_extra_nodes=True

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -36,13 +36,9 @@ class TestJudgmentModel(TestCase):
                         <proprietary source="ewca/civ/2004/811/eng/docx"
                             xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
                             <uk:court>EWCA-Civil</uk:court>
+                            <uk:cite>[2017] EWHC 3289 (QB)</uk:cite>
                         </proprietary>
                     </meta>
-                    <header>
-                        <p>
-                            <neutralCitation>[2017] EWHC 3289 (QB)</neutralCitation>
-                        </p>
-                    </header>
                 </judgment>
             </akomaNtoso>
         """


### PR DESCRIPTION
An editor noted that they had edited the Neutral Citation for a judgment, which
had updated the metadata correctly, but the old citation was showing in the
search results.

It transpires we were picking out the incorrect element for the citation -
we were using the `akn:neutralCitation` element, which is not editable by
the editors. We should instead be picking out the citation from the judgment
metadata, `uk:cite`.