### PR TITLE
Remove 'adjacent line' centering rule in judgment css

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text.scss
@@ -156,10 +156,6 @@
 
   &__line-separator {
     text-align: center;
-
-    ~p {
-      text-align: center;
-    }
   }
 
   &__queens-counsel {


### PR DESCRIPTION
This removes a rather arcane CSS rule that centers any text immediately following a horizontal rule, because it's now been superceded by the new centering mechanism, and is causing weird problems elsewhere.
