### PR TITLE
Fix/crest alignment judgments

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text.scss
@@ -52,6 +52,9 @@
   }
 }
 
+
+
+
 .judgment-header {
 
   padding-top: $spacer__unit * 3;
@@ -62,6 +65,37 @@
       border-color: transparent;
     }
   }
+
+  // START – Thi is a fix to correct the alignment of the crest image so that it is centred.
+  // Refer to NCN [2022] EWCA Crim 985 as an example.
+
+  table.crest-alignment-fix {
+    margin-top: 1rem;
+
+    td {
+      border-color: transparent;
+      width: 67%;
+      padding-left: 0;
+
+      &:last-child {
+        padding: 0;
+        width: 33%;
+        text-align: right;
+      }
+
+      img {
+        display: block;
+        padding-left: 57%;
+        margin: 1rem auto;
+      }
+    }
+
+    .judgment-header__neutral-citation {
+      text-align: left;
+    }
+  }
+
+  // ENDS
 
   &__logo {
 
@@ -202,11 +236,12 @@
   }
 }
 
+
 .judgment-body {
 
   table {
     border: 1px solid $color__almost-black;
-    margin:  1rem auto;
+    margin: 1rem auto;
     table-layout: auto;
     width: 100%;
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
There are a few judgments that use a table for the judgment header where the crest image is. teh result, is that the alignment of the crest image and the NCN is too far to the left and not in the centre as it should be.

## Trello card / Rollbar error (etc)
https://trello.com/c/dtzMnNHE/45-%E2%8C%B8%E2%8C%B8-judgment-crests-are-out-of-align

## Screenshots of UI changes:

### Before

![1263-desktop-BEFORE](https://user-images.githubusercontent.com/102584881/200340218-dfd46f67-5ea2-4f65-8ee2-1b5dc3c7ed0a.png)
![1263-mobile-BEFORE](https://user-images.githubusercontent.com/102584881/200340237-68bc1e2d-f116-4600-af60-b27f35866af3.png)
![985-Desktop-BEFORE](https://user-images.githubusercontent.com/102584881/200340270-aea9adbe-8b27-41d6-9bb5-abd04ad8c96e.png)
![985-mobile–BEFORE](https://user-images.githubusercontent.com/102584881/200340293-786e7f42-26f2-4646-bb95-eb9dc164ac63.png)


### After
![1263-Dessktop-AFTER](https://user-images.githubusercontent.com/102584881/200340332-ff63e4ae-7a06-469c-ba3b-f5e404094d48.png)
![1263-mobile-AFTER](https://user-images.githubusercontent.com/102584881/200340339-5d0a67a8-4db8-46de-a453-2a110b893d29.png)

![985-Desktop-AFTER](https://user-images.githubusercontent.com/102584881/200340364-5de5bc96-57d7-4276-bd27-330fb71aabcc.png)

![985-mobile–AFTER](https://user-images.githubusercontent.com/102584881/200340373-2143ecac-8469-4038-96da-f9a2884f083d.png)


- [ ] Requires env variable(s) to be updated
