### PR TITLE
taken off the align right style for the paragraph last-child on judgm…

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text.scss
@@ -49,7 +49,6 @@
 
   td>p:last-child {
     margin-bottom: 0;
-    text-align: right;
   }
 }
 


### PR DESCRIPTION
…ent text styles

## Changes in this PR:

Taken out an unrequired style on the judgment text. 
Which was [the direct `last-child p` tag within a` <td>](text-align: right from the .judgment td > p:last-child)`.
We don't need` text-align: right `and was interfering with other styles.

## Trello card / Rollbar error (etc)
Direct request from Jim, but part of the https://trello.com/c/dtzMnNHE/45-%E2%8C%B8%E2%8C%B8-judgment-crests-are-out-of-align card.

## Screenshots of UI changes:

### Before
![Screenshot 2022-11-03 at 18 46 44](https://user-images.githubusercontent.com/102584881/199808462-07679e39-e808-40fb-b146-05e1e109692f.png)

### After

![Screenshot 2022-11-03 at 18 46 54](https://user-images.githubusercontent.com/102584881/199808451-0cb80f58-a706-46e6-8c86-d09a47c0b71f.png)


- [ ] Requires env variable(s) to be updated
