### PR TITLE
Add the option to choose the number of search results

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_result_controls.scss
+++ b/ds_judgements_public_ui/sass/includes/_result_controls.scss
@@ -8,22 +8,36 @@
     margin: 0;
   }
 
-  &__order-by-label {
+  form {
+    display: flex;
+    flex-direction: row;
+    gap: $spacer__unit;
+
+    > div {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+    }
+  }
+
+  &__label {
     font-family: $font__roboto;
     font-size: 1rem;
     margin-bottom: calc($spacer__unit / 2);
     display: block;
   }
 
-  &__order-by {
+  &__select {
     @include select;
     min-width: auto;
+    width: auto;
+    padding-right: calc(1.5 * $spacer__unit);
     display: inline-block;
   }
 
   &__button {
     @include call-to-action-button($color__dark-blue, $color__white);
-    margin: 0;
+    margin: calc(2.2 * $spacer__unit) 0 1rem 0;
     font-size: 0.85rem;
     outline-color: $color__dark-blue;
     padding: 0.625rem;

--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -7,16 +7,26 @@
 {% if context.query %}
   <form method="get" action="{{request.path}}" id="analytics-result-controls">
       {% for key, value in context.query_params.items %}
-        {% if key != "order" %}
+        {% if key != "order" or key != "per_page" %}
           <input type="hidden" name="{{key}}" value="{{value}}" />
         {% endif %}
       {% endfor %}
-      <label for="order_by">Order results by</label>
-      <select class="result-controls__order-by" id="order_by" name="order">
+      <div>
+      <label for="order_by" class="result-controls__label">Order results by</label>
+      <select class="result-controls__select" id="order_by" name="order">
         <option value="relevance" {% if context.order == "relevance" or context.order is None %}selected='selected'{% endif %}>Relevance</option>
         <option value="-date" {% if context.order == "-date" %}selected='selected'{% endif %}>Date descending</option>
         <option value="date" {% if context.order == "date" %}selected='selected'{% endif %}>Date ascending</option>
       </select>
+      </div>
+      <div>
+      <label for="per_page" class="result-controls__label">Results per page</label>
+      <select class="result-controls__select" id="per_page" name="per_page">
+        <option value="10" {% if context.per_page == "10" or context.per_page is None %}selected='selected'{% endif %}>10</option>
+        <option value="25" {% if context.per_page == "25" %}selected='selected'{% endif %}>25</option>
+        <option value="50" {% if context.per_page == "50" %}selected='selected'{% endif %}>50</option>
+      </select>
+    </div>
       <input type="submit" value="Go" class="result-controls__button">
   </form>
 {% endif %}

--- a/ds_judgements_public_ui/templates/includes/results_applied_filters.html
+++ b/ds_judgements_public_ui/templates/includes/results_applied_filters.html
@@ -1,19 +1,21 @@
 {% load query_filters %}
 {% if context.query_params.items %}
-  <h2 class="results-search-component__sub-header">Filters include (select any to remove)</h2>
-  <ul class="results-search-component__removable-options">
-    {% for key, value in context.query_params.items %}
-      {% if value and key != 'order' %}
+<h2 class="results-search-component__sub-header">Filters include (select any to remove)</h2>
+<ul class="results-search-component__removable-options">
+  {% for key, value in context.query_params.items %}
+    {% if value %}
+      {% if key != 'order' and key != 'per_page' %}
         <li>
           <a role="button" draggable="false" class="results-search-component__removable-options-link"
-             href="{% url 'advanced_search' %}?{{ context.query_params|remove_query:key }}">
-            <span class="results-search-component__removable-options-key">{{ key|capfirst }}:</span>
-            <span class="results-search-component__removable-options-value">
-          <span class="results-search-component__removable-options-value-text">{{ value }}</span>
-        </span>
+              href="{% url 'advanced_search' %}?{{ context.query_params|remove_query:key }}">
+              <span class="results-search-component__removable-options-key">{{ key|capfirst }}:</span>
+              <span class="results-search-component__removable-options-value">
+                <span class="results-search-component__removable-options-value-text">{{ value }}</span>
+              </span>
           </a>
         </li>
       {% endif %}
-    {% endfor %}
-  </ul>
+    {% endif %}
+  {% endfor %}
+</ul>
 {% endif %}

--- a/ds_judgements_public_ui/templates/includes/results_search_component.html
+++ b/ds_judgements_public_ui/templates/includes/results_search_component.html
@@ -1,5 +1,11 @@
 <div class="results-search-component">
   <form action="{% url 'advanced_search' %}" id="analytics-results-filters">
+    {% if context.per_page is not None %}
+      <input type="hidden" name="per_page" value="{{context.per_page}}" />
+    {% endif %}
+    {% if context.order is not None %}
+      <input type="hidden" name="order" value="{{context.order}}" />
+    {% endif %}
 
     <div class="results-search-component__container">
       {% include 'includes/results_search_field.html' %}

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from caselawclient.Client import api_client
+from caselawclient.Client import RESULTS_PER_PAGE, api_client
 from requests_toolbelt.multipart import decoder
 
 from .models import SearchResults
@@ -25,6 +25,7 @@ def perform_advanced_search(
     date_from=None,
     date_to=None,
     page=1,
+    per_page=RESULTS_PER_PAGE,
 ):
     response = api_client.advanced_search(
         q=query,
@@ -37,6 +38,7 @@ def perform_advanced_search(
         order=order,
         date_from=date_from,
         date_to=date_to,
+        page_size=per_page,
     )
     multipart_data = decoder.MultipartDecoder.from_response(response)
     return SearchResults.create_from_string(multipart_data.parts[0].text)

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -33,6 +33,8 @@ from .utils import perform_advanced_search
 
 env = environ.Env()
 
+MAX_RESULTS_PER_PAGE = 50
+
 
 def browse(request, court=None, subdivision=None, year=None):
     court_query = "/".join(filter(lambda x: x is not None, [court, subdivision]))
@@ -107,6 +109,9 @@ def advanced_search(request):
     per_page = (
         params.get("per_page") if params.get("per_page") else str(RESULTS_PER_PAGE)
     )
+    if int(per_page) > MAX_RESULTS_PER_PAGE:
+        per_page = str(MAX_RESULTS_PER_PAGE)
+
     order = query_params["order"]
     # If there is no query, order by -date, else order by relevance
     if not order and not query_params["query"]:
@@ -245,6 +250,9 @@ def results(request):
         per_page = (
             params.get("per_page") if params.get("per_page") else str(RESULTS_PER_PAGE)
         )
+        if int(per_page) > MAX_RESULTS_PER_PAGE:
+            per_page = str(MAX_RESULTS_PER_PAGE)
+
         if query:
             order = params.get("order", default="-relevance")
             model = perform_advanced_search(

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -284,7 +284,7 @@ def results(request):
     return TemplateResponse(request, template, context={"context": context})
 
 
-def paginator(current_page, total, size_per_page):
+def paginator(current_page, total, size_per_page=RESULTS_PER_PAGE):
     number_of_pages = math.ceil(int(total) / size_per_page)
     next_pages = list(
         range(current_page + 1, min(current_page + 10, number_of_pages) + 1)


### PR DESCRIPTION
## Changes in this PR:

Users can choose either 10, 25, or 50 results to be shown per page in the results page and in the advanced search.

This also fixes a bug whereby if the user refined their search filters, the search order selected would be forgotten.

## Trello card / Rollbar error (etc)

https://trello.com/c/TyBKKRXo/986-%F0%9F%8F%86see-more-search-results-option-for-10-20-50-per-page

## Screenshots of UI changes:

### Before

<img width="446" alt="Screenshot 2022-09-21 at 16 59 15" src="https://user-images.githubusercontent.com/4279/191539600-a5dbcd20-4f79-467b-8771-70b9da3f028c.png">
<img width="1270" alt="Screenshot 2022-09-21 at 16 59 03" src="https://user-images.githubusercontent.com/4279/191539610-ca89da44-a9dc-4b53-9de2-4a7a6beb661b.png">


###
<img width="446" alt="Screenshot 2022-09-21 at 16 59 19" src="https://user-images.githubusercontent.com/4279/191539630-1fa89a0f-bdc0-4470-b44e-ea0bd312f0e5.png">
<img width="1270" alt="Screenshot 2022-09-21 at 16 58 38" src="https://user-images.githubusercontent.com/4279/191539633-9a2e16af-94f8-47e0-b244-69138da00900.png">
 After


