### PR TITLE
Vary order of advanced search results depending on presence of a search query

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -79,12 +79,19 @@ def advanced_search(request):
         "party": params.get("party"),
         "neutral_citation": params.get("neutral_citation"),
         "specific_keyword": params.get("specific_keyword"),
-        "order": params.get("order"),
+        "order": params.get("order", ""),
         "from": params.get("from"),
         "to": params.get("to"),
     }
     page = params.get("page", 1)
     page = page if page else 1
+    order = query_params["order"]
+    # If there is no query, order by -date, else order by relevance
+    if not order and not query_params["query"]:
+        order = "-date"
+    elif not order:
+        order = "relevance"
+
     context = {}
 
     try:
@@ -96,7 +103,7 @@ def advanced_search(request):
             neutral_citation=query_params["neutral_citation"],
             specific_keyword=query_params["specific_keyword"],
             page=page,
-            order=query_params["order"],
+            order=order,
             date_from=query_params["from"],
             date_to=query_params["to"],
         )
@@ -111,7 +118,7 @@ def advanced_search(request):
         context["query_params"] = query_params
         for key in query_params:
             context[key] = query_params[key] or ""
-        context["order"] = query_params["order"]
+        context["order"] = order
 
     except MarklogicResourceNotFoundError:
         raise Http404("Search failed")  # TODO: This should be something else!


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR:

For advanced search (`advanced_search` view):
- Order by -date (date descending) if there is no search query (but there may be
filters applied)
- Order by relevance if there is a search query

For the basic search (which uses the `results` view) the ordering remains the
same as before:
- Order by -date if there is a search query
- Order by -date if there is not a search query (this view is used for the
"Latest judgments" page so needs to be in date order)

## Trello card 

https://trello.com/c/6wordm0R and https://trello.com/c/74MffT78

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
