### PR TITLE
Fix empty results bug when browsing by court

### DIFF
--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -5,12 +5,14 @@
 <div class="result-controls">
   <form method="get" action="{{request.path}}" id="analytics-result-controls">
       {% for key, value in context.query_params.items %}
-        {% if key == "court" %}
-          {% for court in value %}
-            <input type="hidden" name="court" value="{{court}}" />
-          {% endfor %}
-        {% elif key != "order" or key != "per_page" %}
-          <input type="hidden" name="{{key}}" value="{{value}}" />
+        {% if value != None %}
+          {% if key == "court" %}
+            {% for court in value %}
+              <input type="hidden" name="court" value="{{court}}" />
+            {% endfor %}
+          {% elif key != "order" or key != "per_page" %}
+            <input type="hidden" name="{{key}}" value="{{value}}" />
+          {% endif %}
         {% endif %}
       {% endfor %}
 


### PR DESCRIPTION
## Changes in this PR:
When browsing by court from the homepage, and changing the number of results per page, no courts were returned. This was because the form to change the number of results per page was including Null parameters as hidden fields in error - have added a check to make sure these are not added to the query.

## Trello card / Rollbar error (etc)
https://trello.com/c/Pe6F0tx5/44-browsing-into-a-court-and-changing-search-results-adds-all-advanced-filters-to-search-with-none-value-leading-to-0-results


