### PR TITLE
fix to neutral citation number to keep it on one

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text.scss
@@ -114,7 +114,7 @@
     text-align: right;
 
     span {
-      font-weight: bolder;
+      font-weight: normal;
       display: inline-block;
       text-decoration: underline;
     }


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Fix to the Neutral citation where the number can break in to two lines on mobile viewports.
I have added a `white-space: no-wrap` to make sure the whole number stays on one line and if it does break, it will break after the label only.

## Trello card / Rollbar error (etc)
https://trello.com/c/EZveMUVv/98-break-point-on-neutral-citation-number-on-mobile-bug-or-dev-backlog
## Screenshots of UI changes:

### Before
![BEFORE](https://user-images.githubusercontent.com/102584881/202458447-83a9493b-3321-46f2-b267-a7f375bf656b.png)

### After
![AFTER](https://user-images.githubusercontent.com/102584881/202458468-ab933e2d-40e7-48ea-9f52-54ad8b0c270b.png)

- [ ] Requires env variable(s) to be updated
