### PR TITLE
Fix CTA color consistency.

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_how_can_this_service_be_improved.scss
+++ b/ds_judgements_public_ui/sass/includes/_how_can_this_service_be_improved.scss
@@ -15,7 +15,7 @@
   }
 
   &__cta-button {
-    @include call-to-action-button($color__black, $color__white);
+    @include call-to-action-button-secondary;
     &:visited  {
       color: #ffffff;
     }

--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -40,13 +40,16 @@
   }
 
   a {
-    background-color: $color__aqua-blue;
-    color: $color__white;
     padding: calc($spacer__unit / 2) calc($spacer__unit * 3);
     display: inline-block;
     text-decoration: none;
     outline-offset: 3px;
     margin: 0;
+
+    &.btn {
+      @include call-to-action-button;
+      margin-bottom: calc($spacer__unit / 3) !important;
+    }
 
     @media (min-width: $grid__breakpoint-small) {
       padding: calc($spacer__unit / 2) calc($spacer__unit * 1.5);

--- a/ds_judgements_public_ui/sass/includes/_links.scss
+++ b/ds_judgements_public_ui/sass/includes/_links.scss
@@ -13,6 +13,7 @@ a {
 
   &:focus {
     @include focus-default;
+    color: $color__link-blue-focus;
   }
   &:visited {
     color: $color__link-blue-visited;

--- a/ds_judgements_public_ui/sass/includes/_mixins.scss
+++ b/ds_judgements_public_ui/sass/includes/_mixins.scss
@@ -53,12 +53,12 @@
   }
 }
 
-@mixin call-to-action-button($background_color, $foreground_color) {
-  background-color: $background_color;
+@mixin call-to-action-button {
+  background-color: $color__cta-background;
   text-decoration: none;
   font-weight: 700;
   border: 0;
-  color: $foreground_color;
+  color: $color__white;
   padding: 1rem 1.3rem;
   display: inline-block;
   margin-top: 1em;
@@ -66,13 +66,22 @@
 
   &:focus, &:hover {
     @include focus-default;
-    color: $foreground_color;
-    background-color: $background_color;
-    outline-color: $background_color;
+    color: $color__white !important;
+    background-color: $color__cta-background-hover;
+    outline-color: $color__cta-background-hover;
+    border-color: $color__cta-background-hover;
     text-decoration: underline;
     outline-offset: 0.2rem;
   }
 }
+
+@mixin call-to-action-button-secondary {
+  @include call-to-action-button;
+  background-color: transparent;
+  color: $color__cta-background !important;
+  border: 2px solid $color__cta-background;
+}
+
 
 @mixin emphasised-block {
   padding: $spacer__unit;

--- a/ds_judgements_public_ui/sass/includes/_result_controls.scss
+++ b/ds_judgements_public_ui/sass/includes/_result_controls.scss
@@ -36,7 +36,7 @@
   }
 
   &__button {
-    @include call-to-action-button($color__dark-blue, $color__white);
+    @include call-to-action-button;
     margin: calc(2.2 * $spacer__unit) 0 1rem 0;
     font-size: 0.85rem;
     outline-color: $color__dark-blue;

--- a/ds_judgements_public_ui/sass/includes/_results_search_component.scss
+++ b/ds_judgements_public_ui/sass/includes/_results_search_component.scss
@@ -59,7 +59,7 @@
   }
 
   input[type=submit] {
-    @include call-to-action-button($color__dark-blue, $color__white);
+    @include call-to-action-button;
     padding-right: calc($spacer__unit * 3);
     padding-left: calc($spacer__unit * 3 + 1.5rem);
     margin-top: calc($spacer__unit * 0.5);
@@ -132,7 +132,7 @@
   }
 
   &__search-submit-button {
-    @include call-to-action-button($color__dark-blue, $color__white);
+    @include call-to-action-button;
     padding-left: calc($spacer__unit * 3);
     padding-right: calc($spacer__unit * 3);
   }
@@ -235,7 +235,7 @@
   }
 
   &__filter-submit-button {
-    @include call-to-action-button($color__dark-blue, $color__white);
+    @include call-to-action-button;
     margin: 0 auto;
   }
 

--- a/ds_judgements_public_ui/sass/includes/_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_search.scss
@@ -49,7 +49,7 @@
   }
 
   input[type=submit] {
-    @include call-to-action-button($color__black, $color__white);
+    @include call-to-action-button;
     padding-left: calc($spacer__unit * 3);
     padding-right: calc($spacer__unit * 3);
   }

--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -254,7 +254,7 @@
   }
 
   input[type=submit] {
-    @include call-to-action-button($color__dark-blue, $color__white);
+    @include call-to-action-button;
     padding-right: calc($spacer__unit * 3);
     padding-left: calc($spacer__unit * 3);
     margin-top: calc($spacer__unit * 0.5);

--- a/ds_judgements_public_ui/sass/includes/_typography.scss
+++ b/ds_judgements_public_ui/sass/includes/_typography.scss
@@ -17,5 +17,6 @@ a {
 
   &:focus {
     @include focus-default;
+    color: $color__link-blue-focus;
   }
 }

--- a/ds_judgements_public_ui/sass/includes/_variables.scss
+++ b/ds_judgements_public_ui/sass/includes/_variables.scss
@@ -12,12 +12,15 @@ $color__highlight-blue: #0066cc;
 $color__yellow: #ffb952;
 $color__aqua-blue: #037091;
 
-$color__link-blue: #1d70b8;
-$color__link-blue-hover: #003078;
+$color__link-blue: $color__aqua-blue;
+$color__link-blue-hover: $color__dark-blue;
+$color__link-blue-focus: $color__dark-blue;
 $color__link-blue-visited: #4c2c92;
 $color__link-blue-active: #1e1e2a;
 
-$color__focus-blue-outline: #1d70b8;
+$color__focus-blue-outline: $color__dark-blue;
+$color__cta-background: $color__aqua-blue;
+$color__cta-background-hover: $color__dark-blue;
 
 $grid__breakpoint-small: 576px;
 $grid__breakpoint-medium: 768px;

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -8,7 +8,7 @@
     {% endif %}
 
     <div class="judgment-toolbar__download judgment-toolbar-download">
-      <a class="judgment-toolbar-download__option--pdf" role="button" draggable="false" href="{% url 'detail_pdf' context.judgment_uri %}">{% translate "judgment.downloadaspdf" %}{{context.pdf_size}}</a>
+      <a class="judgment-toolbar-download__option--pdf btn" role="button" draggable="false" href="{% url 'detail_pdf' context.judgment_uri %}">{% translate "judgment.downloadaspdf" %}{{context.pdf_size}}</a>
       <p class="judgment-toolbar-download__download-options" role="note"><a href="#download-options">{% translate "judgment.downloadoptions.shortcutlink" %}</a></p>
     </div>
   </div>


### PR DESCRIPTION
## Changes in this PR:

We're using two diffferent colours for CTAs across the site, this harmonises them and sets a master variable to control them from SASS. After some discussion, we've harmonised to the 'link blue' and made sure all links and buttons use a darker blue for the hover state (consistent with the colour of the focus outline too).

We've also added a 'secondary button' style which is inverted and less prominent for use on eg the survey link.

## Trello card / Rollbar error (etc)

https://trello.com/c/XYhV8pwv/340-da-%E2%9C%8F%EF%B8%8F-pui-ctas-colour-inconsistency


## Screenshots of UI changes:

### Before
![Screenshot 2023-01-23 at 20 38 13](https://user-images.githubusercontent.com/4279/214133517-60204caf-1b2e-4269-8301-d56ccc13ed28.png)
![Screenshot 2023-01-23 at 20 37 59](https://user-images.githubusercontent.com/4279/214133527-fd2803f4-79e8-46a5-84e8-885165eb29f1.png)
<img width="911" alt="Screenshot 2023-01-23 at 11 12 14" src="https://user-images.githubusercontent.com/4279/214133573-19998cd8-7a51-45ca-8062-532af1725370.png">
<img width="676" alt="Screenshot 2023-01-23 at 10 44 00" src="https://user-images.githubusercontent.com/4279/214133656-ffe13560-ae37-4ed4-b60f-eb585462ab64.png">


### After
<img width="879" alt="Screenshot 2023-01-23 at 10 44 14" src="https://user-images.githubusercontent.com/4279/214133616-4b0def6a-d53b-441c-86e4-d5d6bb76ba6e.png">
<img width="676" alt="Screenshot 2023-01-23 at 10 44 00" src="https://user-images.githubusercontent.com/4279/214133630-6a3062fa-d7e3-4f5a-a017-b851fea1fcba.png">
<img alt="" src="https://user-images.githubusercontent.com/4279/214133980-025ba38c-9076-44bd-8335-b3af53374434.png" />
