### PR TITLE
UI text changes for `s/Queen/King/gi`

### DIFF
--- a/ds_judgements_public_ui/templates/includes/structured_search_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/structured_search_inputs.html
@@ -87,7 +87,7 @@
               </option>
               <option value="ewhc/qb"
               {% if context.court == 'ewhc/qb' %}selected="selected"{% endif %}>
-                Queen's Bench Division of the High Court
+                King's / Queen's Bench Division of the High Court
               </option>
               <option value="ewhc/tcc"
               {% if context.court == 'ewhc/tcc' %}selected="selected"{% endif %}>

--- a/ds_judgements_public_ui/templates/pages/what_to_expect.html
+++ b/ds_judgements_public_ui/templates/pages/what_to_expect.html
@@ -80,7 +80,7 @@
       <li>All judgments and tribunal decisions from the Upper Tribunals, High Court, Court of Appeal and Supreme Court
         from 19 April 2022
       </li>
-      <li>Judgments and decisions provided by the British and Irish Legal Information Institure (BAILII), that have been published under its contract with Her Majesty's
+      <li>Judgments and decisions provided by the British and Irish Legal Information Institure (BAILII), that have been published under its contract with His Majesty's
         Courts and Tribunals Service (HMCTS)/Ministry of Justice (MoJ)</li>
       <li>Judgments provided directly by the Supreme Court and the Upper Tribunals</li>
     </ul>
@@ -123,6 +123,7 @@
           <li>High Court (Mercantile Court) 2008-2014</li>
           <li>High Court (Patents Court) 2003-2022</li>
           <li>High Court (Queen's Bench Division) 2003-2022</li>
+          <li>High Court (King's Bench Division) 2022-</li>
           <li>High Court (Technology and Construction Court) 2003-2022</li>
           <li>Court of Protection 2009-2022</li>
           <li>Family Court 2014-2022</li>

--- a/judgments/fixtures/courts.py
+++ b/judgments/fixtures/courts.py
@@ -65,7 +65,7 @@ courts = [
         "years": "2003 &ndash; 2022",
     },
     {
-        "name": "Queen's Bench Division of the High Court",
+        "name": "King's / Queen's Bench Division of the High Court",
         "href": "/judgments/advanced_search?court=ewhc/qb",
         "years": "2003 &ndash; 2022",
     },


### PR DESCRIPTION
This removes all appropriate mentions of "Queen" / "Her Majesty" and replaces with a sensible alternative in the user facing text.

No identifiers are changed for the moment.

In the case of ui elements for searches / filters for judgments at the king's bench, this provides the single option "King's / Queen's bench division of the high court"

should work as a starter :-)