### PR TITLE
Feature/judgment tables styles

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text.scss
@@ -205,6 +205,17 @@
 
 .judgment-body {
 
+  table {
+    border: 1px solid $color__almost-black;
+    margin:  1rem auto;
+    table-layout: auto;
+    width: 100%;
+
+    td {
+      border: 1px solid $color__almost-black;
+    }
+  }
+
   h3 {
     font-size: 1rem;
   }


### PR DESCRIPTION
<!-- Amend as appropriate -->
## Changes in this PR:

- Made basic style improvements to Judgement content tables that better matched the judgement document PDF.
- Added margin above and below the table so it kicked away from the surrounding content.

## Trello card / Rollbar error (etc)

trello.com/c/fom57IA8/43-discuss-incremental-improvements-to-the-html-presentation-of-tables

## Screenshots of UI changes:

### Before
![no-table-style](https://user-images.githubusercontent.com/102584881/199463175-33e6c271-59e6-4c74-a6c7-22883d35f9af.png)

### After
![With-basic-table-style](https://user-images.githubusercontent.com/102584881/199463490-b6f128e0-b0a5-457e-a2b5-55a767bc4a19.png)


- [ ] Requires env variable(s) to be updated
