### PR TITLE
Remove emailers

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -85,21 +85,6 @@ EMAIL_SUBJECT_PREFIX = env(
 # Django Admin URL regex.
 ADMIN_URL = env("DJANGO_ADMIN_URL")
 
-# Anymail
-# ------------------------------------------------------------------------------
-# https://anymail.readthedocs.io/en/stable/installation/#installing-anymail
-INSTALLED_APPS += ["anymail"]  # noqa F405
-# https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
-# https://anymail.readthedocs.io/en/stable/installation/#anymail-settings-reference
-# https://anymail.readthedocs.io/en/stable/esps/mailgun/
-EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
-ANYMAIL = {
-    "MAILGUN_API_KEY": env("MAILGUN_API_KEY"),
-    "MAILGUN_SENDER_DOMAIN": env("MAILGUN_DOMAIN"),
-    "MAILGUN_API_URL": env("MAILGUN_API_URL", default="https://api.mailgun.net/v3"),
-}
-
-
 # LOGGING
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#logging

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,7 +4,3 @@
 
 gunicorn==20.1.0  # https://github.com/benoitc/gunicorn
 psycopg2==2.9.3  # https://github.com/psycopg/psycopg2
-
-# Django
-# ------------------------------------------------------------------------------
-django-anymail[mailgun]==8.6  # https://github.com/anymail/django-anymail


### PR DESCRIPTION
We don't need the email libraries (anymail, mailgun) which were installed by the Django quick-start pack we used.