### PR TITLE
Bump the version of ds-caselaw-utils

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,6 +17,6 @@ lxml~=4.9.1
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client~=5.0.0
-ds-caselaw-utils>=0.4.0
+ds-caselaw-utils~=0.4.1
 rollbar
 django-weasyprint==2.2.0


### PR DESCRIPTION
To fix https://trello.com/c/shEyapgh

Two of the canonical params for Court of Appeal courts were incorrect, they were `ecwa` instead of `ewca`

