### PR TITLE
Remove robots directives from static pages

### DIFF
--- a/ds_judgements_public_ui/templates/base.html
+++ b/ds_judgements_public_ui/templates/base.html
@@ -4,7 +4,11 @@
 <html lang="{{ LANGUAGE_CODE }}">
   <head>
     <meta charset="utf-8">
-    <meta name="robots" content="noindex,nofollow">
+
+    {% block robots %}
+      <meta name="robots" content="noindex,nofollow">
+    {% endblock robots %}
+
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title>{% block title %}{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/ds_judgements_public_ui/templates/pages/accessibility_statement.html
+++ b/ds_judgements_public_ui/templates/pages/accessibility_statement.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
 
+{% block robots %}
+{% endblock robots %}
+
 {% block title %}
   {% translate "accessibilitystatement.title" %} - {% translate "common.findcaselaw" %}
 {% endblock title %}

--- a/ds_judgements_public_ui/templates/pages/home.html
+++ b/ds_judgements_public_ui/templates/pages/home.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
+
+{% block robots %}
+{% endblock robots %}
+
 {% include 'includes/phase_banner.html' %}
 {% block title %}
   {% translate "common.findcaselaw" %}

--- a/ds_judgements_public_ui/templates/pages/how_to_use_this_service.html
+++ b/ds_judgements_public_ui/templates/pages/how_to_use_this_service.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% load i18n static %}
 
+{% block robots %}
+{% endblock robots %}
+
 {% block title %}
   {% translate "howtousethisservice.title" %} - {% translate "common.findcaselaw" %}
 {% endblock title %}

--- a/ds_judgements_public_ui/templates/pages/open_justice_licence.html
+++ b/ds_judgements_public_ui/templates/pages/open_justice_licence.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
 
+{% block robots %}
+{% endblock robots %}
+
 {% block title %}
   {% translate "openjusticelicence.title" %} - {% translate "common.findcaselaw" %}
 {% endblock %}

--- a/ds_judgements_public_ui/templates/pages/terms_of_use.html
+++ b/ds_judgements_public_ui/templates/pages/terms_of_use.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
 
+{% block robots %}
+{% endblock robots %}
+
 {% block title %}
   {% translate "terms.title" %} - {% translate "common.findcaselaw" %}
 {% endblock title %}

--- a/ds_judgements_public_ui/templates/pages/transactional_licence.html
+++ b/ds_judgements_public_ui/templates/pages/transactional_licence.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% load static i18n %}
 
+{% block robots %}
+{% endblock robots %}
+
 {% block title %}
   {% translate "transactionallicenceform.title" %} - {% translate "common.findcaselaw" %}
 {% endblock title %}

--- a/ds_judgements_public_ui/templates/pages/what_to_expect.html
+++ b/ds_judgements_public_ui/templates/pages/what_to_expect.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 {% load i18n static %}
 
+
+{% block robots %}
+{% endblock robots %}
+
 {% block title %}
   {% translate "whattoexpect.title" %} - {% translate "common.findcaselaw" %}
 {% endblock title %}

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -252,3 +252,18 @@ class TestConverters(TestCase):
     def test_subdivision_converter_fails_to_parse(self):
         converter = converters.SubdivisionConverter()
         self.assertIsNone(re.match(converter.regex, "notasubdivision"))
+
+
+class TestRobotsDirectives(TestCase):
+    def test_homepage(self):
+        # The homepage should not have a robots meta tag with nofollow,noindex
+        response = self.client.get("/")
+        self.assertNotContains(
+            response, '<meta name="robots" content="noindex,nofollow">'
+        )
+
+    def test_judgment_results(self):
+        # The judgment search results page should not have a robots meta tag
+        # with nofollow,noindex
+        response = self.client.get("/judgments/results?query=waltham+forest")
+        self.assertContains(response, '<meta name="robots" content="noindex,nofollow">')

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -263,7 +263,7 @@ class TestRobotsDirectives(TestCase):
         )
 
     def test_judgment_results(self):
-        # The judgment search results page should not have a robots meta tag
+        # The judgment search results page should have a robots meta tag
         # with nofollow,noindex
         response = self.client.get("/judgments/results?query=waltham+forest")
         self.assertContains(response, '<meta name="robots" content="noindex,nofollow">')

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -268,7 +268,7 @@ class TestRobotsDirectives(TestCase):
 
     @patch("judgments.feeds.perform_advanced_search")
     @patch("judgments.models.SearchResult.create_from_node")
-    def test_judgment_results(self,fake_result, fake_advanced_search):
+    def test_judgment_results(self, fake_result, fake_advanced_search):
         fake_advanced_search.return_value = fake_search_results()
         fake_result.return_value = fake_search_result()
         # The judgment search results page should have a robots meta tag

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -255,14 +255,22 @@ class TestConverters(TestCase):
 
 
 class TestRobotsDirectives(TestCase):
-    def test_homepage(self):
+    @patch("judgments.feeds.perform_advanced_search")
+    @patch("judgments.models.SearchResult.create_from_node")
+    def test_homepage(self, fake_result, fake_advanced_search):
         # The homepage should not have a robots meta tag with nofollow,noindex
+        fake_advanced_search.return_value = fake_search_results()
+        fake_result.return_value = fake_search_result()
         response = self.client.get("/")
         self.assertNotContains(
             response, '<meta name="robots" content="noindex,nofollow">'
         )
 
-    def test_judgment_results(self):
+    @patch("judgments.feeds.perform_advanced_search")
+    @patch("judgments.models.SearchResult.create_from_node")
+    def test_judgment_results(self,fake_result, fake_advanced_search):
+        fake_advanced_search.return_value = fake_search_results()
+        fake_result.return_value = fake_search_result()
         # The judgment search results page should have a robots meta tag
         # with nofollow,noindex
         response = self.client.get("/judgments/results?query=waltham+forest")

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -255,7 +255,7 @@ class TestConverters(TestCase):
 
 
 class TestRobotsDirectives(TestCase):
-    @patch("judgments.feeds.perform_advanced_search")
+    @patch("judgments.views.perform_advanced_search")
     @patch("judgments.models.SearchResult.create_from_node")
     def test_homepage(self, fake_result, fake_advanced_search):
         # The homepage should not have a robots meta tag with nofollow,noindex
@@ -266,7 +266,7 @@ class TestRobotsDirectives(TestCase):
             response, '<meta name="robots" content="noindex,nofollow">'
         )
 
-    @patch("judgments.feeds.perform_advanced_search")
+    @patch("judgments.views.perform_advanced_search")
     @patch("judgments.models.SearchResult.create_from_node")
     def test_judgment_results(self, fake_result, fake_advanced_search):
         fake_advanced_search.return_value = fake_search_results()


### PR DESCRIPTION
This commit selectively removes the noindex,nofollow 'robots' meta tag from all the static pages, as requested in [Trello ticket #922](https://trello.com/c/ggWzD6hq/922-%F0%9F%91%A9%E2%9A%96%EF%B8%8Findex-static-pages-in-addition-to-home-page).

I've taken a hidden-by-default approach - the robots tag appears in the `base.html` template, and we use a jinja2 block to allow it to be overridden in the templates that extend it. In the static page templates we therefore override this with an empty block to allow them to be indexed.

I've included a test of the homepage (as an example of a page where we do not want the tag to be included) and the results page (as an example of a page where we want the tag to be included) in order to validate the effectiveness of this approach, however it seemed overkill to include a test for every single template. If you disagree however, i'd be happy to add them!

