### PR TITLE
updated fix changes to NCN so that it no longer wraps on to two lines…

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text.scss
@@ -114,9 +114,10 @@
     text-align: right;
 
     span {
-      font-weight: bolder;
+      font-weight: normal;
       display: inline-block;
       text-decoration: underline;
+      white-space: nowrap;
     }
   }
 


### PR DESCRIPTION
… on mobile

<!-- Amend as appropriate -->

## Changes in this PR:
Fixed an issue where the NCN was wrapping on two lines on smaller mobile devices.
It now uses a span around the actual NCN number of `white-space:nowrap` to stop it breaking.

## Trello card / Rollbar error (etc)
https://trello.com/c/EZveMUVv/98-break-point-on-neutral-citation-number-on-mobile-bug-or-dev-backlog
## Screenshots of UI changes:

### Before
![BEFORE](https://user-images.githubusercontent.com/102584881/202480249-c3221ac9-aa05-498b-bdff-46272a3b407a.png)

### After
![AFTER](https://user-images.githubusercontent.com/102584881/202480225-e69864bb-305a-4914-b4d0-26066a92bb70.png)

- [ ] Requires env variable(s) to be updated
