### PR TITLE
fix/h1 headings line height was too small for headings of more than o…

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_standard_text_template.scss
+++ b/ds_judgements_public_ui/sass/includes/_standard_text_template.scss
@@ -8,7 +8,7 @@
     max-width: 30rem;
   }
 
-  margin-top: calc($spacer__unit * 5);
+  margin-top: calc($spacer__unit * 4);
   margin-bottom: calc($spacer__unit * 8);
   min-height: 18rem;
 
@@ -20,6 +20,7 @@
   h1 {
     font-size: 2.2rem;
     margin: 0 0 calc($spacer__unit * 2);
+    line-height: 2.8rem;
   }
 
   h2 {


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Added more line-height to H1 so that it is more readable when these headings are on more than one line.
Compensated the new extra space above the H1s by reducing the top margin of the Standard text template by 1rem.
the starting position is now the same.

## Trello card #911

## Screenshots of UI changes:

### Before

![Screenshot 2022-09-01 at 13 52 57](https://user-images.githubusercontent.com/102584881/187918705-32efcc2c-ce43-4570-9f30-966cf4064bdc.png)

### After
![Screenshot 2022-09-01 at 13 52 31](https://user-images.githubusercontent.com/102584881/187918723-09cf24bf-87eb-4796-95b3-82f13a2dfcc7.png)

- [ ] Requires env variable(s) to be updated
