### PR TITLE
Add a note about edits to the shared CSS bing picked up in the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ Instead, we share the judgment CSS between both apps. This repository is the
 production release, will be reflected in `ds-caselaw-editor-ui` (note that the changes have to be included in
 [a release](https://github.com/nationalarchives/ds-caselaw-public-ui/releases) before they are used in the editor).
 
+Note that if a release is made on `ds-caselaw-public-ui` which contains edits to this CSS, a deployment will need to be
+made to `ds-caselaw-editor-ui` to force that app to pick up the new version of the CSS. A deployment can be made via
+dalmatian, without needing to do a full release of the editor.
+
 `_judgment_text.scss` only contains styles for the HTML judgment view. Other CSS styles for the public UI and editor
 UI applications are not shared.
 


### PR DESCRIPTION
Because the editor only picks up the shared CSS on release/deployment, if the public UI does a release containing changes to the shared CSS the editor will need to be redeployed to pick up the new version.

<!-- Amend as appropriate -->

## Changes in this PR:

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
