### PR TITLE
Add a descriptive aria-label to the judgement sort button

### DIFF
--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -35,6 +35,6 @@
         <option value="50" {% if context.per_page == "50" %}selected='selected'{% endif %}>50</option>
       </select>
     </div>
-    <input type="submit" value="Go" class="result-controls__button">
+    <input aria-label="Sort judgments" type="submit" value="Go" class="results-controls__button">
   </form>
 </div>


### PR DESCRIPTION

## Changes in this PR:

Adds Aria-label to the 'go' button on sorting judgments to make its function clear to screen reader users

## Trello card / Rollbar error (etc)

https://trello.com/c/gSvglcua/345-da-%E2%9C%8F%EF%B8%8F-pui-sorting-judgments-go-button
