### PR TITLE
order  atom feeds by publication date

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -67,7 +67,7 @@ class LatestJudgmentsFeed(Feed):
         slugs = filter(lambda x: x is not None, [court, subdivision, year])
         slug = "/".join([str(s) for s in slugs])
         page = int(request.GET.get("page", 1)) or 1
-        order = request.GET.get("order", "-updated")
+        order = request.GET.get("order", "-date")
         model = perform_advanced_search(
             court=court_query if court_query else None,
             date_from=datetime.date(year=year, month=1, day=1).strftime("%Y-%m-%d")


### PR DESCRIPTION
Temporarily revert the ordering of Atom feeds to descending publication date, as the feeds were no longer working when combined with a court name