### PR TITLE
Bump the API Client version to 4.10.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,6 @@ requests-toolbelt~=0.9.1
 lxml~=4.9.1
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=4.7
+ds-caselaw-marklogic-api-client~=4.10.0
 rollbar
 django-weasyprint==2.1.0


### PR DESCRIPTION
Among other things, this version bump ensures the public UI is using the renamed XSLT file in Marklogic, `accessible-html.xsl`

