### PR TITLE
Adjust filter toggle approach to prevent FOUC

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_js_enabled.scss
+++ b/ds_judgements_public_ui/sass/includes/_js_enabled.scss
@@ -1,0 +1,7 @@
+// These styles are separated from others because they are JavaScript specific
+// All rules exist to prevent flash of unstyled content where JavaScript is available.
+.js-enabled {
+  .js-results-facets {
+    display: none;
+  }
+}

--- a/ds_judgements_public_ui/sass/main.scss
+++ b/ds_judgements_public_ui/sass/main.scss
@@ -27,3 +27,4 @@
 @import "includes/cookie_consent/cookie-consent";
 @import "includes/homepage_browse";
 @import "includes/what_to_expect";
+@import "includes/js_enabled";

--- a/ds_judgements_public_ui/static/js/src/modules/manage_filters.js
+++ b/ds_judgements_public_ui/static/js/src/modules/manage_filters.js
@@ -10,9 +10,9 @@ import $ from "jquery";
             const $control_container = $('.js-results-control-container', $(this));
 
             const btn = $('<button>', {
-                'class': 'results-search-component__toggle-control',
+                'class': 'results-search-component__toggle-control collapsed',
                 'type': 'button',
-                'text': settings.expanded_text,
+                'text': settings.collapsed_text,
                 'click': (e) => {
                     $toggle_area.toggle();
 
@@ -26,10 +26,6 @@ import $ from "jquery";
                 }
             });
 
-            if (settings.initially_hidden) {
-                btn.trigger('click');
-            }
-
             $control_container.append(btn)
         });
     };
@@ -37,7 +33,6 @@ import $ from "jquery";
     $.fn.manage_filters.defaults = {
         'collapsed_text': 'Show filter options',
         'expanded_text': 'Hide filter options',
-        'initially_hidden': true
     }
 }($));
 

--- a/ds_judgements_public_ui/templates/base.html
+++ b/ds_judgements_public_ui/templates/base.html
@@ -25,6 +25,9 @@
   </head>
 
   <body>
+    <script>
+      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+    </script>
     {% include 'includes/cookie_consent/cookie_banner.html' %}
     <a id="skip-to-main-content" href="#main-content">{% translate "skiplink" %}</a>
     {% include 'includes/gtm/gtm_body.html' %}


### PR DESCRIPTION
This commit introduces inline JavaScript to apply a `.js-enabled` class to the body element and namespaced CSS to prevent the filters from being shown where JavaScript is available. Updates are also made to the`manage_filters` plugin to ensure that it presents the correct state (both in terms of the button text and `collapsed` class) when the plugin first runs and then when users have interacted with it.