### PR TITLE
Show a 404 for unpublished judgments

### DIFF
--- a/judgments/views.py
+++ b/judgments/views.py
@@ -74,7 +74,7 @@ def detail(request, judgment_uri):
         context["page_title"] = model.metadata_name
         context["judgment_uri"] = judgment_uri
         context["pdf_size"] = get_pdf_size(judgment_uri)
-    except MarklogicResourceNotFoundError:
+    except (MarklogicResourceNotFoundError, AttributeError):
         raise Http404("Judgment was not found")
     template = loader.get_template("judgment/detail.html")
     return TemplateResponse(request, template, context={"context": context})

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -65,19 +65,27 @@ def browse(request, court=None, subdivision=None, year=None):
 def detail(request, judgment_uri):
     context = {}
     try:
-        results = api_client.eval_xslt(judgment_uri)
-        xml_results = api_client.get_judgment_xml(judgment_uri)
-        multipart_data = decoder.MultipartDecoder.from_response(results)
-        judgment = multipart_data.parts[0].text
-        model = Judgment.create_from_string(xml_results)
-        context["judgment"] = judgment
-        context["page_title"] = model.metadata_name
-        context["judgment_uri"] = judgment_uri
-        context["pdf_size"] = get_pdf_size(judgment_uri)
-    except (MarklogicResourceNotFoundError, AttributeError):
+        is_published = api_client.get_published(judgment_uri)
+    except MarklogicAPIError:
         raise Http404("Judgment was not found")
-    template = loader.get_template("judgment/detail.html")
-    return TemplateResponse(request, template, context={"context": context})
+
+    if is_published:
+        try:
+            results = api_client.eval_xslt(judgment_uri)
+            xml_results = api_client.get_judgment_xml(judgment_uri)
+            multipart_data = decoder.MultipartDecoder.from_response(results)
+            judgment = multipart_data.parts[0].text
+            model = Judgment.create_from_string(xml_results)
+            context["judgment"] = judgment
+            context["page_title"] = model.metadata_name
+            context["judgment_uri"] = judgment_uri
+            context["pdf_size"] = get_pdf_size(judgment_uri)
+        except MarklogicResourceNotFoundError:
+            raise Http404("Judgment was not found")
+        template = loader.get_template("judgment/detail.html")
+        return TemplateResponse(request, template, context={"context": context})
+    else:
+        raise Http404("This Judgment is not available")
 
 
 def advanced_search(request):


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

A user hacking the URLs managed to stumble across a judgment which exists, but is not published. They complained about getting a 500 error.

This PR returns a 404 if a judgment is in Marklogic (exists) but is unpublished (unavailable). The first commit shows a 404 and "Judgment not found" whether the judgment doesn't exist or is unavailable. The second commit shows a slightly different message if the judgment exists and is unavailable.

We can drop the second commit if we just want to show "Judgment not found" no matter what. 

## Trello card / Rollbar error (etc)

https://rollbar.com/dxw/tna-caselaw-public-ui/items/24/?item_page=0&#instances

https://trello.com/c/budavgUm

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
