### PR TITLE
Improve Atom Feed: manifested/handed down dates, content hashes

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -121,8 +121,8 @@ class LatestJudgmentsFeed(Feed):
         return extra_kwargs
 
     def item_updateddate(self, item: SearchResult) -> datetime.datetime:
-        date_string = item.last_modified or "1970-01-01T00:00:00.000"
-        return datetime.datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%f")
+        date_string = item.transformation_date or "1970-01-01T00:00:00.000"
+        return datetime.datetime.fromisoformat(date_string)
 
     def item_pubdate(self, item: SearchResult) -> datetime.datetime:
         date_string = item.date or "1970-01-01"

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -124,6 +124,10 @@ class LatestJudgmentsFeed(Feed):
         date_string = item.last_modified or "1970-01-01T00:00:00.000"
         return datetime.datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%f")
 
+    def item_pubdate(self, item: SearchResult) -> datetime.datetime:
+        date_string = item.date or "1970-01-01"
+        return datetime.datetime.fromisoformat(date_string)
+
     def feed_extra_kwargs(self, obj):
         extra_kwargs = super().item_extra_kwargs(obj)
         extra_kwargs["total"] = int(obj["model"].total)

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -19,6 +19,7 @@ class JudgmentAtomFeed(Atom1Feed):
     def add_item_elements(self, handler, item) -> None:
         super().add_item_elements(handler, item)
         handler.addQuickElement("tna:uri", item.get("uri", ""))
+        handler.addQuickElement("tna:contenthash", item.get("content_hash", ""))
 
     def add_root_elements(self, handler):
         super().add_root_elements(handler)
@@ -116,6 +117,7 @@ class LatestJudgmentsFeed(Feed):
     def item_extra_kwargs(self, item: SearchResult):
         extra_kwargs = super().item_extra_kwargs(item)
         extra_kwargs["uri"] = item.uri
+        extra_kwargs["content_hash"] = item.content_hash
         return extra_kwargs
 
     def item_updateddate(self, item: SearchResult) -> datetime.datetime:

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -119,11 +119,8 @@ class LatestJudgmentsFeed(Feed):
         return extra_kwargs
 
     def item_updateddate(self, item: SearchResult) -> datetime.datetime:
-        return (
-            datetime.datetime.strptime(item.last_modified, "%Y-%m-%dT%H:%M:%S.%f")
-            if item.last_modified
-            else datetime.datetime.now()
-        )
+        date_string = item.last_modified or "1970-01-01T00:00:00.000"
+        return datetime.datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%f")
 
     def feed_extra_kwargs(self, obj):
         extra_kwargs = super().item_extra_kwargs(obj)

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -85,7 +85,7 @@ class LatestJudgmentsFeed(Feed):
             order=order,
             page=page,
         )
-        return {"slug": slug, "model": model, "page": page}
+        return {"slug": slug, "model": model, "page": page, "order": order}
 
     def title(self, obj):
         if not obj["slug"]:
@@ -95,7 +95,7 @@ class LatestJudgmentsFeed(Feed):
 
     def link(self, obj):
         page = obj.get("page", 1)
-        return f"/{obj['slug']}/atom.xml?page={page}"
+        return f"/{obj['slug']}/atom.xml/?page={page}&order={obj.get('order')}"
 
     def items(self, obj):
         return [

--- a/judgments/models.py
+++ b/judgments/models.py
@@ -23,6 +23,7 @@ class Judgment(xmlmodels.XmlModel):
         "//akn:FRBRdate[@name='judgment']/@date", ignore_extra_nodes=True
     )
     court = xmlmodels.XPathTextField("//akn:proprietary/uk:court")
+    content_hash = xmlmodels.XPathTextField("//akn:proprietary/uk:hash")
 
 
 class SearchResult:
@@ -36,6 +37,7 @@ class SearchResult:
         matches=[],
         author="",
         last_modified="",
+        content_hash="",
     ) -> None:
         self.uri = uri
         self.neutral_citation = neutral_citation
@@ -45,6 +47,7 @@ class SearchResult:
         self.matches = matches
         self.author = author
         self.last_modified = last_modified
+        self.content_hash = content_hash
 
     @staticmethod
     def create_from_node(node):
@@ -72,6 +75,7 @@ class SearchResult:
             date=judgment.date,
             author=author,
             last_modified=last_modified,
+            content_hash=judgment.content_hash,
         )
 
 

--- a/judgments/models.py
+++ b/judgments/models.py
@@ -24,6 +24,10 @@ class Judgment(xmlmodels.XmlModel):
     )
     court = xmlmodels.XPathTextField("//akn:proprietary/uk:court")
     content_hash = xmlmodels.XPathTextField("//akn:proprietary/uk:hash")
+    transformation_date = xmlmodels.XPathTextField(
+        "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRManifestation/"
+        + "akn:FRBRdate[@name='transform']/@date"
+    )
 
 
 class SearchResult:
@@ -38,6 +42,7 @@ class SearchResult:
         author="",
         last_modified="",
         content_hash="",
+        transformation_date="",
     ) -> None:
         self.uri = uri
         self.neutral_citation = neutral_citation
@@ -48,6 +53,7 @@ class SearchResult:
         self.author = author
         self.last_modified = last_modified
         self.content_hash = content_hash
+        self.transformation_date = transformation_date
 
     @staticmethod
     def create_from_node(node):
@@ -76,6 +82,7 @@ class SearchResult:
             author=author,
             last_modified=last_modified,
             content_hash=judgment.content_hash,
+            transformation_date=judgment.transformation_date,
         )
 
 

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -26,7 +26,9 @@ def fake_search_result():
         author="",
         last_modified="2022-01-01T00:01:00.123",
         content_hash="A hash!",
+        transformation_date="2022-01-01T00:02:00",
     )
+
 
 class TestAtomFeed(TestCase):
     @patch("judgments.utils.perform_advanced_search")
@@ -97,6 +99,9 @@ class TestJudgmentModel(TestCase):
                         <identification source="#tna">
                             <FRBRdate date="2004-06-10" name="judgment"/>
                             <FRBRname value="My Judgment Name"/>
+                            <FRBRManifestation>
+                                <FRBRdate date="2020-01-01T10:30:00" name="transform"/>
+                            </FRBRManifestation>
                         </identification>
                         <proprietary source="ewca/civ/2004/811/eng/docx"
                             xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
@@ -114,6 +119,7 @@ class TestJudgmentModel(TestCase):
         self.assertEqual("[2017] EWHC 3289 (QB)", model.neutral_citation)
         self.assertEqual("2004-06-10", model.date)
         self.assertEqual("EWCA-Civil", model.court)
+        self.assertEqual("2020-01-01T10:30:00", model.transformation_date)
         self.assertEqual("A hash!", model.content_hash)
 
 

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -25,8 +25,8 @@ def fake_search_result():
         date="2022-01-01T00:01:00",
         author="",
         last_modified="2022-01-01T00:01:00.123",
+        content_hash="A hash!",
     )
-
 
 class TestAtomFeed(TestCase):
     @patch("judgments.utils.perform_advanced_search")
@@ -102,6 +102,7 @@ class TestJudgmentModel(TestCase):
                             xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
                             <uk:court>EWCA-Civil</uk:court>
                             <uk:cite>[2017] EWHC 3289 (QB)</uk:cite>
+                            <uk:hash>A hash!</uk:hash>
                         </proprietary>
                     </meta>
                 </judgment>
@@ -113,6 +114,7 @@ class TestJudgmentModel(TestCase):
         self.assertEqual("[2017] EWHC 3289 (QB)", model.neutral_citation)
         self.assertEqual("2004-06-10", model.date)
         self.assertEqual("EWCA-Civil", model.court)
+        self.assertEqual("A hash!", model.content_hash)
 
 
 class TestPaginator(TestCase):


### PR DESCRIPTION
Note: sorting the atom feed by manifestation date is in https://github.com/nationalarchives/ds-caselaw-public-access-service/pull/48 and turns out to be entirely unrelated in code.

## Changes in this PR:
* content hash `<tna:contenthash>4684bfd014...b14ca512e</tna:contenthash>`
* manifested dates: `<updated>2022-05-13T13:18:52+00:00</updated>`
* handed down dates: `<published>2022-05-10T00:00:00+00:00</published>`
* order in link name `<link href="http://atom.xml/?page=1&amp;order=manifestation" rel="alternate"></link>`
(note: there is a bug here with a lack of a domain, and maybe this should be on self?)

## Trello card / Rollbar error (etc)
https://trello.com/c/P9nbWAlz/675-orderupdated-on-atom-feeds-isnt-in-same-order-as-updatedfield
