### PR TITLE
Move 'back to top' anchor to the top of the <body>

### DIFF
--- a/ds_judgements_public_ui/templates/layout_judgment_html.html
+++ b/ds_judgements_public_ui/templates/layout_judgment_html.html
@@ -24,12 +24,12 @@
 
     {% include 'includes/gtm/gtm_head.html' %}
 </head>
-<body>
+<body id="start-of-document">
 {% include 'includes/cookie_consent/cookie_banner.html' %}
 <a id="skip-to-main-content" href="#main-content">{% translate "skiplink" %}</a>
 {% include 'includes/gtm/gtm_body.html' %}
 {% include 'includes/phase_banner.html' %}
-<header class="page-header" id="start-of-document">
+<header class="page-header">
   {% include 'includes/breadcrumbs.html' with current=context.page_title title=context.page_title link=request.path %}
   {% include 'includes/logo.html' %}
 </header>


### PR DESCRIPTION

## Changes in this PR:


This fixes an inconsistency where Microsoft Edge didn't scroll to the top of the page.


## Trello card / Rollbar error (etc)

https://trello.com/c/NSGBXPgT/1041-back-to-top-skip-to-end-navigation-covers-banner-after-you-use-back-to-the-top-navigation-at-the-end-of-the-document
