### PR TITLE
Add sort select menu to search results

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_result_controls.scss
+++ b/ds_judgements_public_ui/sass/includes/_result_controls.scss
@@ -1,15 +1,33 @@
 .result-controls {
-  text-align: right;
+  text-align: left;
+  display: inline-block;
+  margin: $spacer__unit 0 0;
+
+  @media (min-width: $grid__breakpoint-extra-large) {
+    text-align: right;
+    margin: 0;
+  }
 
   &__order-by-label {
     font-family: $font__roboto;
-    font-size: 1.4rem;
+    font-size: 1rem;
+    margin-bottom: $spacer__unit / 2;
     display: block;
-    margin-bottom: $spacer__unit;
   }
 
   &__order-by {
     @include select;
     min-width: auto;
+    display: inline-block;
+  }
+
+  &__button {
+    @include call-to-action-button($color__dark-blue, $color__white);
+    margin: 0;
+    font-size: 0.85rem;
+    outline-color: $color__dark-blue;
+    padding: 0.625rem;
+    font-weight: normal;
+    vertical-align: 1px;
   }
 }

--- a/ds_judgements_public_ui/sass/includes/_results.scss
+++ b/ds_judgements_public_ui/sass/includes/_results.scss
@@ -17,12 +17,22 @@
   }
 
   &__result-list-container {
-    background-color: #fff;
+    background-color: $color__white;
 
     h2 {
       @include sr-only;
     }
   }
+
+  &__result-controls-container {
+     border-bottom: 1px solid $color__yellow;
+
+     @media (min-width: $grid__breakpoint-extra-large) {
+       display: flex;
+       align-items: flex-start;
+       justify-content: space-between;
+     }
+   }
 
   &__results-intro {
     font-family: $font__roboto;

--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -1,35 +1,23 @@
-{% load i18n query_filters %}
+{% load i18n %}
 <div class="results__result-header">
   <p class="results__results-intro">We found {{ context.total }} judgments</p>
 </div>
 <div class="result-controls">
 
-  {%  comment  %} START: PLACEHOLDER HTML FOR NEW IMPLEMENTATION {%  endcomment %}
-  <form action="#" id="analytics-result-controls">
+{% if context.query %}
+  <form method="get" action="{{request.path}}" id="analytics-result-controls">
+      {% for key, value in context.query_params.items %}
+        {% if key != "order" %}
+          <input type="hidden" name="{{key}}" value="{{value}}" />
+        {% endif %}
+      {% endfor %}
       <label for="order_by">Order results by</label>
-      <select class="result-controls__order-by" id="order_by" name="order_by">
-        <option value="relevance">Relevance</option>
-        <option value="date_dec">Date descending</option>
-        <option value="date_asc">Date ascending</option>
+      <select class="result-controls__order-by" id="order_by" name="order">
+        <option value="relevance" {% if context.order == "relevance" or context.order is None %}selected='selected'{% endif %}>Relevance</option>
+        <option value="-date" {% if context.order == "-date" %}selected='selected'{% endif %}>Date descending</option>
+        <option value="date" {% if context.order == "date" %}selected='selected'{% endif %}>Date ascending</option>
       </select>
       <input type="submit" value="Go" class="result-controls__button">
   </form>
-  {%  comment  %} END: PLACEHOLDER HTML FOR NEW IMPLEMENTATION {%  endcomment %}
-
-
-  {%  comment  %} START: CURRENT LIVE IMPLEMENTATION {%  endcomment %}
-  {%  comment  %}
-    {% if context.query %}
-      <div class="result-controls__order-by-label">
-        {% if context.order == "-date" %}
-          <a class="" href="{{request.path}}?{{context.query_params|remove_query_key:'order'}}&order=relevance">{% translate "results.order-by.relevance" %}</a>
-        {% else %}
-          <a class="" href="{{request.path}}?{{context.query_params|remove_query_key:'order'}}&order=-date">{% translate "results.order-by.date" %}</a>
-        {% endif %}
-      </div>
-    {% endif %}
-  {%  endcomment %}
-  {%  comment  %} END: CURRENT LIVE IMPLEMENTATION {%  endcomment %}
-
+{% endif %}
 </div>
-

--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -1,12 +1,35 @@
 {% load i18n query_filters %}
-<div class="result-controls">
-  {% if context.query %}
-    <div class="result-controls__order-by-label">
-      {% if context.order == "-date" %}
-        <a class="" href="{{request.path}}?{{context.query_params|remove_query_key:'order'}}&order=relevance">{% translate "results.order-by.relevance" %}</a>
-      {% else %}
-        <a class="" href="{{request.path}}?{{context.query_params|remove_query_key:'order'}}&order=-date">{% translate "results.order-by.date" %}</a>
-      {% endif %}
-    </div>
-  {% endif %}
+<div class="results__result-header">
+  <p class="results__results-intro">We found {{ context.total }} judgments</p>
 </div>
+<div class="result-controls">
+
+  {%  comment  %} START: PLACEHOLDER HTML FOR NEW IMPLEMENTATION {%  endcomment %}
+  <form action="#" id="analytics-result-controls">
+      <label for="order_by">Order results by</label>
+      <select class="result-controls__order-by" id="order_by" name="order_by">
+        <option value="relevance">Relevance</option>
+        <option value="date_dec">Date descending</option>
+        <option value="date_asc">Date ascending</option>
+      </select>
+      <input type="submit" value="Go" class="result-controls__button">
+  </form>
+  {%  comment  %} END: PLACEHOLDER HTML FOR NEW IMPLEMENTATION {%  endcomment %}
+
+
+  {%  comment  %} START: CURRENT LIVE IMPLEMENTATION {%  endcomment %}
+  {%  comment  %}
+    {% if context.query %}
+      <div class="result-controls__order-by-label">
+        {% if context.order == "-date" %}
+          <a class="" href="{{request.path}}?{{context.query_params|remove_query_key:'order'}}&order=relevance">{% translate "results.order-by.relevance" %}</a>
+        {% else %}
+          <a class="" href="{{request.path}}?{{context.query_params|remove_query_key:'order'}}&order=-date">{% translate "results.order-by.date" %}</a>
+        {% endif %}
+      </div>
+    {% endif %}
+  {%  endcomment %}
+  {%  comment  %} END: CURRENT LIVE IMPLEMENTATION {%  endcomment %}
+
+</div>
+

--- a/ds_judgements_public_ui/templates/includes/results_list.html
+++ b/ds_judgements_public_ui/templates/includes/results_list.html
@@ -1,8 +1,5 @@
 {% load static i18n %}
 <h2>Results listing</h2>
-<div class="results__result-header">
-  <p class="results__results-intro">We found {{ context.total }} judgments</p>
-</div>
 <ul class="judgment-listing__list">
   {% for item in context.search_results %}
     <li>

--- a/judgments/templatetags/query_filters.py
+++ b/judgments/templatetags/query_filters.py
@@ -8,10 +8,3 @@ def remove_query(query_params, key):
     params = dict(query_params)
     params[key] = None
     return "&".join([f'{key}={params[key] or ""}' for key in params])
-
-
-@register.filter
-def remove_query_key(query_params, key):
-    params = dict(query_params)
-    params.pop(key)
-    return "&".join([f'{key}={params[key] or ""}' for key in params])


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Co-Authored-By: @matt-blair 

Users have a need to view the "end" of a set of search results. If the set of results is very large, this may be many pages away and we have experienced performance issues with Marklogic when rendering very large sets of results.

If the user wishes to search by date and see the "end" of the results, they can now choose to flip the search results from date descending (newest first) to date ascending (oldest first). This is achieved via a form and a GET request. 

We have assumed that if the user is ordering by relevance, they will not wish to see the "least relevant" first.

## Trello card / Rollbar error (etc)

https://trello.com/c/bZ9NkZ7i

## Screenshots of UI changes:

### After

<img width="1191" alt="Screenshot 2022-09-14 at 09 35 44" src="https://user-images.githubusercontent.com/1089521/190104460-ad5be7a9-d48a-4627-92ed-5f8c5e68cb48.png">


- [ ] Requires env variable(s) to be updated
