### PR TITLE
Auto-push to `production` branch instead of `latest` tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Add latest tag to new release
+name: Release latest code for production deploy
 on:
   release:
     types: [published]
@@ -8,7 +8,11 @@ jobs:
     name: Run local action
     runs-on: ubuntu-latest
     steps:
+
       - name: Checkout repository
         uses: actions/checkout@master
       - name: Run latest-tag
-        uses: EndBug/latest-tag@latest
+        uses: dxw/latest-tag@force-branch
+        with:
+          tagName: production
+          forceBranch: true

--- a/README.md
+++ b/README.md
@@ -211,6 +211,6 @@ To deploy to production:
 1. Create a [new release](https://github.com/nationalarchives/ds-caselaw-public-ui/releases).
 2. Set the tag and release name to `vX.Y.Z`, following semantic versioning.
 3. Publish the release.
-4. Automated workflow will then tag that release as `latest`, which will then be deployed to the production environment.
+4. Automated workflow will then force-push that release to the `production` branch, which will then be deployed to the production environment.
 
 The production app is at [https://caselaw.nationalarchives.gov.uk/](https://caselaw.nationalarchives.gov.uk/)


### PR DESCRIPTION
## Changes in this PR:

Change the release workflow to use a `production` branch, rather than a `latest` tag. This is done with a modification to the `latest-tag` workflow which we were already using. See https://github.com/EndBug/latest-tag/pull/14.