### PR TITLE
Fix django-admin errors

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -106,7 +106,9 @@ def sh(c):
     """
     Run bash in a local container (with access to dependencies)
     """
-    subprocess.run(["docker-compose", "exec", "django", "bash"])
+    subprocess.run(
+        ["docker-compose", "exec", "django", "env", "DJANGO_SETTINGS_MODULE=", "bash"]
+    )
 
 
 @task


### PR DESCRIPTION
When  DJANGO_SETTINGS_MODULE is set in the environment for `fab sh`, the `django-admin` command fails as the given settings module is not on the python import path. resetting this so that it is empty fixes the problem (as seen also in `compose/production/django/start`, line 11). This commit ensures that this env var is reset on starting `fab-sh` so that django-admin commands can be run from within it without error!
