### PR TITLE
Add URI attribute to atom feed

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -8,8 +8,19 @@ from .models import SearchResult
 from .utils import perform_advanced_search
 
 
+class JudgmentAtomFeed(Atom1Feed):
+    def root_attributes(self):
+        attrs = super().root_attributes()
+        attrs["xmlns:tna"] = "https://caselaw.nationalarchives.gov.uk"
+        return attrs
+
+    def add_item_elements(self, handler, item) -> None:
+        super().add_item_elements(handler, item)
+        handler.addQuickElement("tna:uri", item.get("uri", ""))
+
+
 class LatestJudgmentsFeed(Feed):
-    feed_type = Atom1Feed
+    feed_type = JudgmentAtomFeed
     author_name = "The National Archives"
 
     def get_object(self, request, court=None, subdivision=None, year=None):
@@ -60,6 +71,11 @@ class LatestJudgmentsFeed(Feed):
 
     def item_author_name(self, item: SearchResult) -> str:
         return item.author
+
+    def item_extra_kwargs(self, item: SearchResult):
+        extra_kwargs = super().item_extra_kwargs(item)
+        extra_kwargs["uri"] = item.uri
+        return extra_kwargs
 
     def item_updateddate(self, item: SearchResult) -> datetime.datetime:
         return (


### PR DESCRIPTION
Adds a custom URI attribute, under the `tna` namespace, to the Atom XML feed.

A feed entry now looks like:

```xml
<entry>
  <title>X v Y</title>
  <link href="https://caselaw.nationalarchives.com/ewca/civ/2022/111" rel="alternate"/>
  <updated>2022-05-04T09:57:02.892706+00:00</updated>
  <author>
    <name>Ministry of Justice</name>
  </author>
  <id>https://caselaw.nationalarchives.com/ewca/civ/2022/111</id>
  <summary type="html"/>
  <tna:uri>ewca/civ/2022/111</tna:uri>
</entry>
```

The feed validates as an Atom 1.0 feed:

![Screenshot from the w3.org atom feed validator, with a "Valid" image, a title of "Congratulations!", and text stating "This is a valid Atom 1.0 feed"](https://user-images.githubusercontent.com/4388406/166910611-6f0116d0-cbeb-4bea-9959-05a353dc8c19.png)
