### PR TITLE
Improve spacing for download buttons on judgment page

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -12,8 +12,10 @@
     display: inline-block;
     text-decoration: none;
     outline-offset: 3px;
-    &:first-child {
-      margin-right: $spacer__unit;
+    margin: 0 $spacer__unit $spacer__unit 0;
+
+    @media (min-width: $grid__breakpoint-small) {
+      margin-bottom: 0;
     }
   }
 
@@ -39,12 +41,11 @@
     > div {
       @media (max-width: $grid__breakpoint-small) {
         text-align: center;
-        padding: $spacer__unit;
+        padding: 0.25rem $spacer__unit;
       }
     }
 
     @media (min-width: $grid__breakpoint-small) {
-
       text-align: center;
     }
 


### PR DESCRIPTION
## Changes in this PR:

Adding addition styling for on judgment page to improve the spacing between 'Download the XML' and 'Download the PDF' buttons.

## Trello card / Rollbar error (etc)

Issue #553

## Screenshots of UI changes:

### Before

<img width="314" alt="Before" src="https://user-images.githubusercontent.com/7143978/185409511-07db2bc4-4258-4f79-a31f-6c82282f2bd8.png">

### After

<img width="386" alt="After" src="https://user-images.githubusercontent.com/7143978/185409539-8b900f13-2834-463d-845e-f2d2569bc1b4.png">

