### PR TITLE
Use fields from search results in SearchResult model

### DIFF
--- a/judgments/models.py
+++ b/judgments/models.py
@@ -6,34 +6,6 @@ from djxml import xmlmodels
 from lxml import etree
 
 
-class Judgment(xmlmodels.XmlModel):
-    class Meta:
-        namespaces = {
-            "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
-            "uk": "https://caselaw.nationalarchives.gov.uk/akn",
-        }
-
-    metadata_name = xmlmodels.XPathTextField(
-        "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/"
-        + "akn:FRBRname/@value",
-        ignore_extra_nodes=True,
-    )
-    neutral_citation = xmlmodels.XPathTextField(
-        "//akn:proprietary/uk:cite", ignore_extra_nodes=True
-    )
-    date = xmlmodels.XPathTextField(
-        "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRWork/"
-        + "akn:FRBRdate/@date",
-        ignore_extra_nodes=True,
-    )
-    court = xmlmodels.XPathTextField("//akn:proprietary/uk:court")
-    content_hash = xmlmodels.XPathTextField("//akn:proprietary/uk:hash")
-    transformation_date = xmlmodels.XPathTextField(
-        "/akn:akomaNtoso/akn:judgment/akn:meta/akn:identification/akn:FRBRManifestation/"
-        + "akn:FRBRdate[@name='transform']/@date"
-    )
-
-
 class SearchResult:
     def __init__(
         self,

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -62,14 +62,13 @@ class TestAtomFeed(TestCase):
 
 class TestJudgment(TestCase):
     @patch("judgments.views.requests.head")
-    @patch("judgments.views.Judgment")
     @patch("judgments.views.decoder.MultipartDecoder")
     @patch("judgments.views.api_client")
-    def test_valid_content(self, client, decoder, judgment, head):
+    def test_valid_content(self, client, decoder, head):
         head.return_value.headers = {"Content-Length": "1234567890"}
         client.eval_xslt.return_value = "eval_xslt"
         decoder.MultipartDecoder.from_response.return_value.parts[0].text = "part0text"
-        judgment.create_from_string.return_value.metadata_name = "judgment metadata"
+        client.get_judgment_name.return_value = "judgment metadata"
 
         response = self.client.get("/ewca/civ/2004/632")
         decoded_response = response.content.decode("utf-8")

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -8,7 +8,7 @@ from lxml import etree
 import judgments.models
 import judgments.utils  # noqa: F401 -- used to mock
 from judgments import converters, views
-from judgments.models import Judgment, SearchResult, SearchResults
+from judgments.models import SearchResult, SearchResults
 from judgments.views import display_back_link
 
 
@@ -89,72 +89,6 @@ class TestJudgment(TestCase):
         decoded_response = response.content.decode("utf-8")
         self.assertIn("Page not found", decoded_response)
         self.assertEqual(response.status_code, 404)
-
-
-class TestJudgmentModel(TestCase):
-    def test_can_parse_judgment(self):
-        xml = """
-            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
-                <judgment name="judgment" contains="originalVersion">
-                    <meta>
-                        <identification source="#tna">
-                            <FRBRManifestation>
-                                <FRBRname value="My Judgment Name"/>
-                                <FRBRdate date="2020-01-01T10:30:00" name="transform"/>
-                            </FRBRManifestation>
-                            <FRBRWork>
-                                <FRBRname value="My Judgment Name"/>
-                                <FRBRdate date="2004-06-10T10:30:00" name="judgment"/>
-                            </FRBRWork>
-                        </identification>
-                        <proprietary source="ewca/civ/2004/811/eng/docx"
-                            xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
-                            <uk:court>EWCA-Civil</uk:court>
-                            <uk:cite>[2017] EWHC 3289 (QB)</uk:cite>
-                            <uk:hash>A hash!</uk:hash>
-                        </proprietary>
-                    </meta>
-                </judgment>
-            </akomaNtoso>
-        """
-
-        model = Judgment.create_from_string(xml)
-        self.assertEqual("My Judgment Name", model.metadata_name)
-        self.assertEqual("[2017] EWHC 3289 (QB)", model.neutral_citation)
-        self.assertEqual("2004-06-10T10:30:00", model.date)
-        self.assertEqual("EWCA-Civil", model.court)
-        self.assertEqual("2020-01-01T10:30:00", model.transformation_date)
-        self.assertEqual("A hash!", model.content_hash)
-
-    def test_can_parse_judgment_hearing_date(self):
-        xml = """
-            <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
-                <judgment name="judgment" contains="originalVersion">
-                    <meta>
-                        <identification source="#tna">
-                            <FRBRManifestation>
-                                <FRBRname value="My Judgment Name"/>
-                                <FRBRdate date="2020-01-01T10:30:00" name="transform"/>
-                            </FRBRManifestation>
-                            <FRBRWork>
-                                <FRBRname value="My Judgment Name"/>
-                                <FRBRdate date="2004-06-10T10:30:00" name="hearing"/>
-                            </FRBRWork>
-                        </identification>
-                        <proprietary source="ewca/civ/2004/811/eng/docx"
-                            xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
-                            <uk:court>EWCA-Civil</uk:court>
-                            <uk:cite>[2017] EWHC 3289 (QB)</uk:cite>
-                            <uk:hash>A hash!</uk:hash>
-                        </proprietary>
-                    </meta>
-                </judgment>
-            </akomaNtoso>
-        """
-
-        model = Judgment.create_from_string(xml)
-        self.assertEqual("My Judgment Name", model.metadata_name)
-        self.assertEqual("2004-06-10T10:30:00", model.date)
 
 
 class TestSearchResult(TestCase):

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -28,7 +28,7 @@ from requests_toolbelt.multipart import decoder
 
 from judgments.fixtures.courts import courts
 from judgments.fixtures.tribunals import tribunals
-from judgments.models import Judgment, SearchResult
+from judgments.models import SearchResult
 
 from .utils import perform_advanced_search
 
@@ -87,12 +87,10 @@ def detail(request, judgment_uri):
     if is_published:
         try:
             results = api_client.eval_xslt(judgment_uri)
-            xml_results = api_client.get_judgment_xml(judgment_uri)
             multipart_data = decoder.MultipartDecoder.from_response(results)
             judgment = multipart_data.parts[0].text
-            model = Judgment.create_from_string(xml_results)
             context["judgment"] = judgment
-            context["page_title"] = model.metadata_name
+            context["page_title"] = api_client.get_judgment_name(judgment_uri)
             context["judgment_uri"] = judgment_uri
             context["pdf_size"] = get_pdf_size(judgment_uri)
             context["back_link"] = get_back_link(request)


### PR DESCRIPTION

<!-- Amend as appropriate -->

## Changes in this PR:

~This should not be pushed to production before nationalarchives/ds-caselaw-public-access-service#88 is deployed to Marklogic production.~

Previously, we were getting a judgement's neutral citation, name, court, date and hash by making an API call to Marklogic, getting the judgment XML, and parsing it. We can actually get these elements as part of the search results, and it means we lose an extra call to the API. As we show at least 10 results per page, this means the app will load faster, as we lose at least 10 calls per page.

## Trello card / Rollbar error (etc)

https://trello.com/c/wBZUsMuz

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
