### PR TITLE
Change where we pick a judgement's date from in the model

### DIFF
--- a/judgments/models.py
+++ b/judgments/models.py
@@ -20,7 +20,9 @@ class Judgment(xmlmodels.XmlModel):
         "//akn:proprietary/uk:cite", ignore_extra_nodes=True
     )
     date = xmlmodels.XPathTextField(
-        "//akn:FRBRdate[@name='judgment']/@date", ignore_extra_nodes=True
+        "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/"
+        + "akn:FRBRdate/@date",
+        ignore_extra_nodes=True,
     )
     court = xmlmodels.XPathTextField("//akn:proprietary/uk:court")
     content_hash = xmlmodels.XPathTextField("//akn:proprietary/uk:hash")

--- a/judgments/models.py
+++ b/judgments/models.py
@@ -14,7 +14,9 @@ class Judgment(xmlmodels.XmlModel):
         }
 
     metadata_name = xmlmodels.XPathTextField(
-        "//akn:FRBRname/@value", ignore_extra_nodes=True
+        "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/"
+        + "akn:FRBRname/@value",
+        ignore_extra_nodes=True,
     )
     neutral_citation = xmlmodels.XPathTextField(
         "//akn:proprietary/uk:cite", ignore_extra_nodes=True

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -97,11 +97,14 @@ class TestJudgmentModel(TestCase):
                 <judgment name="judgment" contains="originalVersion">
                     <meta>
                         <identification source="#tna">
-                            <FRBRdate date="2004-06-10" name="judgment"/>
-                            <FRBRname value="My Judgment Name"/>
                             <FRBRManifestation>
+                                <FRBRname value="My Judgment Name"/>
                                 <FRBRdate date="2020-01-01T10:30:00" name="transform"/>
                             </FRBRManifestation>
+                            <FRBRWork>
+                                <FRBRname value="My Judgment Name"/>
+                                <FRBRdate date="2004-06-10T10:30:00" name="judgment"/>
+                            </FRBRWork>
                         </identification>
                         <proprietary source="ewca/civ/2004/811/eng/docx"
                             xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
@@ -117,10 +120,40 @@ class TestJudgmentModel(TestCase):
         model = Judgment.create_from_string(xml)
         self.assertEqual("My Judgment Name", model.metadata_name)
         self.assertEqual("[2017] EWHC 3289 (QB)", model.neutral_citation)
-        self.assertEqual("2004-06-10", model.date)
+        self.assertEqual("2004-06-10T10:30:00", model.date)
         self.assertEqual("EWCA-Civil", model.court)
         self.assertEqual("2020-01-01T10:30:00", model.transformation_date)
         self.assertEqual("A hash!", model.content_hash)
+
+    def test_can_parse_judgment_hearing_date(self):
+        xml = """
+            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
+                <judgment name="judgment" contains="originalVersion">
+                    <meta>
+                        <identification source="#tna">
+                            <FRBRManifestation>
+                                <FRBRname value="My Judgment Name"/>
+                                <FRBRdate date="2020-01-01T10:30:00" name="transform"/>
+                            </FRBRManifestation>
+                            <FRBRWork>
+                                <FRBRname value="My Judgment Name"/>
+                                <FRBRdate date="2004-06-10T10:30:00" name="hearing"/>
+                            </FRBRWork>
+                        </identification>
+                        <proprietary source="ewca/civ/2004/811/eng/docx"
+                            xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+                            <uk:court>EWCA-Civil</uk:court>
+                            <uk:cite>[2017] EWHC 3289 (QB)</uk:cite>
+                            <uk:hash>A hash!</uk:hash>
+                        </proprietary>
+                    </meta>
+                </judgment>
+            </akomaNtoso>
+        """
+
+        model = Judgment.create_from_string(xml)
+        self.assertEqual("My Judgment Name", model.metadata_name)
+        self.assertEqual("2004-06-10T10:30:00", model.date)
 
 
 class TestPaginator(TestCase):


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Back when we started developing this application, we weren't really aware of the
differences between `FRBRWork`, `FRBRManifestation` and `FRBRExpression`. When
picking the date to show when a judgment was handed down, we decided to choose
any `FRBRdate` element with an attribute of `judgment`.

As we have received more & more judgments, some of them have been displayed
in the public ui without a date. This is because not all the judgments have
an `FRBRdate/@name=judgment` in their XML.

Jim jurisdatum suggested that we look instead for ANY date in the `FRBRWork`
block, and use that as the judgment date. It might be a judgment date, a hearing
date etc. but it is the "correct" date for the work.

Co-authored-by: jurisdatum <jim@jurisdatum.com>

## Trello card / Rollbar error (etc)

https://trello.com/c/naUx8R1j/846-date-public-ui

## Screenshots of UI changes:

### Before

### After

<!-- Have you updated the changelog? -->

- [ ] Requires env variable(s) to be updated
