### PR TITLE
Use v5 of custom-api-client

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,6 @@ requests-toolbelt~=0.9.1
 lxml~=4.9.1
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=4.10.0
+ds-caselaw-marklogic-api-client~=5.0.0
 rollbar
 django-weasyprint==2.1.0


### PR DESCRIPTION
We want to support King's/Queen's Bench Division and Costs/SCCO mergers, but that requires changing the interface between the XQuery and the Custom API client to use version 2 of the search XQuery and version 5 of the custom-api-client.