### PR TITLE
Add last page to paginator

### DIFF
--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -116,17 +116,42 @@ class TestJudgmentModel(TestCase):
 
 
 class TestPaginator(TestCase):
-    def test_paginator(self):
+    def test_paginator_2500(self):
         expected_result = {
             "current_page": 10,
             "has_next_page": True,
             "has_prev_page": True,
             "next_page": 11,
             "prev_page": 9,
-            "next_pages": [11, 12, 13, 14, 15, 16, 17, 18, 19],
-            "number_of_pages": 200,
+            "next_pages": [11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+            "number_of_pages": 250,
         }
-        self.assertEqual(views.paginator(10, 2000), expected_result)
+        self.assertEqual(views.paginator(10, 2500), expected_result)
+
+    def test_paginator_25(self):
+        # 25 items has 5 items on page 3.
+        expected_result = {
+            "current_page": 1,
+            "has_next_page": True,
+            "has_prev_page": False,
+            "next_page": 2,
+            "prev_page": 0,
+            "next_pages": [2, 3],
+            "number_of_pages": 3,
+        }
+        self.assertEqual(views.paginator(1, 25), expected_result)
+
+    def test_paginator_5(self):
+        expected_result = {
+            "current_page": 1,
+            "has_next_page": False,
+            "has_prev_page": False,
+            "next_page": 2,  # Note: remember to check has_next_page
+            "prev_page": 0,
+            "next_pages": [],
+            "number_of_pages": 1,
+        }
+        self.assertEqual(views.paginator(1, 5), expected_result)
 
     @skip("This test works locally but fails on CI, to fix")
     @patch("judgments.utils.perform_advanced_search")

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -267,7 +267,9 @@ def results(request):
 def paginator(current_page, total):
     size_per_page = RESULTS_PER_PAGE
     number_of_pages = math.ceil(int(total) / size_per_page)
-    next_pages = list(range(current_page + 1, min(current_page + 10, number_of_pages)))
+    next_pages = list(
+        range(current_page + 1, min(current_page + 10, number_of_pages) + 1)
+    )
 
     return {
         "current_page": current_page,


### PR DESCRIPTION
If there were 25 judgments, only two pages would be shown on the paginator
due to an off-by-one error: list(range(1,5)) returns [1, 2, 3, 4]. We
now add one to the maximum value.

This has the side effect of making page 20 visible from page 10 when there
are a large number of pages. This feels more like the correct behaviour
to me.

The 2000-page pagination test has been increased to 2500 to test behaviour
when there are more judgements than the paginator wants to show; additional
tests now exist for 5 and 25 judgments to test smaller edge cases.

## Screenshots of UI changes:

### Before

<img width="970" alt="image" src="https://user-images.githubusercontent.com/85497046/177148321-1dd1a5b1-b11f-4669-bfcf-b048b1768be9.png">
but also
<img width="987" alt="image" src="https://user-images.githubusercontent.com/85497046/177148426-bcf4f115-f6ee-48e8-a3be-d5fdef180a68.png">


### After

<img width="983" alt="image" src="https://user-images.githubusercontent.com/85497046/177148139-93e55db2-d570-4811-99ab-416cd42c07f8.png">

<img width="519" alt="image" src="https://user-images.githubusercontent.com/85497046/177148770-1c5fe752-dea1-48fc-b295-fcdcbf5a394b.png">
(note page 11... maybe not ideal...)
