### PR TITLE
Feature/958 fix back to search results

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -5,35 +5,18 @@
   padding: $spacer__unit;
   border-bottom: 0.125rem solid $color__grey;
 
-  a {
-    background-color: $color__aqua-blue;
-    color: $color__white;
-    padding: calc($spacer__unit / 2) calc($spacer__unit * 1.5);
-    display: inline-block;
-    text-decoration: none;
-    outline-offset: 3px;
-    margin: 0;
-  }
-
-  &__return-link {
-    display: inline-block;
-
-    a {
-      background: $color__aqua-blue url($fa_chevron_left_white) 0.8rem 0.6rem no-repeat;
-      background-size: 0.75rem;
-      padding: calc($spacer__unit / 2) calc($spacer__unit * 1.5) calc($spacer__unit / 2) calc($spacer__unit * 2.5);
-      display: inline-block;
-      text-decoration: none;
-    }
-  }
-
-  &__download {
-    display: inline-block;
-
-  }
-
   &__container {
     margin: auto;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: stretch;
+
+
+    @media (min-width: $grid__breakpoint-small) {
+      flex-direction: row;
+      align-items: flex-start;
+    }
 
     > div {
       @media (max-width: $grid__breakpoint-small) {
@@ -53,6 +36,46 @@
 
     @media (min-width: $grid__breakpoint-medium) {
       max-width: 46rem;
+    }
+  }
+
+  a {
+    background-color: $color__aqua-blue;
+    color: $color__white;
+    padding: calc($spacer__unit / 2) calc($spacer__unit * 3);
+    display: inline-block;
+    text-decoration: none;
+    outline-offset: 3px;
+    margin: 0;
+
+    @media (min-width: $grid__breakpoint-small) {
+      padding: calc($spacer__unit / 2) calc($spacer__unit * 1.5);
+    }
+  }
+
+  &__return-link {
+
+    text-align: left;
+
+    a {
+      background: transparent url($fa_chevron_left_aqua_blue) 1.5rem 0.65rem no-repeat;
+      background-size: 0.75rem;
+      color: $color__aqua-blue;
+      padding: calc($spacer__unit / 2) calc($spacer__unit * 3);
+      margin: 0;
+      display: inline-block;
+      text-decoration: underline;
+
+      &:hover {
+        text-decoration: none;
+      }
+
+
+      @media (min-width: $grid__breakpoint-small) {
+        background: transparent url($fa_chevron_left_aqua_blue) 0rem 0.65rem no-repeat;
+        padding: calc($spacer__unit / 2) calc($spacer__unit * 1.2);
+        background-size: 0.75rem;
+      }
     }
   }
 }

--- a/ds_judgements_public_ui/sass/includes/_variables.scss
+++ b/ds_judgements_public_ui/sass/includes/_variables.scss
@@ -34,8 +34,10 @@ $fa_path: '/static/fontawesome-svgs/';
 // Images
 $fa_chevron_right: '#{$fa_path}chevron-right.svg';
 $fa_chevron_right_white: '#{$fa_path}chevron-right-white.svg';
+$fa_chevron_right_aqua_blue: '#{$fa_path}chevron-left-aqua-blue.svg';
 $fa_chevron_right_disabled: '#{$fa_path}chevron-right-disabled.svg';
 $fa_chevron_left: '#{$fa_path}chevron-left.svg';
 $fa_chevron_left_white: '#{$fa_path}chevron-left-white.svg';
+$fa_chevron_left_aqua_blue: '#{$fa_path}chevron-left-aqua-blue.svg';
 $fa_chevron_left_disabled: '#{$fa_path}chevron-left-disabled.svg';
 $fa_download: '#{$fa_path}download.svg';

--- a/ds_judgements_public_ui/static/fontawesome-svgs/chevron-left-aqua-blue.svg
+++ b/ds_judgements_public_ui/static/fontawesome-svgs/chevron-left-aqua-blue.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License). The fill colour and stroke of this SVG has been modified. -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 320 512" style="enable-background:new 0 0 320 512;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#037091;stroke:#26262A;stroke-width:5;stroke-miterlimit:10;}
+</style>
+<path class="st0" d="M34.5,239L228.9,44.7c9.4-9.4,24.6-9.4,33.9,0l22.7,22.7c9.4,9.4,9.4,24.5,0,33.9L131.5,256l154,154.8
+	c9.3,9.4,9.3,24.5,0,33.9l-22.7,22.7c-9.4,9.4-24.6,9.4-33.9,0L34.5,273C25.2,263.6,25.2,248.4,34.5,239z"/>
+</svg>

--- a/ds_judgements_public_ui/static/fontawesome-svgs/chevron-right-aqua-blue.svg
+++ b/ds_judgements_public_ui/static/fontawesome-svgs/chevron-right-aqua-blue.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License). The stroke of this SVG has been modified. -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 320 512" style="enable-background:new 0 0 320 512;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#037091;stroke:#000000;stroke-width:5;stroke-miterlimit:10;}
+</style>
+<path class="st0" d="M285.5,273L91.1,467.3c-9.4,9.4-24.6,9.4-33.9,0l-22.7-22.7c-9.4-9.4-9.4-24.5,0-33.9l154-154.7l-154-154.7
+	c-9.3-9.4-9.3-24.5,0-33.9l22.7-22.7c9.4-9.4,24.6-9.4,33.9,0L285.5,239C294.8,248.4,294.8,263.6,285.5,273z"/>
+</svg>

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -1,10 +1,9 @@
 {% load i18n %}
 <div class="judgment-toolbar">
     <div class="judgment-toolbar__container">
-
-        {% if request.args.origin == 'results' %}
+        {% if context.back_link %}
             <div class="judgment-toolbar__return-link"></div>
-                <a href="{{ request.args.return_link }}">{% translate "judgment.back" %}</a>
+                <a href="{{ context.back_link }}">{% translate "judgment.back" %}</a>
             </div>
         {% endif %}
 

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -2,7 +2,7 @@
 <div class="judgment-toolbar">
     <div class="judgment-toolbar__container">
         {% if context.back_link %}
-            <div class="judgment-toolbar__return-link"></div>
+            <div class="judgment-toolbar__return-link">
                 <a href="{{ context.back_link }}">{% translate "judgment.back" %}</a>
             </div>
         {% endif %}

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -8,6 +8,7 @@ import judgments.models
 import judgments.utils  # noqa: F401 -- used to mock
 from judgments import converters, views
 from judgments.models import Judgment, SearchResult, SearchResults
+from judgments.views import display_back_link
 
 
 def fake_search_results():
@@ -275,3 +276,19 @@ class TestRobotsDirectives(TestCase):
         # with nofollow,noindex
         response = self.client.get("/judgments/results?query=waltham+forest")
         self.assertContains(response, '<meta name="robots" content="noindex,nofollow">')
+
+
+class TestBackLink(TestCase):
+    def test_no_referrer(self):
+        # When there is no referrer, the back link is not displayed:
+        self.assertIs(display_back_link(None), False)
+
+    def test_refererrer_not_results_page(self):
+        # When there is a referrer, but it is not a results page,
+        # the back link is not displayed:
+        self.assertIs(display_back_link("https://example.com/any/other/path"), False)
+
+    def test_referrer_is_results_page(self):
+        # When there is a referrer, and it is a results page,
+        # the back link is displayed:
+        self.assertIs(display_back_link("https://example.com/judgments/results"), True)

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -4,6 +4,7 @@ import math
 import os
 import re
 import urllib
+from urllib.parse import urlparse
 
 import environ
 import requests
@@ -82,6 +83,7 @@ def detail(request, judgment_uri):
             context["page_title"] = model.metadata_name
             context["judgment_uri"] = judgment_uri
             context["pdf_size"] = get_pdf_size(judgment_uri)
+            context["back_link"] = get_back_link(request)
         except MarklogicResourceNotFoundError:
             raise Http404("Judgment was not found")
         template = loader.get_template("judgment/detail.html")
@@ -311,3 +313,19 @@ def paginator(current_page, total, size_per_page=RESULTS_PER_PAGE):
 
 def trim_leading_slash(uri):
     return re.sub("^/|/$", "", uri)
+
+
+def get_back_link(request):
+    back_link = request.META.get("HTTP_REFERER")
+    if display_back_link(back_link):
+        return back_link
+    else:
+        return None
+
+
+def display_back_link(back_link):
+    if back_link:
+        url = urlparse(back_link)
+        return url.path == "/judgments/results"
+    else:
+        return False


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

This reinstates the 'back to search results' link on individual judgments, which was present in the prototype but broken in such a way that it never displayed in the production django app.

The back link should only show when the user navigates to a judgment from a search results page - I have added tests for this logic.

@matt-blair  I'm not 100% happy with the typography / layout currently at the small breakpoint - I feel that perhaps the back link should be less prominent, but it looks messy in smaller type. Any advice greatly appreciated!



## Trello card / Rollbar error (etc)

https://trello.com/c/d2DvIFNO/958-%F0%9F%8F%86back-to-search-results-button-on-judgements-not-displaying


## Screenshots of UI changes:

### Before
<img width="449" alt="Screenshot 2022-09-21 at 12 07 29" src="https://user-images.githubusercontent.com/4279/191477619-c01a317f-9dcf-42f9-95a6-8324aea55fe8.png">
<img width="1165" alt="Screenshot 2022-09-21 at 12 07 43" src="https://user-images.githubusercontent.com/4279/191477607-1997f4cf-3bbc-46ff-a9dd-6271b2efdb26.png">


### After
<img width="449" alt="Screenshot 2022-09-21 at 12 00 51" src="https://user-images.githubusercontent.com/4279/191477643-1979185d-cfad-43de-9860-8fbd1aaa3666.png">
<img width="1054" alt="Screenshot 2022-09-21 at 12 00 35" src="https://user-images.githubusercontent.com/4279/191477654-75dba10b-7d32-4796-a4e3-bc55812442e5.png">

