### PR TITLE
Add breadcrumbs and back links on 404/403/500 pages

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_header.scss
+++ b/ds_judgements_public_ui/sass/includes/_header.scss
@@ -24,6 +24,7 @@
       display: inline-block;
       position: relative;
       margin-right: calc($spacer__unit / 2);
+      color: $color__white;
 
       &:not(:nth-child(1)) {
         padding-left: $spacer__unit;

--- a/ds_judgements_public_ui/templates/403.html
+++ b/ds_judgements_public_ui/templates/403.html
@@ -3,8 +3,20 @@
 {% block title %}Forbidden - Find Case Law{% endblock %}
 
 {% block content %}
+  <header class="page-header">
+      <div class="page-header__breadcrumb">
+      <nav class="page-header__breadcrumb-container" aria-label="Breadcrumb">
+      <span class="page-header__breadcrumb-you-are-in">You are in: </span>
+        <ol>
+          <li><a href="{% url 'home' %}">Find case law</a></li>
+          <li>Forbidden</li>
+        </ol>
+      </nav>
+    </div>
+  </header>
     <div class="standard-text-template">
       <h1>Forbidden</h1>
       <p>{% if exception %}{{ exception }}{% else %}Access to this page is forbidden.{% endif %}</p>
+      <p><a href="{% url 'home' %}">Return to Find case law</a></p>
     </div>
 {% endblock content %}

--- a/ds_judgements_public_ui/templates/404.html
+++ b/ds_judgements_public_ui/templates/404.html
@@ -3,10 +3,23 @@
 {% block title %}Page not found - Find case law{% endblock %}
 
 {% block content %}
+  <header class="page-header">
+      <div class="page-header__breadcrumb">
+      <nav class="page-header__breadcrumb-container" aria-label="Breadcrumb">
+      <span class="page-header__breadcrumb-you-are-in">You are in: </span>
+        <ol>
+          <li><a href="{% url 'home' %}">Find case law</a></li>
+          <li>Page not found</li>
+        </ol>
+      </nav>
+    </div>
+  </header>
+
   <div class="standard-text-template">
     <h1>Page not found</h1>
 
     <p>If you typed the web address, check it is correct.</p>
     <p>If you pasted the web address, check you copied the entire address.</p>
+    <p><a href="{% url 'home' %}">Return to Find case law</a></p>
   </div>
 {% endblock content %}

--- a/ds_judgements_public_ui/templates/500.html
+++ b/ds_judgements_public_ui/templates/500.html
@@ -3,8 +3,20 @@
 {% block title %}Server Error - Find Case Law{% endblock %}
 
 {% block content %}
+  <header class="page-header">
+      <div class="page-header__breadcrumb">
+      <nav class="page-header__breadcrumb-container" aria-label="Breadcrumb">
+      <span class="page-header__breadcrumb-you-are-in">You are in: </span>
+        <ol>
+          <li><a href="{% url 'home' %}">Find case law</a></li>
+          <li>Server error</li>
+        </ol>
+      </nav>
+    </div>
+  </header>
   <div class="standard-text-template">
     <h1>Server Error</h1>
     <p>Sorry, there seems to be an error. Please try again soon.</p>
+    <p><a href="{% url 'home' %}">Return to Find case law</a></p>
   </div>
 {% endblock content %}


### PR DESCRIPTION



<!-- Amend as appropriate -->

## Changes in this PR:

The error pages in the application offered no way for a user to return
to the Find case law homepage. Add a breadcrumb & a link back to the main
site on these pages.

## Trello card / Rollbar error (etc)

Trello: https://trello.com/c/vcqbPLxF

## Screenshots of UI changes:

### After

<img width="1324" alt="Screenshot 2022-08-03 at 12 03 53" src="https://user-images.githubusercontent.com/1089521/182593489-a3af38f5-ae1e-4ebf-95fd-5aaf484858e9.png">
<img width="1198" alt="Screenshot 2022-08-03 at 12 03 44" src="https://user-images.githubusercontent.com/1089521/182593495-be4e16ee-6022-47b8-95da-57c609426595.png">
<img width="1265" alt="Screenshot 2022-08-03 at 12 03 34" src="https://user-images.githubusercontent.com/1089521/182593498-bad857ae-55ad-453c-a1ae-b57d70f41d82.png">


<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
