### PR TITLE
Bump isort version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black"]


### PR DESCRIPTION
## Changes in this PR:

Fixes this bug which causes pre-commit to fail:

https://github.com/PyCQA/isort/issues/2077

