### PR TITLE
Fix 'back to top' UI bug.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{py,rst,ini}]
+[*.{py,rst,ini,js}]
 indent_style = space
 indent_size = 4
 

--- a/ds_judgements_public_ui/sass/includes/_back_to_top_link.scss
+++ b/ds_judgements_public_ui/sass/includes/_back_to_top_link.scss
@@ -8,4 +8,8 @@
     position: fixed;
     top: 0;
   }
+
+  &.hide {
+    display: none;
+  }
 }

--- a/ds_judgements_public_ui/static/js/src/modules/back_to_top.js
+++ b/ds_judgements_public_ui/static/js/src/modules/back_to_top.js
@@ -1,3 +1,5 @@
+import $ from "jquery";
+
 const handler = (entries) => {
     manage_class(entries[0].isIntersecting)
 };
@@ -9,12 +11,15 @@ const createObserver = (element) => {
 };
 
 const manage_class = (intersecting) => {
-    const button = document.getElementById('js-back-to-top-link');
+    const button = document.getElementById("js-back-to-top-link");
+    const pageScrolls = $(".judgment-body").height() > $(window).height();
 
-    if (intersecting) {
-        button.classList.add('show');
+    if (intersecting && pageScrolls) {
+        button.classList.add("show");
+        button.classList.remove("hide");
     } else {
-        button.classList.remove('show');
+        button.classList.remove("show");
+        button.classList.add("hide");
     }
 };
 


### PR DESCRIPTION
As reported on trello ticket [391](https://trello.com/c/NXSHOm9m/391-if-a-judgment-is-very-short-the-back-to-the-top-obscures-the-alpha-banner) - on short judgements (eg [This one](https://caselaw.nationalarchives.gov.uk/ewhc/comm/2011/68#js-phase-banner)), the 'back to top' link appears above the site header.

This ticket fixes this by only displaying the link when the length of the judgement itself exceeds the size of the viewport.

(In addition, i've changed the .editorconfig file to respect what appears to be the norm in the existing code of using 4 spaces for tabs in js files, without this my editor tends to mangle every file I touch with whitespace changes - hope this is ok!)

While this is a very small change I'd appreciate review, particularly on the following two points:

1) Is this an appropriate place to be using JQuery? I'm basing this decision on the recommendation in [TNA's developer gude](https://github.com/nationalarchives/front-end-development-guide/blob/master/development-guide.md) as things like viewport dimensions tend in my experience to be a cross-browser compatibility can of worms. Very happy to revise in vanilla JS if that's more appropriate here.

2) I'm not 100% happy with adding a second ".hidden" class to the link and managing the state of both a 'shown' and 'hidden' class independently - however, this is necessary to ensure that the 'back to top' link is not shown at all on short judgements (it's rather unsightly and redundant even at the bottom of the page) when JS is enabled, while also ensuring that it's shown and is functional when js is not enabled or not loaded. (the alternative would be to hide it by default and show it using the 'show' class, but that degrades the experience without JS on long judgements).

Anyway, sorry for the ridiculous commit-message to lines-changed ratio, I'll be briefer about these things when I've got settled in :-)

Many thanks!

Tim

