### PR TITLE
Boost Strict Transport Security (force HTTPS) to six days

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -38,7 +38,7 @@ CSRF_COOKIE_SECURE = True
 # https://docs.djangoproject.com/en/dev/topics/security/#ssl-https
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-hsts-seconds
 # TODO: set this to 60 seconds first and then to 518400 once you prove the former works
-SECURE_HSTS_SECONDS = 60
+SECURE_HSTS_SECONDS = 6 * 24 * 3600
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-hsts-include-subdomains
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool(
     "DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS", default=True


### PR DESCRIPTION
WARNING: There is, as far as I can tell, no sensible way of testing this.
Please check my maths.

We currently force HTTPS if the user has used HTTPS in the last sixty seconds.
This gives us confidence that we're not trying to access some resource that isn't, for some reason, available
via HTTPS.

We should improve the protection this gives us, but we also don't want to accidentally lock ourselves out forever should there be an undiscovered problem. Moving to six days (so we reduce the policy to 0, then work on it the week after) gives an intermediary step between "we can't use caselaw.nationalarchives.gov.uk for a year" and "users aren't protected from http downgrades".
