### PR TITLE
PDF size on download button

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -8,7 +8,7 @@
         </div>
         <div class="judgment-toolbar__download">
             <a class="judgment-download__option--xml" role="button" draggable="false" href="{% url 'detail_xml' context.judgment_uri %}">{% translate "judgment.downloadasxml" %}</a>
-            <a class="judgment-download__option--pdf" role="button" draggable="false" href="{% url 'detail_pdf' context.judgment_uri %}">{% translate "judgment.downloadaspdf" %}</a>
+            <a class="judgment-download__option--pdf" role="button" draggable="false" href="{% url 'detail_pdf' context.judgment_uri %}">{% translate "judgment.downloadaspdf" %}{{context.pdf_size}}</a>
         </div>
     </div>
 </div>

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -70,6 +70,7 @@ class LatestJudgmentsFeed(Feed):
         try:
             page = int(request.GET.get("page", 1))
         except ValueError:
+            # e.g. the user provided ?page= or ?page=jam
             raise Http404
         order = request.GET.get("order", "-date")
         model = perform_advanced_search(

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -45,13 +45,13 @@ class TestAtomFeed(TestCase):
         self.assertIn("http://www.w3.org/2005/Atom", decoded_response)
         # that it has an entry
         self.assertIn("<entry>", decoded_response)
-        # and it contains actual content - neither neutral citation or court appear.
+        # and it contains actual content - neither neutral citation or court appear in the feed to test.
         self.assertIn("A SearchResult name!", decoded_response)
 
-    def feed_page_is_blank(self):
-        response = self.client.get("/atom.xml?page=")
+    def test_bad_page_404(self):
+        # "&page=" 404s, not 500
+        response = self.client.get("/atom.xml&page=")
         self.assertEqual(response.status_code, 404)
-
 
 class TestJudgment(TestCase):
     @skip

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -55,6 +55,7 @@ class TestAtomFeed(TestCase):
         response = self.client.get("/atom.xml&page=")
         self.assertEqual(response.status_code, 404)
 
+
 class TestJudgment(TestCase):
     @patch("judgments.views.requests.head")
     @patch("judgments.views.Judgment")
@@ -73,10 +74,17 @@ class TestJudgment(TestCase):
         self.assertEqual(response.status_code, 200)
 
     @skip
+    def test_good_response(self):
+        response = self.client.get("/ewca/civ/2004/637")
+        decoded_response = response.content.decode("utf-8")
+        self.assertIn("[2004] EWCA Civ 637", decoded_response)
+        self.assertEqual(response.status_code, 200)
+
+    @skip
     def test_404_response(self):
         response = self.client.get("/ewca/civ/2004/63X")
         decoded_response = response.content.decode("utf-8")
-        self.assertIn("Judgment was not found", decoded_response)
+        self.assertIn("Page not found", decoded_response)
         self.assertEqual(response.status_code, 404)
 
 

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -48,22 +48,33 @@ class TestAtomFeed(TestCase):
         # and it contains actual content - neither neutral citation or court appear in the feed to test.
         self.assertIn("A SearchResult name!", decoded_response)
 
-    def test_bad_page_404(self):
+    @patch("judgments.utils.perform_advanced_search")
+    def test_bad_page_404(self, fake_advanced_search):
         # "&page=" 404s, not 500
+        fake_advanced_search.return_value = fake_search_results()
         response = self.client.get("/atom.xml&page=")
         self.assertEqual(response.status_code, 404)
 
 class TestJudgment(TestCase):
-    @skip
-    def test_valid_content(self):
-        response = self.client.get("/judgments/ewca/civ/2004/632")
+    @patch("judgments.views.requests.head")
+    @patch("judgments.views.Judgment")
+    @patch("judgments.views.decoder.MultipartDecoder")
+    @patch("judgments.views.api_client")
+    def test_valid_content(self, client, decoder, judgment, head):
+        head.return_value.headers = {"Content-Length": "1234567890"}
+        client.eval_xslt.return_value = "eval_xslt"
+        decoder.MultipartDecoder.from_response.return_value.parts[0].text = "part0text"
+        judgment.create_from_string.return_value.metadata_name = "judgment metadata"
+
+        response = self.client.get("/ewca/civ/2004/632")
         decoded_response = response.content.decode("utf-8")
-        self.assertIn("[2004] EWCA Civ 632", decoded_response)
+        self.assertIn("(1.1\xa0GB)", decoded_response)
+        # We don't use the Download as PDF text because there's an issue with localisated strings on CI
         self.assertEqual(response.status_code, 200)
 
     @skip
     def test_404_response(self):
-        response = self.client.get("/judgments/ewca/civ/2004/63X")
+        response = self.client.get("/ewca/civ/2004/63X")
         decoded_response = response.content.decode("utf-8")
         self.assertIn("Judgment was not found", decoded_response)
         self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
## Changes in this PR:
Add PDF size to the download button. (Will be absent if falling back to weasyprint.)
## Trello card / Rollbar error (etc)

## Screenshots of UI changes:
### After
<img width="460" alt="image" src="https://user-images.githubusercontent.com/85497046/173819261-bf0ef466-7af1-4902-b6c5-6bdecff7be86.png">

Note this PR expands upon the previous one.
