### PR TITLE
Reinstate settings module

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -60,7 +60,7 @@ WSGI_APPLICATION = "config.wsgi.application"
 DJANGO_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
-    # "django.contrib.sessions",
+    "django.contrib.sessions",
     # "django.contrib.sites",
     "django.contrib.messages",
     "django.contrib.staticfiles",


### PR DESCRIPTION
Whilst staging seems fine with sessions being absent,
local development seems to sometiems require it -- probably as a result
of it being imported by one of the development dependencies, and
stuff being cached.