### PR TITLE
642 Fixes to Atom Feed

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -25,7 +25,7 @@ class JudgmentAtomFeed(Atom1Feed):
         pagination = paginator(self.feed["page"], self.feed["total"])
 
         handler.addQuickElement(
-            "link", "", {"rel": "first", "href": self.feed["feed_url"]}
+            "link", "", {"rel": "first", "href": f'{self.feed["feed_url"]}?page=1'}
         )
         handler.addQuickElement(
             "link",

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -92,7 +92,8 @@ class LatestJudgmentsFeed(Feed):
         return f'Latest judgments for {obj.get("slug", "/")}'
 
     def link(self, obj):
-        return f'{obj.get("slug", "/")}?page={obj["page"]}'
+        page = obj.get("page", 1)
+        return f"/{obj['slug']}/atom.xml?page={page}"
 
     def items(self, obj):
         return [

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -43,7 +43,7 @@ class JudgmentAtomFeed(Atom1Feed):
                 "link",
                 "",
                 {
-                    "rel": "previous",
+                    "rel": "next",
                     "href": f'{self.feed["feed_url"]}?page={str(pagination["next_page"])}',
                 },
             )
@@ -53,7 +53,7 @@ class JudgmentAtomFeed(Atom1Feed):
                 "link",
                 "",
                 {
-                    "rel": "next",
+                    "rel": "previous",
                     "href": f'{self.feed["feed_url"]}?page={str(pagination["prev_page"])}',
                 },
             )


### PR DESCRIPTION
Before
```
<link href="http://localhost:3000ewhc/2022?page=1" rel="alternate"></link>
(invalid link, missing /)
<link href="http://localhost:3000/ewhc/2022/atom.xml" rel="self"></link>
(not sure how we change this... should probably be ?page=1)
<id>http://localhost:3000ewhc/2022?page=1</id>
(note missing /)
<link href="http://localhost:3000/ewhc/2022/atom.xml" rel="first"></link>
<link href="http://localhost:3000/ewhc/2022/atom.xml?page=21" rel="last"></link>
<link href="http://localhost:3000/ewhc/2022/atom.xml?page=2" rel="previous"></link>
(page 2 is not the previous page!, but the next)
```

After:
```
<link href="http://localhost:3000/ewhc/2022/atom.xml?page=1" rel="alternate"></link>
<link href="http://localhost:3000/ewhc/2022/atom.xml" rel="self"></link>
<id>http://localhost:3000/ewhc/2022/atom.xml?page=1</id>
<link href="http://localhost:3000/ewhc/2022/atom.xml?page=1" rel="first"></link>
<link href="http://localhost:3000/ewhc/2022/atom.xml?page=21" rel="last"></link>
<link href="http://localhost:3000/ewhc/2022/atom.xml?page=2" rel="next"></link>
```
[Trello: 642 Make Atom feed validate -- no previous on first entry](https://trello.com/c/VE5DjM75/642-make-atom-feed-validate-no-previous-on-first-entry)

(Please check https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fstaging.caselaw.nationalarchives.gov.uk%2Fewhc%2F2022%2Fatom.xml%3Fpage%3D1 validates after merging.)