### PR TITLE
Refactor to get rid of separate show/hide classes

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_back_to_top_link.scss
+++ b/ds_judgements_public_ui/sass/includes/_back_to_top_link.scss
@@ -3,13 +3,14 @@
     padding: $spacer__unit;
     background-color: $color__white;
 
-  &.show {
-    margin: auto;
-    position: fixed;
-    top: 0;
-  }
-
-  &.hide {
+  &.autohide {
     display: none;
+
+    &.show {
+      display: inline-block;
+      margin: auto;
+      position: fixed;
+      top: 0;
+    }
   }
 }

--- a/ds_judgements_public_ui/static/js/src/modules/back_to_top.js
+++ b/ds_judgements_public_ui/static/js/src/modules/back_to_top.js
@@ -16,14 +16,15 @@ const manage_class = (intersecting) => {
 
     if (intersecting && pageScrolls) {
         button.classList.add("show");
-        button.classList.remove("hide");
     } else {
         button.classList.remove("show");
-        button.classList.add("hide");
     }
 };
 
-let judgment_body = document.querySelector('.judgment-body');
+let judgment_body = document.querySelector(".judgment-body");
+const button = document.getElementById("js-back-to-top-link");
+
+button.classList.add("autohide");
 
 if (judgment_body) {
     createObserver(judgment_body);


### PR DESCRIPTION
Little refactor to get rid of the nastiness in my previous PR where we had to manage the state of both a 'show' and a 'hide' class on the back-to-top link. I tried to sneak it onto the branch after review but you beat me to it with the merge! 😂 