### PR TITLE
Require Judgment URIs to be /year/id terminated

### DIFF
--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -34,18 +34,20 @@ urlpatterns = [
         name="feed",
     ),
     re_path(
-        "(?P<judgment_uri>.*/.*/.*)/data.pdf",
+        r"(?P<judgment_uri>.*/\d{4}/\d+)/data.pdf",
         views.get_best_pdf,
         name="detail_pdf",
     ),
     re_path(
-        "(?P<judgment_uri>.*/.*/.*)/generated.pdf",
+        r"(?P<judgment_uri>.*/\d{4}/\d+)/generated.pdf",
         views.PdfDetailView.as_view(),
         name="weasy_pdf",
     ),
-    re_path("(?P<judgment_uri>.*/.*/.*)/data.xml", views.detail_xml, name="detail_xml"),
-    re_path("(?P<judgment_uri>.*/.*/.*)/data.html", views.detail, name="detail"),
-    re_path("(?P<judgment_uri>.*/.*/.*)", views.detail, name="detail"),
+    re_path(
+        r"(?P<judgment_uri>.*/\d{4}/\d+)/data.xml", views.detail_xml, name="detail_xml"
+    ),
+    re_path(r"(?P<judgment_uri>.*/\d{4}/\d+)/data.html", views.detail, name="detail"),
+    re_path(r"(?P<judgment_uri>.*/\d{4}/\d+)", views.detail, name="detail"),
     path("judgments/results", views.results, name="results"),
     path("judgments/advanced_search", views.advanced_search, name="advanced_search"),
     path("", views.index, name="home"),


### PR DESCRIPTION
Invalid paths like /2022/123/generated.pdf can be parsed as a judgment uri with court 2022, year 123 and id generated.pdf, leading to 500 errors. We tighten up the paths a little so they have to have a 4-digit 'year' in the penultimate place and end with a numeric 'identifier', so that we don't get the wrong information in the wrong place.

It might be worth validating the judgment uri more closely (does it start with a known court or court/subcourt combo before the numbers?)

Should resolve https://rollbar.com/dxw/tna-caselaw-public-ui/items/111/
