### PR TITLE
BUGFIX: in-page navigation links continue showing over header.

### DIFF
--- a/ds_judgements_public_ui/static/js/src/modules/document_navigation_links.js
+++ b/ds_judgements_public_ui/static/js/src/modules/document_navigation_links.js
@@ -1,13 +1,15 @@
 import $ from "jquery";
 
 const handler = (entries) => {
-    manageClass(entries[0].isIntersecting);
+    manageClass(entries.some((elem) => elem.isIntersecting));
 };
 
-const createObserver = (element) => {
+const createObserver = (elements) => {
     const options = { root: null, rootMargin: "0px" };
     const observer = new IntersectionObserver(handler, options);
-    observer.observe(element);
+    elements.forEach((element) => {
+        observer.observe(element);
+    });
 };
 
 const manageClass = (intersecting) => {
@@ -18,7 +20,7 @@ const manageClass = (intersecting) => {
 
     if (intersecting && pageScrolls) {
         backToTopLinkContainer.classList.remove("show");
-    } else {
+    } else if (pageScrolls) {
         backToTopLinkContainer.classList.add("show");
     }
 };
@@ -55,7 +57,6 @@ $(() => {
         ".judgment-toolbar__container"
     );
     if (judgmentsFooter && judgmentsToolbarContainer) {
-        createObserver(judgmentsFooter);
-        createObserver(judgmentsToolbarContainer);
+        createObserver([judgmentsFooter, judgmentsToolbarContainer]);
     }
 });


### PR DESCRIPTION
## Changes in this PR:

So, this turned out to be a horrible non-deterministic thing, so it took a while both to replicate and to track down. We use IntersectionObservers to test whether either the page header or footer is visible in the viewport, and hide the in page navigation links when that is the case. However, by using two seperate observers, we opened the door to a concurrency bug whereby if the 'footer' observer was called after the 'header' one, the links would be set to 'show', over the top of the header. Thankfully, IntersectionObservers can apply to multiple elements, so i've refactored to use a single observer on both elements which fixes the problem.


## Trello card / Rollbar error (etc)

https://trello.com/c/NSGBXPgT/1041-back-to-top-skip-to-end-navigation-covers-banner-after-you-use-back-to-the-top-navigation-at-the-end-of-the-document
