### PR TITLE
Content Security Policy headers

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -123,6 +123,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
+    "csp.middleware.CSPMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.common.BrokenLinkEmailsMiddleware",
@@ -246,3 +247,23 @@ LOGGING = {
 
 # Your stuff...
 # ------------------------------------------------------------------------------
+
+# Content-Security-Policy configuration
+
+CSP_DEFAULT_SRC = ["'self'"]
+CSP_FONT_SRC = ["fonts.gstatic.com"]
+# unsafe-inline required by HTML view of judgment having many inline styles
+CSP_STYLE_SRC = ["fonts.googleapis.com", "'unsafe-inline'", "'self'"]
+CSP_SCRIPT_SRC = [
+    "www.google-analytics.com",
+    "www.googletagmanager.com",
+    "'sha256-IWjjekDxqqURWMjVH447fuaAvoZKwpDwLS0ZdcJ+Ey4='",
+    "'self'",
+]
+
+# unsafe data: required by css on structured_search wanting a downward arrow from css/main.css
+CSP_IMG_SRC = ["'self'", "data:"]
+CSP_REPORT_URI = (
+    "/content-security-policy-reporter"  # somewhere JSON data can get posted
+)
+CSP_REPORT_ONLY = False  # We need to change this to True when we're happy it's right

--- a/config/urls.py
+++ b/config/urls.py
@@ -67,6 +67,11 @@ urlpatterns = [
         "robots.txt",
         TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
     ),
+    path(
+        "content-security-policy-reporter",
+        views.csp_view,
+        name="csp",
+    ),
     path("", include("judgments.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 

--- a/config/views.py
+++ b/config/views.py
@@ -1,5 +1,12 @@
+import rollbar
+from django.http import HttpResponse
 from django.utils.translation import gettext
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
+
+
+class ContentSecurityPolicyReport(Exception):
+    pass
 
 
 class TemplateViewWithContext(TemplateView):
@@ -52,3 +59,16 @@ class WhatToExpectView(TemplateViewWithContext):
 
 class HowToUseThisService(TemplateViewWithContext):
     template_name = "pages/how_to_use_this_service.html"
+
+
+@csrf_exempt
+def csp_view(request):
+    if request.method == "POST":
+        data = request.body
+        rollbar.report_message(f"CSP report: \n{data}", "warning")
+        return HttpResponse("Thanks.", status=200)
+    else:
+        return HttpResponse(
+            "This page is for browsers to submit Content Security Policy errors.",
+            status=405,
+        )

--- a/ds_judgements_public_ui/templates/base.html
+++ b/ds_judgements_public_ui/templates/base.html
@@ -29,6 +29,8 @@
   </head>
 
   <body>
+    {# if you change this script, you will need to change the sha256 hash 'IWjjek...' in config/settings/base.html #}
+    {# otherwise the browsers will block this script from running due to the Content-Security-Policy header #}
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ds-judgments-public-ui",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
@@ -2087,14 +2088,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001311",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001311.tgz",
-      "integrity": "sha512-mleTFtFKfykEeW34EyfhGIFjGCqzhh38Y0LhdQ9aWF+HorZTtdgKV/1hEE0NlFkG2ubvisPV6l400tlbPys98A==",
+      "version": "1.0.30001412",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
+      "integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -5065,9 +5072,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001311",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001311.tgz",
-      "integrity": "sha512-mleTFtFKfykEeW34EyfhGIFjGCqzhh38Y0LhdQ9aWF+HorZTtdgKV/1hEE0NlFkG2ubvisPV6l400tlbPys98A==",
+      "version": "1.0.30001412",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
+      "integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==",
       "dev": true
     },
     "chalk": {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,3 +19,4 @@ wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client~=5.0.0
 rollbar
 django-weasyprint==2.1.0
+django-csp==3.7


### PR DESCRIPTION
We use the `django-csp` library to create CSP headers for us.

We permit a couple of Google URLs to provide script, style and fonts
to us: these can be found on the front page (and probably every page)

The inscrutible sha-256 hash `IWjjek`... refers to the inline script
in `templates/base.py` and appears to be the only inline script in
the public-ui.

There's two bigger problems:

* HTML versions of the judgments have a great many inline styles. These
are taken directly from the word document. We don't have a good way
of not using inline styles here right now.

* `data:` uris are used in the CSS, but isn't secure. It's fine, because the
CSS isn't dynamically generated, but I can't see an obvious way to
allow the CSS to use `data:`

We've set it to report only for now; it should report CSP issues
to rollbar as warnings. I recommend we run this in production for
a while, and if there's no errors, turn on the actual protection a
little later.

Or possibly this is only useful as an understanding of the challenges we'd face if we wanted to tighten up Content Security.