### PR TITLE
Add the 'results per page' selector to the 'recent judgements' list and browse pages

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_results.scss
+++ b/ds_judgements_public_ui/sass/includes/_results.scss
@@ -11,8 +11,7 @@
 
   &__result-header {
     @media (min-width: $grid__breakpoint-large) {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
+      margin-bottom: $spacer__unit;
     }
   }
 
@@ -29,7 +28,7 @@
 
      @media (min-width: $grid__breakpoint-extra-large) {
        display: flex;
-       align-items: flex-start;
+       align-items: flex-end;
        justify-content: space-between;
      }
    }

--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -29,5 +29,17 @@
     </div>
       <input type="submit" value="Go" class="result-controls__button">
   </form>
+{% else %}
+<form method="get" action="{{request.path}}" id="analytics-result-controls">
+  <div>
+  <label for="per_page" class="result-controls__label">Results per page</label>
+  <select class="result-controls__select" id="per_page" name="per_page">
+    <option value="10" {% if context.per_page == "10" or context.per_page is None %}selected='selected'{% endif %}>10</option>
+    <option value="25" {% if context.per_page == "25" %}selected='selected'{% endif %}>25</option>
+    <option value="50" {% if context.per_page == "50" %}selected='selected'{% endif %}>50</option>
+  </select>
+</div>
+  <input type="submit" value="Go" class="result-controls__button">
+</form>
 {% endif %}
 </div>

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -276,12 +276,12 @@ def results(request):
             context["query_params"] = {"query": query, "order": order}
         else:
             order = params.get("order", default="-date")
-            model = perform_advanced_search(order=order, page=page)
+            model = perform_advanced_search(order=order, page=page, per_page=per_page)
             search_results = [
                 SearchResult.create_from_node(result) for result in model.results
             ]
             context["recent_judgments"] = search_results
-
+            context["per_page"] = per_page
             context["total"] = model.total
             context["search_results"] = search_results
             context["order"] = order

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -40,6 +40,16 @@ MAX_RESULTS_PER_PAGE = 50
 def browse(request, court=None, subdivision=None, year=None):
     court_query = "/".join(filter(lambda x: x is not None, [court, subdivision]))
     page = request.GET.get("page", 1)
+
+    per_page = (
+        request.GET.get("per_page")
+        if request.GET.get("per_page")
+        else str(RESULTS_PER_PAGE)
+    )
+
+    if int(per_page) > MAX_RESULTS_PER_PAGE:
+        per_page = str(MAX_RESULTS_PER_PAGE)
+
     context = {}
 
     try:
@@ -53,12 +63,14 @@ def browse(request, court=None, subdivision=None, year=None):
             else None,
             order="-date",
             page=int(page or 1),
+            per_page=int(per_page),
         )
         context["search_results"] = [
             SearchResult.create_from_node(result) for result in model.results
         ]
         context["total"] = model.total
-        context["paginator"] = paginator(int(page), model.total, RESULTS_PER_PAGE)
+        context["per_page"] = per_page
+        context["paginator"] = paginator(int(page), model.total, int(per_page))
     except MarklogicResourceNotFoundError:
         raise Http404("Search failed")  # TODO: This should be something else!
     template = loader.get_template("judgment/results.html")


### PR DESCRIPTION

## Changes in this PR:

As requested by Rose. Also fixes a layout bug when >9999 results are returned.