### PR TITLE
Handle Ctrl-C in 'fab run' and close Docker container

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -73,7 +73,11 @@ def run(c):
     django_exec("DJANGO_SETTINGS_MODULE= django-admin compilemessages")
     django_exec("python manage.py migrate")
     django_exec("python manage.py collectstatic")
-    return django_exec("python manage.py runserver 0.0.0.0:3000")
+    try:
+        django_exec("python manage.py runserver 0.0.0.0:3000")
+    except KeyboardInterrupt:
+        pass
+    stop(c, "django")
 
 
 @task


### PR DESCRIPTION
When Ctrl-C is pressed to stop the execution of the server, it would
instead stop the execution of the `run()` function. We now catch that explicitly.

In addition, we now stop the `django` Docker container we opened,
so that the user doesn't have to manually do something about the
still-running server which prevents new servers from running on the
old port.