### PR TITLE
Fix page titles and error pages

### DIFF
--- a/ds_judgements_public_ui/templates/403.html
+++ b/ds_judgements_public_ui/templates/403.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Forbidden (403){% endblock %}
+{% block title %}Forbidden - Find Case Law{% endblock %}
 
 {% block content %}
-<h1>Forbidden (403)</h1>
-
-<p>{% if exception %}{{ exception }}{% else %}Access to this page is forbidden.{% endif %}</p>
+    <div class="standard-text-template">
+      <h1>Forbidden</h1>
+      <p>{% if exception %}{{ exception }}{% else %}Access to this page is forbidden.{% endif %}</p>
+    </div>
 {% endblock content %}

--- a/ds_judgements_public_ui/templates/404.html
+++ b/ds_judgements_public_ui/templates/404.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Page not found{% endblock %}
+{% block title %}Page not found - Find case law{% endblock %}
 
 {% block content %}
   <div class="standard-text-template">

--- a/ds_judgements_public_ui/templates/500.html
+++ b/ds_judgements_public_ui/templates/500.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Server Error{% endblock %}
+{% block title %}Server Error - Find Case Law{% endblock %}
 
 {% block content %}
-<h1>internal Server Error</h1>
-
-<p>Sorry, there seems to be an error. Please try again soon.</p>
+  <div class="standard-text-template">
+    <h1>Server Error</h1>
+    <p>Sorry, there seems to be an error. Please try again soon.</p>
+  </div>
 {% endblock content %}

--- a/ds_judgements_public_ui/templates/base.html
+++ b/ds_judgements_public_ui/templates/base.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <meta name="robots" content="noindex,nofollow">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>{% if context.page_title %}{{ context.page_title }} - {% endif %}{% translate "common.findcaselaw" %}</title>
+    <title>{% block title %}{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link rel="icon" href="{% static 'images/favicons/favicon.png' %}">

--- a/ds_judgements_public_ui/templates/pages/accessibility_statement.html
+++ b/ds_judgements_public_ui/templates/pages/accessibility_statement.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block title %}
-  {{ page_title }} - {% translate "common.findcaselaw" %}
+  {% translate "accessibilitystatement.title" %} - {% translate "common.findcaselaw" %}
 {% endblock title %}
 
 {% block content %}

--- a/ds_judgements_public_ui/templates/pages/home.html
+++ b/ds_judgements_public_ui/templates/pages/home.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% include 'includes/phase_banner.html' %}
+{% block title %}
+  {% translate "common.findcaselaw" %}
+{% endblock %}
 {% block content %}
     <header class="page-header">
      {% include 'includes/breadcrumbs.html' with current="home" %}

--- a/ds_judgements_public_ui/templates/pages/open_justice_licence.html
+++ b/ds_judgements_public_ui/templates/pages/open_justice_licence.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 {% load i18n %}
 
+{% block title %}
+  {% translate "openjusticelicence.title" %} - {% translate "common.findcaselaw" %}
+{% endblock %}
+
 {% block content %}
   {% translate "openjusticelicence.title" as page_title %}
 

--- a/ds_judgements_public_ui/templates/pages/terms_of_use.html
+++ b/ds_judgements_public_ui/templates/pages/terms_of_use.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block title %}
-  {{ page_title }} - {% translate "common.findcaselaw" %}
+  {% translate "terms.title" %} - {% translate "common.findcaselaw" %}
 {% endblock title %}
 
 {% block content %}

--- a/ds_judgements_public_ui/templates/pages/transactional_licence.html
+++ b/ds_judgements_public_ui/templates/pages/transactional_licence.html
@@ -2,7 +2,7 @@
 {% load static i18n %}
 
 {% block title %}
-  {{ page_title }} - {% translate "common.findcaselaw" %}
+  {% translate "transactionallicenceform.title" %} - {% translate "common.findcaselaw" %}
 {% endblock title %}
 
 {% block content %}


### PR DESCRIPTION
This PR updates the approach used for page titles to ensure all follow a consistent format and fixes some issues with the error pages (such as typos and missing formatting). 

The page titles are now:

 - 404 is "Page not found - Find case law"
 - 500 is "Server error - Find case law"
 - Accessibility statement is "Accessibility statement - Find case law"
 - How to use this service is "How to use the Find Case Law service - Find case law"
 - Search is "Search - Find case law"
 - Search results is "Search results - Find case law"
 - Judgments have the case title followed by " - Find case law"
 - 403 is "Forbidden - Find case law"
 - Transactional licence is "Application to re-use Court Judgments and Tribunal Decisions - Find case law"
 - Terms of Use is "Terms of use - Find case law"
 - Open Justice Licence is "Open Justice Licence - Find case law" 