### PR TITLE
Correct link to the UK Government Licensing Framework

### DIFF
--- a/ds_judgements_public_ui/templates/pages/open_justice_licence.html
+++ b/ds_judgements_public_ui/templates/pages/open_justice_licence.html
@@ -130,7 +130,9 @@
       which Crown copyright subsists.</p>
     <p>Further context, best practice and guidance relating to the re-use of public sector information can be found in
       the UK Government Licensing Framework section on The National Archives website <a
-              href="http://www.nationalarchives.gov.uk/information-management/uk-govlicensing-framework.htm ">http://www.nationalarchives.gov.uk/information-management/uk-govlicensing-framework.htm</a>
+        href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/ ">
+        https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/
+      </a>
     </p>
   </div>
 {% endblock %}


### PR DESCRIPTION
The link t othe UK Government Licensing Framework section on the Open Justice
Licence was incorrect.

Trello: https://trello.com/c/AMFfAXUi/513-link-on-open-justice-link-broken