### PR TITLE
Add the full court name as a tooltip to the court filter buttons

### DIFF
--- a/ds_judgements_public_ui/templates/includes/results_applied_filters.html
+++ b/ds_judgements_public_ui/templates/includes/results_applied_filters.html
@@ -1,4 +1,4 @@
-{% load query_filters %}
+{% load query_filters court_utils %}
 {% if context.query_params.items %}
 {% if context.filtered %}
   <h2 class="results-search-component__sub-header">Current filters:</h2>
@@ -20,7 +20,8 @@
         {% for court in value %}
           <li>
             <a role="button" tabindex="0" draggable="false" class="results-search-component__removable-options-link"
-                href="{% url 'advanced_search' %}?{{ context.query_params|remove_court:court }}">
+                href="{% url 'advanced_search' %}?{{ context.query_params|remove_court:court }}"
+                title="{{court|get_court_name}}">
                 <span class="results-search-component__removable-options-key">{{ key|capfirst }}:</span>
                 <span class="results-search-component__removable-options-value">
                   <span class="results-search-component__removable-options-value-text">{{ court }}</span>

--- a/judgments/templatetags/court_utils.py
+++ b/judgments/templatetags/court_utils.py
@@ -1,0 +1,12 @@
+from django import template
+from ds_caselaw_utils import courts as all_courts
+
+register = template.Library()
+
+
+@register.filter
+def get_court_name(court):
+    court_object = all_courts.get_by_param(court)
+    if court_object is None:
+        return ""
+    return court_object.name

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -9,6 +9,7 @@ import judgments.models
 import judgments.utils  # noqa: F401 -- used to mock
 from judgments import converters, utils, views
 from judgments.models import SearchResult, SearchResults
+from judgments.templatetags.court_utils import get_court_name
 from judgments.views import display_back_link
 
 
@@ -342,3 +343,11 @@ def test_solo_stop_word_regex():
     stop_words = ["and", "of", "the", "for"]
     expected_output = r"(^and$)|(^of$)|(^the$)|(^for$)"
     assert utils.solo_stop_word_regex(stop_words) == expected_output
+
+
+def test_get_court_name():
+    assert get_court_name("uksc") == "United Kingdom Supreme Court"
+
+
+def test_get_court_name_non_existent():
+    assert get_court_name("ffff") == ""


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR:

Display the full court name as a tooltip on the search filters.

Adding it as a tooltip was suggsted by the designers to avoid significantly changing the filter layout. The full court names are much longer than the court short codes.

## Trello card / Rollbar error (etc)

https://trello.com/c/UbMIEd7S/42-pui-search-results-should-return-court-name-instead-of-abbreviations

## Screenshots of UI changes:

### After

<img width="1124" alt="Screenshot 2022-10-31 at 16 04 46" src="https://user-images.githubusercontent.com/1089521/199054185-2b267340-1756-4a55-ba8e-3a279202f645.png">


- [ ] Requires env variable(s) to be updated
