### PR TITLE
Removing search filters does not return to the top of the result list

### DIFF
--- a/judgments/templatetags/query_filters.py
+++ b/judgments/templatetags/query_filters.py
@@ -19,6 +19,7 @@ def make_query_string(params):
 @register.filter
 def remove_query(query_params, key):
     params = dict(query_params)
+    params["page"] = None
     params[key] = None
     return make_query_string(params)
 
@@ -26,5 +27,6 @@ def remove_query(query_params, key):
 @register.filter
 def remove_court(query_params, court):
     params = dict(query_params)
+    params["page"] = None
     params["court"] = [court2 for court2 in params.get("court", []) if court != court2]
     return make_query_string(params)


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR:

This was probably an earlier oversight on my part- if you expand your search by removing a filter, it doesn't make sense to retain the page number you're currently on, as you're viewing an entirely different result set. This changes the behaviour to consistenly send you back to the first page when the scope of the search query is changed.
## Trello card / Rollbar error (etc)

https://trello.com/c/0s3s0fOj/1072-possible-bug-removing-filters-in-advanced-search-does-not-reset-pagination