### PR TITLE
Add sorting to search results, by relevance or date descending

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_result_controls.scss
+++ b/ds_judgements_public_ui/sass/includes/_result_controls.scss
@@ -1,4 +1,5 @@
 .result-controls {
+  text-align: right;
 
   &__order-by-label {
     font-family: $font__roboto;

--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -1,8 +1,12 @@
+{% load i18n %}
 <div class="result-controls">
-  <form action="#" id="analytics-result-controls">
-    <div>
-      <label class="result-controls__order-by-label" for="order_by">{{ form.order_by.label }}</label>
-      {{ form.order_by }}
+  {% if context.query %}
+    <div class="result-controls__order-by-label">
+      {% if context.order == "-date" %}
+        <a class="" href="{{request.path}}?{{context.query_string}}&order=">{% translate "results.order-by.relevance" %}</a>
+      {% else %}
+        <a class="" href="{{request.path}}?{{context.query_string}}&order=-date">{% translate "results.order-by.date" %}</a>
+      {% endif %}
     </div>
-  </form>
+  {% endif %}
 </div>

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -460,6 +460,11 @@ msgstr "What to expect from this new service"
 msgid "contact.email"
 msgstr "caselaw@nationalarchives.gov.uk"
 
+msgid "results.order-by.date"
+msgstr "Order by date"
+msgid "results.order-by.relevance"
+msgstr "Order by relevance"
+
 #~ msgid "common.home"
 #~ msgstr "Home"
 


### PR DESCRIPTION
This is a temporary-ish fix until we get front-end design input.

Add Sort by date/Sort by relevance links to the search results.

The links re-write the request to alter the `order` query parameter. As such,
we have some code in the view to remove the `order` param and re-add it with
the relevant value.

We also have a tweak in the front end to not show the Order parameter in the
removable filter UI pattern.

<img width="1237" alt="Screenshot 2022-05-06 at 11 24 46" src="https://user-images.githubusercontent.com/1089521/167116445-7b801a82-c71c-41e6-827b-90f3a17e3a3d.png">
<img width="1202" alt="Screenshot 2022-05-06 at 11 24 20" src="https://user-images.githubusercontent.com/1089521/167116450-17237ac6-cd11-4c23-877f-2acf4a029946.png">
