### PR TITLE
Ensure that courts filters are preserved on changing pagination params

### DIFF
--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -5,7 +5,11 @@
 <div class="result-controls">
   <form method="get" action="{{request.path}}" id="analytics-result-controls">
       {% for key, value in context.query_params.items %}
-        {% if key != "order" or key != "per_page" %}
+        {% if key == "court" %}
+          {% for court in value %}
+            <input type="hidden" name="court" value="{{court}}" />
+          {% endfor %}
+        {% elif key != "order" or key != "per_page" %}
           <input type="hidden" name="{{key}}" value="{{value}}" />
         {% endif %}
       {% endfor %}


### PR DESCRIPTION

The change to multiple-select for courts introduced a regression here - changing the page size or sort order lost the selected courts. This fixes it!
