### PR TITLE
fixed issue where visited links did not change colour

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_how_can_this_service_be_improved.scss
+++ b/ds_judgements_public_ui/sass/includes/_how_can_this_service_be_improved.scss
@@ -16,5 +16,8 @@
 
   &__cta-button {
     @include call-to-action-button($color__black, $color__white);
+    &:visited  {
+      color: #ffffff;
+    }
   }
 }

--- a/ds_judgements_public_ui/sass/includes/_links.scss
+++ b/ds_judgements_public_ui/sass/includes/_links.scss
@@ -14,6 +14,11 @@ a {
   &:focus {
     @include focus-default;
   }
+  &:visited {
+    color: $color__link-blue-visited;
+  }
+
+
 }
 
 #skip-to-main-content {


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
The visited link colour was not set up.

I had to be careful to avoid changing any visited link colours if they were white text in a black box button. 
So I added css to keep these as white text when visited, see screen images.

## Trello card #925

## Screenshots of UI changes:

### Before

Visited link without any colour change:
![Screenshot 2022-09-08 at 10 25 34](https://user-images.githubusercontent.com/102584881/189088937-93c0d112-1bed-476b-bd49-e116662bfb14.png)

Without targeting button links:
![Screenshot 2022-09-08 at 10 26 38](https://user-images.githubusercontent.com/102584881/189090026-57de1bc2-9b7b-434b-9d6f-1459e5b8dba6.png)


### After
Visited link with colour change:
![Screenshot 2022-09-08 at 10 26 06](https://user-images.githubusercontent.com/102584881/189089044-35907925-b9ba-4528-a137-9fceffe7eab1.png)

With targeting button links to remain white text:
![Screenshot 2022-09-08 at 10 26 14](https://user-images.githubusercontent.com/102584881/189089551-11b93dae-ae95-4f93-8097-8666eb5df620.png)

- [ ] Requires env variable(s) to be updated
