### PR TITLE
Version bump ds-caselaw-utils to 0.4.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,6 +17,6 @@ lxml~=4.9.2
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client~=5.1.4
-ds-caselaw-utils~=0.4.3
+ds-caselaw-utils~=0.4.4
 rollbar
 django-weasyprint==2.2.0


### PR DESCRIPTION
## Changes in this PR:
This version fixes the end dates for all courts at 2022 allowing us to manually update the court date ranges as new judgments come in.

## Trello card:

https://trello.com/c/M3dSLGfX/263-change-year-ranges-for-browse-by-court

## Screenshots of UI changes:
![image](https://user-images.githubusercontent.com/4279/210378484-84c5bbb4-7b0a-4f27-8dfb-7daaa93233da.png)
