### PR TITLE
Don't show the "Matching text sample" text when there are no search matches

### DIFF
--- a/ds_judgements_public_ui/templates/includes/results_list.html
+++ b/ds_judgements_public_ui/templates/includes/results_list.html
@@ -27,14 +27,16 @@
             </span>
       </span>
       </span>
-      <span class="judgment-listing__result-term-matching">
-        Matching text sample:
-      </span>
-      <span class="judgment-listing__matches">
-      {% autoescape off %}
-        {{ item.matches }}
-      {% endautoescape %}
-      </span>
+      {% if item.matches %}
+        <span class="judgment-listing__result-term-matching">
+          Matching text sample:
+        </span>
+        <span class="judgment-listing__matches">
+        {% autoescape off %}
+          {{ item.matches }}
+        {% endautoescape %}
+        </span>
+      {% endif %}
     </li>
   {% endfor %}
 </ul>

--- a/judgments/models.py
+++ b/judgments/models.py
@@ -58,11 +58,16 @@ class SearchResult:
         author = api_client.get_property(uri, "source-organisation")
         last_modified = api_client.get_last_modified(uri)
 
+        if len(str(matches.transform_to_html())) == 0:
+            matches = None
+        else:
+            matches = matches.transform_to_html()
+
         return SearchResult(
             uri=uri,
             neutral_citation=judgment.neutral_citation,
             name=judgment.metadata_name,
-            matches=matches.transform_to_html(),
+            matches=matches,
             court=judgment.court,
             date=judgment.date,
             author=author,


### PR DESCRIPTION
Trello: https://trello.com/c/PUxsyBiy

Before:
<img width="1130" alt="Screenshot 2022-05-12 at 16 39 56" src="https://user-images.githubusercontent.com/1089521/168265116-2217cc58-fb56-4ba2-8f89-aa440854395e.png">

After:
<img width="1083" alt="Screenshot 2022-05-12 at 16 40 17" src="https://user-images.githubusercontent.com/1089521/168265131-876ec029-0859-478a-b2de-756829f8ea99.png">
