### PR TITLE
Don't highlight stop words in search results

### DIFF
--- a/judgments/search_match.xsl
+++ b/judgments/search_match.xsl
@@ -26,8 +26,16 @@
     </xsl:template>
 
     <xsl:template match="search:highlight">
-        <mark>
-            <xsl:apply-templates/>
-        </mark>
+        <xsl:variable name="lowercase_text" select="translate(text(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')" />
+        <xsl:choose>
+            <xsl:when test="($lowercase_text = 'of')
+            or ($lowercase_text = 'the')
+            or ($lowercase_text = 'and')"/>
+            <xsl:otherwise>
+                <mark>
+                    <xsl:apply-templates/>
+                </mark>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 </xsl:stylesheet>

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -7,7 +7,7 @@ from lxml import etree
 
 import judgments.models
 import judgments.utils  # noqa: F401 -- used to mock
-from judgments import converters, views
+from judgments import converters, utils, views
 from judgments.models import SearchResult, SearchResults
 from judgments.views import display_back_link
 
@@ -318,3 +318,15 @@ def test_min_max():
     assert views.as_integer(2, minimum=1, maximum=3) == 2
     assert views.as_integer(None, minimum=1, default=4) == 4
     assert views.as_integer(None, minimum=1) == 1
+
+
+def test_prep_query():
+    assert utils.remove_unquoted_stop_words("weight of evidence") == "weight evidence"
+    assert (
+        utils.remove_unquoted_stop_words("'weight of evidence'")
+        == "'weight of evidence'"
+    )
+    assert utils.remove_unquoted_stop_words("the") == "the"
+    assert utils.remove_unquoted_stop_words("'the'") == "'the'"
+    assert utils.remove_unquoted_stop_words("judge and jury") == "judge jury"
+    assert utils.remove_unquoted_stop_words('"judge and jury"') == '"judge and jury"'

--- a/judgments/views.py
+++ b/judgments/views.py
@@ -31,6 +31,7 @@ from judgments.fixtures.courts import courts
 from judgments.fixtures.tribunals import tribunals
 from judgments.models import SearchResult
 
+from . import utils
 from .utils import perform_advanced_search
 
 env = environ.Env()
@@ -159,8 +160,9 @@ def advanced_search(request):
     context = {}
 
     try:
+        query_without_stop_words = utils.remove_unquoted_stop_words(params.get("query"))
         model = perform_advanced_search(
-            query=query_params["query"],
+            query=query_without_stop_words,
             court=query_params["court"],
             judge=query_params["judge"],
             party=query_params["party"],


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

https://trello.com/c/Ry47hPz5

This PR does two things:

1. Does not highlight any individual stop words (`the, of, and`) in search result snippets. If the stop words are in a quoted string, they are highlighted (e.g. "weight of evidence"). But if they are individual stop words in an unquoted string, they are not highlighted.

2. If a search query is unquoted and contains stop words (the, and, of), do not pass
those stop words to the search query. Unless the stop word is the only word, in which case pass it through. If the query is quoted (e.g. "weight of evidence") then do not remove the stop
words.

## Screenshots of UI changes:

Both searches are for `evidence of wrongdoing` (without quotes)

### Before

<img width="1286" alt="Screenshot 2022-10-17 at 11 19 15" src="https://user-images.githubusercontent.com/1089521/196153323-a72c2c60-0897-4d17-a2a7-f9efeec0c3bf.png">


### After

<img width="1203" alt="Screenshot 2022-10-17 at 11 18 48" src="https://user-images.githubusercontent.com/1089521/196153341-1cc487de-93d9-4e39-aa07-9c498cf2cf2d.png">


- [ ] Requires env variable(s) to be updated
