### PR TITLE
379 trailing slashes

### DIFF
--- a/config/tests.py
+++ b/config/tests.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+
+
+class TestRedirect(TestCase):
+    def test_slash_redirection_works(self):
+        url = "/arbitrary/url/with/slash/at/end/"
+        response = self.client.get(url)
+        assert response.status_code == 302
+        assert response.url == url.rstrip("/")

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,13 +1,20 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import include, path
+from django.http import HttpResponseRedirect
+from django.urls import include, path, re_path
 from django.views import defaults as default_views
 from django.views.generic.base import TemplateView
 
 from . import views
 
+
+def redirect(request, uri):
+    return HttpResponseRedirect(f"/{uri}")
+
+
 urlpatterns = [
+    re_path("^(?P<uri>.*)/$", redirect),
     path(
         "transactional-licence-form",
         views.TransactionalLicenceFormView.as_view(),

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -52,9 +52,9 @@ class TestAtomFeed(TestCase):
 
     @patch("judgments.utils.perform_advanced_search")
     def test_bad_page_404(self, fake_advanced_search):
-        # "&page=" 404s, not 500
+        # "?page=" 404s, not 500
         fake_advanced_search.return_value = fake_search_results()
-        response = self.client.get("/atom.xml&page=")
+        response = self.client.get("/atom.xml?page=")
         self.assertEqual(response.status_code, 404)
 
 

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -31,7 +31,7 @@ def fake_search_result():
 
 
 class TestAtomFeed(TestCase):
-    @patch("judgments.utils.perform_advanced_search")
+    @patch("judgments.feeds.perform_advanced_search")
     @patch("judgments.models.SearchResult.create_from_node")
     def test_feed_exists(self, fake_result, fake_advanced_search):
         fake_advanced_search.return_value = fake_search_results()

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -34,3 +34,4 @@ django-extensions==3.1.5  # https://github.com/django-extensions/django-extensio
 django-coverage-plugin==2.0.3  # https://github.com/nedbat/django_coverage_plugin
 pytest-django==4.5.2  # https://github.com/pytest-dev/pytest-django
 pytest-cov==3.0.0
+pytest-timeout==2.1.0


### PR DESCRIPTION
We redirect all `/`-terminated URLs to non-`/` terminated versions.

There's also a buggy test that failed because `/atom&page=` isn't a parameter -- `?page=` is. 