### PR TITLE
Hide warning spam from RemovedInDjango40Warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 addopts = --ds=config.settings.test --reuse-db
 python_files = tests.py test_*.py
+filterwarnings =
+    ignore::django.utils.deprecation.RemovedInDjango40Warning


### PR DESCRIPTION
The version of djxml we use appears to have some deprecated code.
The warnings are quite noisy and quite useless so we've turned
the RemovedInDjango40 warning off.

It should be possible to just remove these two warnings, but I
haven't succeeded in getting both silenced at the same time.

The warnings are:

/usr/local/lib/python3.9/site-packages/djxml/xmlmodels/signals.py:4: RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.
/usr/local/lib/python3.9/site-packages/djxml/xmlmodels/fields.py:321: RemovedInDjango40Warning: force_text() is deprecated in favor of force_str().
