### PR TITLE
fix/missing breadcrumbs for Open justice/how to use/what to expect

### DIFF
--- a/ds_judgements_public_ui/templates/pages/how_to_use_this_service.html
+++ b/ds_judgements_public_ui/templates/pages/how_to_use_this_service.html
@@ -6,6 +6,7 @@
 {% endblock title %}
 
 {% block content %}
+{% translate "howtousethisservice.title" as page_title %}
   <header class="page-header">
     {% include 'includes/breadcrumbs.html' with current=page_title title=page_title link=request.path %}
     {% include 'includes/logo.html' %}

--- a/ds_judgements_public_ui/templates/pages/open_justice_licence.html
+++ b/ds_judgements_public_ui/templates/pages/open_justice_licence.html
@@ -7,9 +7,8 @@
 
 {% block content %}
   {% translate "openjusticelicence.title" as page_title %}
-
   <header class="page-header">
-    {% include 'includes/breadcrumbs.html' with current=page_title title=page_title link=request.url %}
+    {% include 'includes/breadcrumbs.html' with current=page_title title=page_title link=request.path %}
     {% include 'includes/logo.html' %}
   </header>
 

--- a/ds_judgements_public_ui/templates/pages/what_to_expect.html
+++ b/ds_judgements_public_ui/templates/pages/what_to_expect.html
@@ -6,6 +6,7 @@
 {% endblock title %}
 
 {% block content %}
+{% translate "whattoexpect.title" as page_title %}
   <header class="page-header">
     {% include 'includes/breadcrumbs.html' with current=page_title title=page_title link=request.path %}
     {% include 'includes/logo.html' %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Fixed missing breadcrumb titles for the following pages:
- What to expect
- How to use this service
- Open justice

## Trello card #903

## Screenshots of UI changes:

### Before
![Screenshot 2022-08-31 at 15 35 40](https://user-images.githubusercontent.com/102584881/187706759-de8593ef-e09c-467e-a785-aca273dd44ab.png)

![Screenshot 2022-08-31 at 15 35 50](https://user-images.githubusercontent.com/102584881/187706815-007112dd-2170-499c-b5dd-1b5867f7727a.png)

![Screenshot 2022-08-31 at 15 36 15](https://user-images.githubusercontent.com/102584881/187706860-17ebbc36-c25e-42d8-a09d-09bcf014a824.png)

### After

![Screenshot 2022-08-31 at 15 47 35](https://user-images.githubusercontent.com/102584881/187708268-751484f1-910f-4b90-bc99-cb452ca3a1cc.png)

![Screenshot 2022-08-31 at 15 47 21](https://user-images.githubusercontent.com/102584881/187708306-bc8b8376-a3cd-49e2-b0b5-1a3e9b0b0300.png)

![Screenshot 2022-08-31 at 15 34 07](https://user-images.githubusercontent.com/102584881/187707335-e22ffe9b-62ad-46e6-8239-905b37b7affa.png)
- [ ] Requires env variable(s) to be updated
