### PR TITLE
Update cookie consent code to reference correct GTM properties

### DIFF
--- a/ds_judgements_public_ui/static/js/cookie_consent/src/ds-cookie-consent.js
+++ b/ds_judgements_public_ui/static/js/cookie_consent/src/ds-cookie-consent.js
@@ -259,7 +259,7 @@ let doNotRememberSettingsRadioInput = document.querySelector(
           const gaScript = document.createElement("script");
           gaScript.id = "frontEndGA";
           gaScript.src =
-            "https://nationalarchives.gov.uk/wp-content/plugins/ds-cookie-consent/dist/gtm-script.js";
+            "/static/js/dist/gtm_script.js";
           DOMhead.appendChild(gaScript);
         });
       }

--- a/ds_judgements_public_ui/static/js/src/gtm_script.js
+++ b/ds_judgements_public_ui/static/js/src/gtm_script.js
@@ -1,0 +1,13 @@
+(function (w, d, s, l, i) {
+    w[l] = w[l] || [];
+    w[l].push({
+        'gtm.start':
+            new Date().getTime(), event: 'gtm.js'
+    });
+    var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
+    j.async = true;
+    j.src =
+        'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+    f.parentNode.insertBefore(j, f);
+})(window, document, 'script', 'dataLayer', 'GTM-MMVM4CJ');

--- a/ds_judgements_public_ui/templates/includes/gtm/gtm_head.html
+++ b/ds_judgements_public_ui/templates/includes/gtm/gtm_head.html
@@ -1,17 +1,4 @@
+{% load static %}
 {% if showGTM %}
-  <script>
-      (function (w, d, s, l, i) {
-          w[l] = w[l] || [];
-          w[l].push({
-              'gtm.start':
-                  new Date().getTime(), event: 'gtm.js'
-          });
-          var f = d.getElementsByTagName(s)[0],
-              j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
-          j.async = true;
-          j.src =
-              'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-          f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-MMVM4CJ');
-  </script>
+  <script src="{% static 'js/dist/gtm_script.js' %}"></script>
 {% endif %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,8 @@ module.exports = {
   devtool: false,
   entry: {
     app: './ds_judgements_public_ui/static/js/src/app.js',
-    cookie_consent: './ds_judgements_public_ui/static/js/cookie_consent/src/ds-cookie-consent.js'
+    cookie_consent: './ds_judgements_public_ui/static/js/cookie_consent/src/ds-cookie-consent.js',
+    gtm_script: './ds_judgements_public_ui/static/js/src/gtm_script.js'
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
This is to address the issue described in this Trello ticket https://trello.com/c/CLn92k8B 

It seems the issue was being caused by the shared cookie consent code loading the script from the main National Archives website. I've updated this to reference the snippet from Find Case Law and have set it up so that both instances of this script (i.e. the one referenced in JavaScript _and_ the one referenced in the template) both point to the same file. This is in an attempt to DRY out the code. 