### PR TITLE
Feature/965 957 judgment spacing tweaks

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text.scss
@@ -37,6 +37,8 @@
 
 .judgment-header {
 
+  padding-top: $spacer__unit * 3;
+
   table {
 
     td {
@@ -45,7 +47,6 @@
   }
 
   &__logo {
-    padding-top: $spacer__unit * 3;
 
     img {
       display: block;

--- a/ds_judgements_public_ui/sass/includes/_judgment_text.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text.scss
@@ -213,24 +213,20 @@
   }
 
   &__section {
-    @media (min-width: $grid__breakpoint-medium) {
       display: grid;
       grid-template-columns: 1fr 15fr;
       grid-template-rows: 1fr;
       gap: 0 $spacer__unit * 0.5;
       grid-template-areas: ". .";
-    }
   }
 
 
   &__nested-section {
-    @media (min-width: $grid__breakpoint-medium) {
       display: grid;
       grid-template-columns: 1fr 24fr;
       grid-template-rows: 1fr;
       gap: 0 $spacer__unit * 0.5;
       grid-template-areas: ". .";
-    }
   }
 
   &__indent {


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Couple of tweaks to the judgements text css to fix the header spacing, and the alignment of paragraph numbers at small breakpoints.

## Trello card / Rollbar error (etc)

https://trello.com/c/H9xVFrr2/957-%F0%9F%8F%86ensure-there-is-consistent-spacing-between-the-toolbar-and-the-start-of-the-judgement-text-on-every-judgement

https://trello.com/c/PtAFMfAb/965-mobile-view-paragraph-numbering-of-judgments-is-appearing-above-the-text
