### PR TITLE
Allow search engines to index static pages

### DIFF
--- a/ds_judgements_public_ui/templates/robots.txt
+++ b/ds_judgements_public_ui/templates/robots.txt
@@ -1,3 +1,9 @@
 User-Agent: *
 Disallow: /
 Allow: /$
+Allow: /transactional-licence-form
+Allow: /what-to-expect
+Allow: /how-to-use-this-service
+Allow: /accessibility-statement
+Allow: /open-justice-licence
+Allow: /terms-of-use


### PR DESCRIPTION
I've taken the simple route of just adding the pages to robots.txt, rather than changing our URL scheme.