### PR TITLE
updated the Update date on the what to expect page

### DIFF
--- a/ds_judgements_public_ui/templates/pages/what_to_expect.html
+++ b/ds_judgements_public_ui/templates/pages/what_to_expect.html
@@ -16,7 +16,7 @@
     <h1>What to expect from this new service</h1>
 
     <p><small>Last updated on
-      <time datetime="27-05-2022">23rd August 2022</time>
+      <time datetime="23-08-2022">23rd August 2022</time>
     </small></p>
 
 

--- a/ds_judgements_public_ui/templates/pages/what_to_expect.html
+++ b/ds_judgements_public_ui/templates/pages/what_to_expect.html
@@ -16,7 +16,7 @@
     <h1>What to expect from this new service</h1>
 
     <p><small>Last updated on
-      <time datetime="27-05-2022">12th August 2022</time>
+      <time datetime="27-05-2022">23rd August 2022</time>
     </small></p>
 
 


### PR DESCRIPTION
## Changes in this PR:
Updated the 'update date' at the top of the What to expect page.

## Trello card 862

## Screenshots of UI changes:

### Before
![Screenshot 2022-08-23 at 14 25 59](https://user-images.githubusercontent.com/102584881/186170485-56ad3235-1c52-409f-a975-2c61a75ccda6.png)

### After
![Screenshot 2022-08-23 at 14 25 44](https://user-images.githubusercontent.com/102584881/186170543-81708091-09be-4bd0-9650-7994ccdb59e0.png)



- [ ] Requires env variable(s) to be updated
