### PR TITLE
Fix/button visited colour

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_results_search_component.scss
+++ b/ds_judgements_public_ui/sass/includes/_results_search_component.scss
@@ -207,6 +207,10 @@
     text-decoration: none;
     padding: calc($spacer__unit / 2) $spacer__unit;
 
+    &:visited {
+      color: $color__black;
+    }
+
     &:hover {
       color: $color__white;
       background: $color__black;
@@ -241,6 +245,10 @@
       &:focus {
         @include focus-default;
         text-decoration: underline;
+      }
+
+      &:visited {
+        color: $color__black;
       }
 
       &:hover {

--- a/ds_judgements_public_ui/sass/includes/_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_search.scss
@@ -40,7 +40,7 @@
       &:visited {
         color: $color__black;
       }
-      
+
       &:hover {
         text-decoration: underline;
         color: $color__black;

--- a/ds_judgements_public_ui/sass/includes/_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_search.scss
@@ -37,6 +37,10 @@
       font-family: $font__roboto;
       font-weight: bold;
 
+      &:visited {
+        color: $color__black;
+      }
+      
       &:hover {
         text-decoration: underline;
         color: $color__black;


### PR DESCRIPTION
<!-- Amend as appropriate -->
Fixed  visited colour change on the text for search tag buttons and also 'Show more filters text so that they remain black. 
## Changes in this PR:

## Trello card 989

## Screenshots of UI changes:

### Before
![Screenshot 2022-09-22 at 10 09 16](https://user-images.githubusercontent.com/102584881/191716840-15811dc7-789f-4998-b996-b3a75aacd7e2.png)
![Screenshot 2022-09-22 at 10 55 14](https://user-images.githubusercontent.com/102584881/191717469-c8f8d3d7-8e17-409f-918f-f894115e812c.png)



### After
![Screenshot 2022-09-22 at 10 09 51](https://user-images.githubusercontent.com/102584881/191716760-158b3f2e-f328-49d4-bf97-9696f76f87e8.png)
![Screenshot 2022-09-22 at 10 01 35](https://user-images.githubusercontent.com/102584881/191717115-ab978ba2-6abb-4b46-b1a6-8803bed8b650.png)

- [ ] Requires env variable(s) to be updated
