### PR TITLE
If page is not a number, 404 instead of 500ing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,4 @@ docker/*
 /ds_judgements_public_ui/static/css/judgmentpdf.css
 /ds_judgements_public_ui/static/css/judgmentpdf.css.map
 /ds_judgements_public_ui/static/js/dist/app.js
+.vscode

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.contrib.syndication.views import Feed
+from django.http import Http404
 from django.urls import reverse
 from django.utils.feedgenerator import Atom1Feed
 
@@ -66,7 +67,10 @@ class LatestJudgmentsFeed(Feed):
         court_query = "/".join(filter(lambda x: x is not None, [court, subdivision]))
         slugs = filter(lambda x: x is not None, [court, subdivision, year])
         slug = "/".join([str(s) for s in slugs])
-        page = int(request.GET.get("page", 1)) or 1
+        try:
+            page = int(request.GET.get("page", 1))
+        except ValueError:
+            raise Http404
         order = request.GET.get("order", "-date")
         model = perform_advanced_search(
             court=court_query if court_query else None,

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -48,6 +48,10 @@ class TestAtomFeed(TestCase):
         # and it contains actual content - neither neutral citation or court appear.
         self.assertIn("A SearchResult name!", decoded_response)
 
+    def feed_page_is_blank(self):
+        response = self.client.get("/atom.xml?page=")
+        self.assertEqual(response.status_code, 404)
+
 
 class TestJudgment(TestCase):
     @skip


### PR DESCRIPTION
e.g. atom.xml?page= or ?page=kitten would not be able to int()
the parameter and would crash. If that'd happen, 404 instead.

I did consider setting the page to 1, but arguably that's misleading
to the API user.

[Rollbar](https://rollbar.com/dxw/tna-caselaw-public-ui/items/46/)