### PR TITLE
Add new SCCO court subdivision

### DIFF
--- a/ds_judgements_public_ui/templates/includes/structured_search_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/structured_search_inputs.html
@@ -66,7 +66,7 @@
                 Commercial Court
               </option>
               <option value="ewhc/costs"
-              {% if context.court == 'ewhc/costs' %}selected="selected"{% endif %}>
+              {% if context.court == 'ewhc/costs' or context.court == 'ewhc/scco' %}selected="selected"{% endif %}>
                 Senior Court Costs Office
               </option>
               <option value="ewhc/fam"

--- a/judgments/converters.py
+++ b/judgments/converters.py
@@ -35,9 +35,7 @@ class CourtConverter:
 
 
 class SubdivisionConverter:
-    regex = (
-        "civ|crim|admin|admlty|ch|comm|costs|fam|ipec|mercantile|pat|qb|iac|lc|tcc|aac"
-    )
+    regex = "civ|crim|admin|admlty|ch|comm|costs|fam|ipec|mercantile|pat|qb|iac|lc|tcc|aac|scco"
 
     def to_python(self, value):
         return value


### PR DESCRIPTION
Part of https://trello.com/c/4qN58GDG

Add SCCO as a new courst subdivision, and have "Senior Court Costs Office"
selected in the search boxes when `ewhc/scco` is in the URL.

TODO: Make SCCO judgments appear when someone searches for `ewhc/costs`, as
`ewhc/costs` and `ewhc/scco` are the same court.

