### PR TITLE
add CSS for forcing paragraph alignments in judgments

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text.scss
@@ -171,6 +171,10 @@
     text-align: center;
   }
 
+  // Classes with `pr-` prefix are purely presentational
+  // escape-hatches for dealing with specific formatting
+  // details in judgments that must be preserved.
+
   &__pr-center {
     text-align: center !important;
   }

--- a/ds_judgements_public_ui/sass/includes/_judgment_text.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text.scss
@@ -170,6 +170,18 @@
   &__approved-judgment {
     text-align: center;
   }
+
+  &__pr-center {
+    text-align: center !important;
+  }
+
+  &__pr-right {
+    text-align: right !important;
+  }
+
+  &__pr-left {
+    text-align: left !important;
+  }
 }
 
 .judgment-body {

--- a/ds_judgements_public_ui/sass/includes/_result_controls.scss
+++ b/ds_judgements_public_ui/sass/includes/_result_controls.scss
@@ -11,7 +11,7 @@
   &__order-by-label {
     font-family: $font__roboto;
     font-size: 1rem;
-    margin-bottom: $spacer__unit / 2;
+    margin-bottom: calc($spacer__unit / 2);
     display: block;
   }
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Three little CSS escape hatches that Jim can use in the judgment html to ensure we have the correct layout!

## Trello card / Rollbar error (etc)

https://trello.com/c/MOeZYajS/954-%F0%9F%91%A9%E2%9A%96%EF%B8%8Fcentre-headings-parser-and-fe

