### PR TITLE
Chore/tim setup improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Then it means the dependencies for WeasyPrint have not been installed correctly.
 
 ## Using the pre-push hook (optional)
 
-Copy `pre-push.sample` to `.git/hooks/pre-push` to set up the pre-push hook. This will run Python linting and style checks when you push to the repo and alert you to any linting issues that will cause CI to fail.
+Copy `pre-push.sample` to `.git/hooks/pre-push` to set up the pre-push hook. This will run Python linting and style checks when you push to the repo and alert you to any linting issues that will cause CI to fail. To use this, you will need to install [pre-commit](https://pre-commit.com/) on your development machine, typically using `pip install pre-commit`.
 
 ## Front end development
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "doc": "docs"
   },
   "scripts": {
-    "start-sass": "sass --watch ds_judgements_public_ui/sass:ds_judgements_public_ui/static/css",
+    "start-sass": "npx sass --watch ds_judgements_public_ui/sass:ds_judgements_public_ui/static/css",
     "start-scripts": "npx webpack --watch",
-    "build": "npx webpack && sass ds_judgements_public_ui/sass:ds_judgements_public_ui/static/css"
+    "build": "npx webpack && npx sass ds_judgements_public_ui/sass:ds_judgements_public_ui/static/css"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Changes in this PR:

Porting across the relevant parts of [This PR](https://github.com/nationalarchives/ds-caselaw-editor-ui/pull/370) in the Editor UI.

Two small changes that fix setup hiccups when onboarding to the project:

 - Use `npx` to run sass to ensure that the locally installed version (managed via `package.json`) is always used
 - Add a note to the readme to point out that [pre-commit](https://pre-commit.com/) is needed in order to use the pre-push hook.
