### PR TITLE
Redesign download links to give XML less prominence

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text_download_options.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_download_options.scss
@@ -1,0 +1,38 @@
+.judgment-download-options {
+    max-width: 90%;
+    margin: 0 auto calc($spacer__unit*3) auto;
+
+    @media (min-width: $grid__breakpoint-medium) {
+        max-width: 46rem;
+    }
+
+    &__header {
+        border-bottom: 4px solid $color__yellow;
+        padding-bottom: calc($spacer__unit * 0.5);
+        margin-bottom: calc($spacer__unit * 2);
+        display: inline-block;
+    }
+
+    &__options-list {
+        display: flex;
+        flex-direction: column;
+        gap: $spacer__unit;
+
+        @media (min-width: $grid__breakpoint-medium) {
+            flex-direction: row;
+        }
+    }
+
+    &__download-option {
+        border: 1px solid $color__yellow;
+        padding: $spacer__unit;
+    }
+
+    h3 {
+        margin-top: 0;
+    }
+
+    p {
+        margin-bottom: 0;
+    }
+}

--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -12,11 +12,7 @@
     display: inline-block;
     text-decoration: none;
     outline-offset: 3px;
-    margin: 0 $spacer__unit $spacer__unit 0;
-
-    @media (min-width: $grid__breakpoint-small) {
-      margin-bottom: 0;
-    }
+    margin: 0;
   }
 
   &__return-link {
@@ -33,6 +29,7 @@
 
   &__download {
     display: inline-block;
+
   }
 
   &__container {
@@ -41,12 +38,13 @@
     > div {
       @media (max-width: $grid__breakpoint-small) {
         text-align: center;
+        display: block;
         padding: 0.25rem $spacer__unit;
       }
     }
 
     @media (min-width: $grid__breakpoint-small) {
-      text-align: center;
+      text-align: right;
     }
 
     @media (min-width: $grid__breakpoint-medium) {
@@ -55,6 +53,36 @@
 
     @media (min-width: $grid__breakpoint-medium) {
       max-width: 46rem;
+    }
+  }
+}
+
+.judgment-download {
+
+  &__option--pdf {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    margin: 0 !important;
+    width: 100%;
+    text-align: center;
+  }
+
+  &__download-options {
+    color: $color__dark-grey;
+    font-size: 0.7rem;
+    font-style: italic;
+    margin: calc($spacer__unit * 0.5) 0 0 0;
+
+    a {
+      background-color: transparent;
+      color: $color__aqua-blue;
+      padding: 0;
+      display: inline;
+      text-decoration: underline;
+
+      &:hover {
+        text-decoration: none;
+      }
     }
   }
 }

--- a/ds_judgements_public_ui/sass/main.scss
+++ b/ds_judgements_public_ui/sass/main.scss
@@ -20,6 +20,7 @@
 @import "includes/judgment_text_toolbar";
 @import "includes/judgment_text_source";
 @import "includes/judgment_text_service_introduction";
+@import "includes/judgment_text_download_options";
 @import "includes/standard_text_template";
 @import "includes/how_can_this_service_be_improved";
 @import "includes/back_to_top_link";

--- a/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+<div id="download-options" class="judgment-download-options">
+    <h2 class="judgment-download-options__header">{% translate "judgment.downloadoptions.title" %}</h2>
+    <div class="judgment-download-options__options-list">
+        <div class="judgment-download-options__download-option">
+            <h3>
+                <a href="{% url 'detail_pdf' context.judgment_uri %}">
+                    {% translate "judgment.downloadoptions.pdf.cta" %}{{context.pdf_size}}
+                </a>
+            </h3>
+            <p>
+                {% translate "judgment.downloadoptions.pdf.description" %}
+            </p>
+        </div>
+        <div class="judgment-download-options__download-option">
+            <h3>
+                <a href="{% url 'detail_xml' context.judgment_uri %}">
+                    {% translate "judgment.downloadoptions.xml.cta" %}
+                </a>
+            </h3>
+            <p>
+                {% translate "judgment.downloadoptions.xml.description" %}
+            </p>
+        </div>
+    </div>
+</div>

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -1,14 +1,16 @@
 {% load i18n %}
 <div class="judgment-toolbar">
     <div class="judgment-toolbar__container">
-        <div class="judgment-toolbar__return-link">
-            {% if request.args.origin == 'results' %}
+
+        {% if request.args.origin == 'results' %}
+            <div class="judgment-toolbar__return-link"></div>
                 <a href="{{ request.args.return_link }}">{% translate "judgment.back" %}</a>
-            {% endif %}
-        </div>
+            </div>
+        {% endif %}
+
         <div class="judgment-toolbar__download">
-            <a class="judgment-download__option--xml" role="button" draggable="false" href="{% url 'detail_xml' context.judgment_uri %}">{% translate "judgment.downloadasxml" %}</a>
             <a class="judgment-download__option--pdf" role="button" draggable="false" href="{% url 'detail_pdf' context.judgment_uri %}">{% translate "judgment.downloadaspdf" %}{{context.pdf_size}}</a>
+            <p class="judgment-download__download-options" role="note">{% translate "judgment.downloadoptions.shortcutlink" %}</p>
         </div>
     </div>
 </div>

--- a/ds_judgements_public_ui/templates/layout_judgment_html.html
+++ b/ds_judgements_public_ui/templates/layout_judgment_html.html
@@ -40,6 +40,7 @@
     {% endblock %}
     <a id="js-back-to-top-link" class="back-to-top-link" href="#js-phase-banner">Back to top</a>
 </main>
+{% include 'includes/judgment_text_download_options.html' %}
 {% include 'includes/footer.html' %}
 </body>
 </html>

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -145,7 +145,7 @@ msgstr "Download this judgment as XML"
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html:22
 msgid "judgment.downloadoptions.xml.description"
-msgstr "The judgment in machine-readable LegalDocXML format for developers, data scientists and researchers."
+msgstr "The judgment in machine-readable LegalDocML format for developers, data scientists and researchers."
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_source.html:4
 msgid "judgment.source_by"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -145,7 +145,7 @@ msgstr "Download this judgment as XML"
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html:22
 msgid "judgment.downloadoptions.xml.description"
-msgstr "The judgment in machine-readable LegalXML format for developers, data scientists and researchers."
+msgstr "The judgment in machine-readable LegalDocXML format for developers, data scientists and researchers."
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_source.html:4
 msgid "judgment.source_by"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-21 10:44+0100\n"
+"POT-Creation-Date: 2022-09-15 14:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,23 +18,24 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ds_judgements_public_ui/templates/base.html:9
-#: ds_judgements_public_ui/templates/includes/breadcrumbs.html:7
-#: ds_judgements_public_ui/templates/judgment/results.html:5
-#: ds_judgements_public_ui/templates/layout_judgment_html.html:11
-#: ds_judgements_public_ui/templates/pages/accessibility_statement.html:5
-#: ds_judgements_public_ui/templates/pages/home.html:14
-#: ds_judgements_public_ui/templates/pages/how_to_use_this_service.html:5
-#: ds_judgements_public_ui/templates/pages/terms_of_use.html:5
-#: ds_judgements_public_ui/templates/pages/transactional_licence.html:5
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:5
-msgid "common.findcaselaw"
-msgstr "Find case law"
-
-#: ds_judgements_public_ui/templates/base.html:29
+#: ds_judgements_public_ui/templates/base.html:36
 #: ds_judgements_public_ui/templates/layout_judgment_html.html:29
 msgid "skiplink"
 msgstr "Skip to Main Content"
+
+#: ds_judgements_public_ui/templates/includes/breadcrumbs.html:7
+#: ds_judgements_public_ui/templates/judgment/results.html:5
+#: ds_judgements_public_ui/templates/layout_judgment_html.html:11
+#: ds_judgements_public_ui/templates/pages/accessibility_statement.html:8
+#: ds_judgements_public_ui/templates/pages/home.html:9
+#: ds_judgements_public_ui/templates/pages/home.html:21
+#: ds_judgements_public_ui/templates/pages/how_to_use_this_service.html:8
+#: ds_judgements_public_ui/templates/pages/open_justice_licence.html:8
+#: ds_judgements_public_ui/templates/pages/terms_of_use.html:8
+#: ds_judgements_public_ui/templates/pages/transactional_licence.html:8
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:9
+msgid "common.findcaselaw"
+msgstr "Find case law"
 
 #: ds_judgements_public_ui/templates/includes/footer.html:7
 msgid "footer.websites"
@@ -73,7 +74,8 @@ msgid "howtousethisservice.titleshort"
 msgstr "How to use this service"
 
 #: ds_judgements_public_ui/templates/includes/footer.html:18
-#: ds_judgements_public_ui/templates/pages/accessibility_statement.html:9
+#: ds_judgements_public_ui/templates/pages/accessibility_statement.html:8
+#: ds_judgements_public_ui/templates/pages/accessibility_statement.html:12
 msgid "accessibilitystatement.title"
 msgstr "Accessibility statement"
 
@@ -90,7 +92,8 @@ msgid "footer.legal"
 msgstr "Legal"
 
 #: ds_judgements_public_ui/templates/includes/footer.html:25
-#: ds_judgements_public_ui/templates/pages/terms_of_use.html:9
+#: ds_judgements_public_ui/templates/pages/terms_of_use.html:8
+#: ds_judgements_public_ui/templates/pages/terms_of_use.html:12
 msgid "terms.title"
 msgstr "Terms of use"
 
@@ -116,13 +119,33 @@ msgstr "How can this service be improved?"
 
 #: ds_judgements_public_ui/templates/includes/how_can_this_service_be_improved.html:5
 #: ds_judgements_public_ui/templates/includes/phase_banner.html:8
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:52
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:56
 msgid "survey.link"
 msgstr "https://corexmsnp4n42lf2kht3.qualtrics.com/jfe/form/SV_0lyyYAzfv9bGcyW"
 
 #: ds_judgements_public_ui/templates/includes/how_can_this_service_be_improved.html:5
 msgid "survey.link.text"
 msgstr "Fill out our short survey"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html:3
+msgid "judgment.downloadoptions.title"
+msgstr "Download options"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html:8
+msgid "judgment.downloadoptions.pdf.cta"
+msgstr "Download this judgment as a PDF"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html:12
+msgid "judgment.downloadoptions.pdf.description"
+msgstr "The original format of the judgment as handed down by the court, for printing and downloading."
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html:18
+msgid "judgment.downloadoptions.xml.cta"
+msgstr "Download this judgment as XML"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html:22
+msgid "judgment.downloadoptions.xml.description"
+msgstr "The judgment in machine-readable LegalXML format for developers, data scientists and researchers."
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_source.html:4
 msgid "judgment.source_by"
@@ -132,17 +155,17 @@ msgstr "This judgment has been provided to The National Archives by "
 msgid "judgment.bailii"
 msgstr "The British and Irish Legal Information Institute"
 
-#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html:6
+#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html:7
 msgid "judgment.back"
 msgstr "Back to search results"
 
-#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html:10
-msgid "judgment.downloadasxml"
-msgstr "Download as XML"
-
-#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html:11
+#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html:12
 msgid "judgment.downloadaspdf"
 msgstr "Download as PDF"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html:13
+msgid "judgment.downloadoptions.shortcutlink"
+msgstr "(Are you looking for <a href=\"#download-options\">more download options</a>?)"
 
 #: ds_judgements_public_ui/templates/includes/recent_judgments.html:21
 #: ds_judgements_public_ui/templates/includes/results_list.html:23
@@ -168,30 +191,31 @@ msgstr "Order by date"
 
 #: ds_judgements_public_ui/templates/judgment/results.html:5
 #: ds_judgements_public_ui/templates/judgment/results.html:9
-#: judgments/views.py:213
+#: judgments/views.py:233
 msgid "results.search.title"
 msgstr "Search results"
 
-#: ds_judgements_public_ui/templates/pages/home.html:16
+#: ds_judgements_public_ui/templates/pages/home.html:23
 msgid "home.useservice"
 msgstr ""
 "Use this service to find, view and download judgments and tribunal decisions"
 
-#: ds_judgements_public_ui/templates/pages/how_to_use_this_service.html:5
+#: ds_judgements_public_ui/templates/pages/how_to_use_this_service.html:8
+#: ds_judgements_public_ui/templates/pages/how_to_use_this_service.html:12
 msgid "howtousethisservice.title"
 msgstr "How to use the Find Case Law service"
 
-#: ds_judgements_public_ui/templates/pages/how_to_use_this_service.html:148
+#: ds_judgements_public_ui/templates/pages/how_to_use_this_service.html:152
 msgid "courtstructure.link"
 msgstr ""
 "https://www.judiciary.uk/about-the-judiciary/the-justice-system/court-"
 "structure"
 
-#: ds_judgements_public_ui/templates/pages/how_to_use_this_service.html:197
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:376
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:414
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:423
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:426
+#: ds_judgements_public_ui/templates/pages/how_to_use_this_service.html:201
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:330
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:368
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:377
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:380
 msgid "caselaw.email"
 msgstr "caselaw@nationalarchives.gov.uk"
 
@@ -210,11 +234,12 @@ msgstr ""
 "Improve your search results by removing filters, double-checking your "
 "spelling, using fewer keywords or searching for something less specific."
 
-#: ds_judgements_public_ui/templates/pages/open_justice_licence.html:5
+#: ds_judgements_public_ui/templates/pages/open_justice_licence.html:8
+#: ds_judgements_public_ui/templates/pages/open_justice_licence.html:12
 msgid "openjusticelicence.title"
 msgstr "Open Justice Licence"
 
-#: ds_judgements_public_ui/templates/pages/open_justice_licence.html:143
+#: ds_judgements_public_ui/templates/pages/open_justice_licence.html:149
 msgid "licensingframework.link"
 msgstr ""
 "https://www.nationalarchives.gov.uk/information-management/re-using-public-"
@@ -229,89 +254,91 @@ msgstr "Search"
 msgid "commom.findcaselaw"
 msgstr "Find case law"
 
-#: ds_judgements_public_ui/templates/pages/terms_of_use.html:24
+#: ds_judgements_public_ui/templates/pages/terms_of_use.html:27
 msgid "caselaw.url"
 msgstr "https://caselaw.nationalarchives.gov.uk"
 
-#: ds_judgements_public_ui/templates/pages/terms_of_use.html:36
+#: ds_judgements_public_ui/templates/pages/terms_of_use.html:39
 msgid "webmaster.email"
 msgstr "webmaster@nationalarchives.gov.uk"
 
-#: ds_judgements_public_ui/templates/pages/terms_of_use.html:72
+#: ds_judgements_public_ui/templates/pages/terms_of_use.html:75
 msgid "robots.link"
 msgstr "https://caselaw.nationalarchives.gov.uk/robots.txt"
 
-#: ds_judgements_public_ui/templates/pages/terms_of_use.html:95
+#: ds_judgements_public_ui/templates/pages/terms_of_use.html:98
 msgid "bailii.link"
 msgstr "www.bailii.org"
 
-#: ds_judgements_public_ui/templates/pages/transactional_licence.html:9
+#: ds_judgements_public_ui/templates/pages/transactional_licence.html:8
+#: ds_judgements_public_ui/templates/pages/transactional_licence.html:12
 msgid "transactionallicenceform.title"
 msgstr "Application to re-use Court Judgments and Tribunal Decisions"
 
-#: ds_judgements_public_ui/templates/pages/transactional_licence.html:25
+#: ds_judgements_public_ui/templates/pages/transactional_licence.html:28
 msgid "caselawlicence.email"
 msgstr "CaseLawLicence@nationalarchives.gov.uk"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:5
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:9
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:13
 msgid "whattoexpect.title"
 msgstr "What to expect from this new service"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:55
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:58
 msgid "publicrecordsact.link"
 msgstr "https://www.legislation.gov.uk/ukpga/Eliz2/6-7/51/contents"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:59
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:60
 msgid "firstschedule.link"
 msgstr ""
 "https://www.legislation.gov.uk/ukpga/Eliz2/6-7/51/schedule/FIRST/"
 "crossheading/records-of-courts-and-tribunals"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:62
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:63
 msgid "sectionthree.link"
 msgstr "https://www.legislation.gov.uk/ukpga/Eliz2/6-7/51/section/3"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:63
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:64
 msgid "sectiontwofourh.link"
 msgstr "https://www.legislation.gov.uk/ukpga/Eliz2/6-7/51/section/2/4/h"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:67
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:68
 msgid "sectiontwothree.link"
 msgstr "https://www.legislation.gov.uk/ukpga/Eliz2/6-7/51/section/2/3"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:70
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:71
 msgid "sectionfivethree.link"
 msgstr "https://www.legislation.gov.uk/ukpga/Eliz2/6-7/51/section/5/3"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:202
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:157
 msgid "legaldocml.link"
 msgstr "https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=legaldocml"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:242
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:197
 msgid "openapi.link"
 msgstr "https://github.com/nationalarchives/ds-caselaw-public-access-service/"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:245
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:200
 msgid "atom.link"
 msgstr "https://caselaw.nationalarchives.gov.uk/atom.xml"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:333
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:287
 msgid "fivesafes.link"
 msgstr "https://en.wikipedia.org/wiki/Five_safes"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:342
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:296
 msgid "reuse.link"
 msgstr "https://www.legislation.gov.uk/uksi/2015/1415/contents"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:345
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:299
 msgid "sectioneight.link"
 msgstr "https://www.legislation.gov.uk/uksi/2015/1415/regulation/8"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:348
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:302
 msgid "sectionthirteen.link"
 msgstr "https://www.legislation.gov.uk/uksi/2015/1415/regulation/13"
 
-#: ds_judgements_public_ui/templates/pages/what_to_expect.html:365
+#: ds_judgements_public_ui/templates/pages/what_to_expect.html:319
 msgid "complaint.link"
 msgstr ""
 "https://www.nationalarchives.gov.uk/information-management/re-using-public-"


### PR DESCRIPTION
## Changes in this PR:


Many judges and clerks were confused by the 'download as XML' button, unsure what it was for, and doubly confused by the results of clicking it. Given it's probably a fairly niche use case, this probably suggests it had undue prominence in the previous design.

This is a proposal for a new design that moves the download links to the bottom of the page in a new 'download options' section, following Matt's design for the judgment summary page as much as posisble, and providing some contextual information for users to understand what the given download options are, and who they might be useful for. Given that downloading the judgement as a PDF is a very common use case, I've maintained the button for this at the top of the page, along with a subtle signposting link for other download options, which points to an anchor tag in the download options section in the footer.

## Trello card / Rollbar error (etc)

https://trello.com/c/6hKcc1A5/221-%F0%9F%91%A9%E2%9A%96%EF%B8%8Fpriority-of-download-as-xml-button-on-site

## Screenshots of UI changes:

### Large breakpoint:
<img width="1774" alt="Screenshot 2022-09-15 at 16 42 57" src="https://user-images.githubusercontent.com/4279/190436511-50ed8563-b01c-45ef-b0a0-9c2229edb83a.png">

<img width="1774" alt="Screenshot 2022-09-15 at 16 43 08" src="https://user-images.githubusercontent.com/4279/190436498-39d8bf22-8e86-4f33-9b87-a265aced8978.png">


### Small breakpoint:
<img width="435" alt="Screenshot 2022-09-15 at 16 44 43" src="https://user-images.githubusercontent.com/4279/190436587-5efb7526-7bf4-4d1f-a4eb-a2b19379da68.png">


<img width="435" alt="Screenshot 2022-09-15 at 16 44 53" src="https://user-images.githubusercontent.com/4279/190436575-cbb403a9-cb54-4c54-bf5f-89dcedaf1fe9.png">


