### PR TITLE
Fix alignment of download button 

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -80,7 +80,14 @@
   }
 }
 
-.judgment-download {
+.judgment-toolbar-download {
+
+  margin: 0 auto;
+
+  @media (min-width: $grid__breakpoint-small) {
+    margin-left: auto;
+    margin-right: 0;
+  }
 
   &__option--pdf {
     margin: 0 !important;

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -7,9 +7,9 @@
             </div>
         {% endif %}
 
-        <div class="judgment-toolbar__download">
-            <a class="judgment-download__option--pdf" role="button" draggable="false" href="{% url 'detail_pdf' context.judgment_uri %}">{% translate "judgment.downloadaspdf" %}{{context.pdf_size}}</a>
-            <p class="judgment-download__download-options" role="note"><a href="#download-options">{% translate "judgment.downloadoptions.shortcutlink" %}</a></p>
+        <div class="judgment-toolbar__download judgment-toolbar-download">
+            <a class="judgment-toolbar-download__option--pdf" role="button" draggable="false" href="{% url 'detail_pdf' context.judgment_uri %}">{% translate "judgment.downloadaspdf" %}{{context.pdf_size}}</a>
+            <p class="judgment-toolbar-download__download-options" role="note"><a href="#download-options">{% translate "judgment.downloadoptions.shortcutlink" %}</a></p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Changes in this PR:

Fixes alignment of download button when the 'back to search results' link isn't displayed.

This was incorrectly ranged left, when it should have been flush with the right margin.


## Trello card / Rollbar error (etc)

https://trello.com/c/nKO2UJWj/990-download-link-layout-bug-regression-caused-by-introducing-back-to-search-results-link

## Screenshots of UI changes:

### Before
<img width="843" alt="Screenshot 2022-09-22 at 12 01 47" src="https://user-images.githubusercontent.com/4279/191725942-0aa93e2c-8778-4840-a766-a1c68155bf9d.png">



### After

<img width="843" alt="image" src="https://user-images.githubusercontent.com/4279/191726068-c235c0b3-f30c-419f-8239-49cda03bb10b.png">


