### PR TITLE
Ensure search results are always ordered correctly beyond page 1

### DIFF
--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -1,11 +1,11 @@
-{% load i18n %}
+{% load i18n query_filters %}
 <div class="result-controls">
   {% if context.query %}
     <div class="result-controls__order-by-label">
       {% if context.order == "-date" %}
-        <a class="" href="{{request.path}}?{{context.query_string}}&order=">{% translate "results.order-by.relevance" %}</a>
+        <a class="" href="{{request.path}}?{{context.query_params|remove_query_key:'order'}}&order=relevance">{% translate "results.order-by.relevance" %}</a>
       {% else %}
-        <a class="" href="{{request.path}}?{{context.query_string}}&order=-date">{% translate "results.order-by.date" %}</a>
+        <a class="" href="{{request.path}}?{{context.query_params|remove_query_key:'order'}}&order=-date">{% translate "results.order-by.date" %}</a>
       {% endif %}
     </div>
   {% endif %}

--- a/ds_judgements_public_ui/templates/includes/results_applied_filters.html
+++ b/ds_judgements_public_ui/templates/includes/results_applied_filters.html
@@ -3,7 +3,7 @@
   <h2 class="results-search-component__sub-header">Filters include (click any to remove)</h2>
   <ul class="results-search-component__removable-options">
     {% for key, value in context.query_params.items %}
-      {% if value %}
+      {% if value and key != 'order' %}
         <li>
           <a role="button" draggable="false" class="results-search-component__removable-options-link"
              href="{% url 'advanced_search' %}?{{ context.query_params|remove_query:key }}">

--- a/judgments/templatetags/query_filters.py
+++ b/judgments/templatetags/query_filters.py
@@ -8,3 +8,10 @@ def remove_query(query_params, key):
     params = dict(query_params)
     params[key] = None
     return "&".join([f'{key}={params[key] or ""}' for key in params])
+
+
+@register.filter
+def remove_query_key(query_params, key):
+    params = dict(query_params)
+    params.pop(key)
+    return "&".join([f'{key}={params[key] or ""}' for key in params])


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

A user commented that search results are only ordered by relevance on page 1 of search results, and subsequent pages were sorted by date. 

We found that because we were removing the `order` parameter from the `query_string` in the context, this meant that when the `query_string` was passed to the paginator, the second (and subsequent) page of results was not ordered.

Add a new template filter to remove the `order` param from the query string, and use this filter in the results ordering template fragment. 

Because the `order` param is now in the query string, we needed to amend the "click to remove" UI pattern to not show the ordering. Users order results via clicking a link, not selecting & unselecting the order values in the search filter design pattern.

## Trello card

https://trello.com/c/2iiyHQYo

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
