### PR TITLE
Prevent users from being able to choose their own locale/language

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -121,7 +121,6 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",


### PR DESCRIPTION
A user on the team, who is based in the USA, noticed that the i18n strings in the application were not being translated. We realised their browser is set up to send en-US as the locale in an Accept header, and as a result django is trying (and failing) to find an en-US locale file.

This is despite the application being set up to use en-GB as the default.

Additionally, other country locales do not have the same issue (e.g ca-ES)

One way to attempt to resolve this is to prevent users from being able to select their language, by removing the `LocaleMiddleware`. We currently do not have any other locales to offer, and we have no current plans to add any.

If/when we decide to add more locales to the application, we can look into reinstating the middleware and figuring out why en-GB is not being treated as the default when a user's locale is set to en-US

https://docs.djangoproject.com/en/4.1/topics/i18n/translation/#how-django-discovers-language-preference

<!-- Amend as appropriate -->

## Changes in this PR:

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
