### PR TITLE
Restrict coverage checks to our own python files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+include = judgments/**/*.py, judgments/*.py
+
+[report]
+omit =
+    *__init__*


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Previously, the coverage check from codecov was checking all files in the
repository, inclusing css, html etc. We only want to check 1) python files, and
2) our own python code, not any tested code which is part of imported apps etc

## Trello card / Rollbar error (etc)

https://trello.com/c/gkScOsNp

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
