### PR TITLE
Show back link on judgments when navigating from advanced search

### DIFF
--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -279,16 +279,23 @@ class TestRobotsDirectives(TestCase):
 
 
 class TestBackLink(TestCase):
-    def test_no_referrer(self):
-        # When there is no referrer, the back link is not displayed:
-        self.assertIs(display_back_link(None), False)
-
-    def test_refererrer_not_results_page(self):
-        # When there is a referrer, but it is not a results page,
-        # the back link is not displayed:
-        self.assertIs(display_back_link("https://example.com/any/other/path"), False)
-
     def test_referrer_is_results_page(self):
         # When there is a referrer, and it is a results page,
         # the back link is displayed:
         self.assertIs(display_back_link("https://example.com/judgments/results"), True)
+
+    def test_referrer_is_advanced_search_page(self):
+        # When there is a referrer and it is the advanced search page,
+        # the back link is displayed:
+        self.assertIs(
+            display_back_link("https://example.com/judgments/advanced_search"), True
+        )
+
+    def test_refererrer_not_results_or_advanced_search_page(self):
+        # When there is a referrer, but it is not a results page
+        # or the advanced search page, the back link is not displayed:
+        self.assertIs(display_back_link("https://example.com/any/other/path"), False)
+
+    def test_no_referrer(self):
+        # When there is no referrer, the back link is not displayed:
+        self.assertIs(display_back_link(None), False)

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -326,6 +326,6 @@ def get_back_link(request):
 def display_back_link(back_link):
     if back_link:
         url = urlparse(back_link)
-        return url.path == "/judgments/results"
+        return url.path in ["/judgments/results", "/judgments/advanced_search"]
     else:
         return False


### PR DESCRIPTION
## Changes in this PR:

This was an oversight in the initial implementation of the back link! It only showed up from the simple keyword search URL, not when other filters were applied.

## Trello card / Rollbar error (etc)

https://trello.com/c/8LpC79SR/991-show-back-to-search-results-when-coming-from-advanced-search-page