### PR TITLE
Remove screenreader only styles from level 2 headings in the Judgment

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text.scss
@@ -147,11 +147,6 @@
 
     @media (min-width: $grid__breakpoint-medium) {
 
-
-      h2 {
-        @include sr-only;
-      }
-
       ul {
         padding: 0;
       }
@@ -170,10 +165,6 @@
 
   &__hearing-dates {
     text-align: center;
-
-    h2 {
-      @include sr-only;
-    }
   }
 
   &__approved-judgment {
@@ -182,9 +173,6 @@
 }
 
 .judgment-body {
-  h2 {
-    @include sr-only;
-  }
 
   h3 {
     font-size: 1rem;


### PR DESCRIPTION
This is to address a bug raised in the Editor Trello board relating to the headings missing from certain judgments. The fix involves removing screenreader only styles that had been applied to level 2 headings in multiple contexts. 

Unfortunately, it seems the examples given (using links from the Editor Interface) are not available on my local machine (I've tried appending the path for several and the app is erroring for every one) but I have tried a few Tribunals from my local machine and can see that the headings are revealed. 