### PR TITLE
Court URIs and per-page bug

### DIFF
--- a/ds_judgements_public_ui/static/js/src/modules/document_navigation_links.js
+++ b/ds_judgements_public_ui/static/js/src/modules/document_navigation_links.js
@@ -50,7 +50,12 @@ $(() => {
                 });
         }
     }
-
-    createObserver(document.querySelector(".judgments-footer"));
-    createObserver(document.querySelector(".judgment-toolbar__container"));
+    let judgmentsFooter = document.querySelector(".judgments-footer");
+    let judgmentsToolbarContainer = document.querySelector(
+        ".judgment-toolbar__container"
+    );
+    if (judgmentsFooter && judgmentsToolbarContainer) {
+        createObserver(judgmentsFooter);
+        createObserver(judgmentsToolbarContainer);
+    }
 });

--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -3,14 +3,14 @@
   <p class="results__results-intro">We found {{ context.total }} judgments</p>
 </div>
 <div class="result-controls">
-
-{% if context.query %}
   <form method="get" action="{{request.path}}" id="analytics-result-controls">
       {% for key, value in context.query_params.items %}
         {% if key != "order" or key != "per_page" %}
           <input type="hidden" name="{{key}}" value="{{value}}" />
         {% endif %}
       {% endfor %}
+
+      {% if context.query %}
       <div>
       <label for="order_by" class="result-controls__label">Order results by</label>
       <select class="result-controls__select" id="order_by" name="order">
@@ -19,27 +19,16 @@
         <option value="date" {% if context.order == "date" %}selected='selected'{% endif %}>Date ascending</option>
       </select>
       </div>
+      {% endif %}
+
       <div>
-      <label for="per_page" class="result-controls__label">Results per page</label>
-      <select class="result-controls__select" id="per_page" name="per_page">
-        <option value="10" {% if context.per_page == "10" or context.per_page is None %}selected='selected'{% endif %}>10</option>
-        <option value="25" {% if context.per_page == "25" %}selected='selected'{% endif %}>25</option>
-        <option value="50" {% if context.per_page == "50" %}selected='selected'{% endif %}>50</option>
-      </select>
-    </div>
+        <label for="per_page" class="result-controls__label">Results per page</label>
+        <select class="result-controls__select" id="per_page" name="per_page">
+          <option value="10" {% if context.per_page == "10" or context.per_page is None %}selected='selected'{% endif %}>10</option>
+          <option value="25" {% if context.per_page == "25" %}selected='selected'{% endif %}>25</option>
+          <option value="50" {% if context.per_page == "50" %}selected='selected'{% endif %}>50</option>
+        </select>
+      </div>
       <input type="submit" value="Go" class="result-controls__button">
   </form>
-{% else %}
-<form method="get" action="{{request.path}}" id="analytics-result-controls">
-  <div>
-  <label for="per_page" class="result-controls__label">Results per page</label>
-  <select class="result-controls__select" id="per_page" name="per_page">
-    <option value="10" {% if context.per_page == "10" or context.per_page is None %}selected='selected'{% endif %}>10</option>
-    <option value="25" {% if context.per_page == "25" %}selected='selected'{% endif %}>25</option>
-    <option value="50" {% if context.per_page == "50" %}selected='selected'{% endif %}>50</option>
-  </select>
-</div>
-  <input type="submit" value="Go" class="result-controls__button">
-</form>
-{% endif %}
 </div>

--- a/ds_judgements_public_ui/templates/includes/structured_search_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/structured_search_inputs.html
@@ -65,7 +65,7 @@
               {% if context.court == 'ewhc/comm' %}selected="selected"{% endif %}>
                 Commercial Court
               </option>
-              <option value="ewhc/costs"
+              <option value="ewhc/scco"
               {% if context.court == 'ewhc/costs' or context.court == 'ewhc/scco' %}selected="selected"{% endif %}>
                 Senior Court Costs Office
               </option>
@@ -85,8 +85,8 @@
               {% if context.court == 'ewhc/pat' %}selected="selected"{% endif %}>
                 Patents Court
               </option>
-              <option value="ewhc/qb"
-              {% if context.court == 'ewhc/qb' %}selected="selected"{% endif %}>
+              <option value="ewhc/kb"
+              {% if context.court == 'ewhc/kb' or context.court == "ewhc/qb" %}selected="selected"{% endif %}>
                 King's / Queen's Bench Division of the High Court
               </option>
               <option value="ewhc/tcc"

--- a/judgments/fixtures/courts.py
+++ b/judgments/fixtures/courts.py
@@ -41,7 +41,7 @@ courts = [
     },
     {
         "name": "Senior Court Costs Office",
-        "href": "/judgments/advanced_search?court=ewhc/costs",
+        "href": "/judgments/advanced_search?court=ewhc/scco",
         "years": "2003 &ndash; 2022",
     },
     {
@@ -66,7 +66,7 @@ courts = [
     },
     {
         "name": "King's / Queen's Bench Division of the High Court",
-        "href": "/judgments/advanced_search?court=ewhc/qb",
+        "href": "/judgments/advanced_search?court=ewhc/kb",
         "years": "2003 &ndash; 2022",
     },
     {


### PR DESCRIPTION

## Changes in this PR:

This was meant to be a bunch of very small uncontroversial tweaks (hence rolling them into one PR): Making sure we use the `kc` and `scco` courts identifiers everywhere instead of their `qc` and `costs` aliases, and ensuring that the "number or search results" option never clears the advanced filters.


However i think there's one aspect that might deserve a little more attention on review as it was a little more complex than I anticipated: In particular the changes to the logic in results_controls.html. Essentially, we want to ensure that the hidden form fields are always rendered when there are *any* query params (so that filters are preserved), but that the "order results" dropdown is only displayed when there is a freetext query string (as 'order by' only makes sense when there's a relevance score). I think this now works as expected, and have tested every permutation I can think of, but another pair of eyes would be great!

Thanks!

Tim




## Trello card / Rollbar error (etc)
1015/1016/1017
