### PR TITLE
Fix/347 search bar wording

### DIFF
--- a/ds_judgements_public_ui/templates/includes/results_search_field.html
+++ b/ds_judgements_public_ui/templates/includes/results_search_field.html
@@ -1,6 +1,7 @@
+{% load i18n %}
 <div class="results-search-component__full-text-panel">
-  <label for="search_term" class="results-search-component__full-text-label">Search</label>
+  <label for="search_term" class="results-search-component__full-text-label">{% translate "basicsearchform.label" %}</label>
   <input class="search-component__search-term-input" id="search_term" name="query" type="text" value="{{context.query}}"
-         placeholder="Enter keyword, party name or neutral citation">
-  <input type="submit" value="Search" class="results-search-component__search-submit-button results-search-component__desktop-submit-button">
+         placeholder="{% translate "basicsearchform.placeholder" %}">
+  <input type="submit" value="{% translate "basicsearchform.cta" %}" class="results-search-component__search-submit-button results-search-component__desktop-submit-button">
 </div>

--- a/ds_judgements_public_ui/templates/pages/structured_search.html
+++ b/ds_judgements_public_ui/templates/pages/structured_search.html
@@ -19,7 +19,7 @@
         <div class="structured-search__container">
           <h1 class="structured-search__main-search-header">Search everything for</h1>
           <div class="structured-search__full-text-panel">
-            <input class="search-component__search-term-input" id="search_term" name="query" type="text" value="">
+            <input class="search-component__search-term-input" id="search_term" name="query" type="text" placeholder="{% translate "basicsearchform.placeholder" %}" value="">
             <label for="search_term" class="structured-search__full-text-label">Search</label>
             <input type="submit" value="Search">
           </div>

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -33,7 +33,7 @@ msgstr "Search"
 
 #: ds_judgements_public_ui/templates/includes/basic_search_form.html:8
 msgid "basicsearchform.placeholder"
-msgstr "Enter a party name or neutral citation"
+msgstr "Enter keyword, party name or neutral citation"
 
 #: ds_judgements_public_ui/templates/includes/basic_search_form.html:10
 msgid "basicsearchform.cta"


### PR DESCRIPTION
## Changes in this PR:

Make the wording consistent on all search field placeholder text, and ensure that we're using i18n consistently.




## Trello card / Rollbar error (etc)

https://trello.com/c/KzlwDkgD/347-da-%E2%9C%8F%EF%B8%8F-pui-search-bar-placeholder-wording-is-inconsistent

## Screenshots of UI changes:

### Before
<img width="1170" alt="Screenshot 2023-01-30 at 11 01 15" src="https://user-images.githubusercontent.com/4279/215448040-64da973c-5b0d-48de-b117-a015e25cec97.png">
<img width="1170" alt="Screenshot 2023-01-30 at 11 01 07" src="https://user-images.githubusercontent.com/4279/215448051-425d544a-4fe1-41dd-88d5-14ec265f7613.png">
<img width="1170" alt="Screenshot 2023-01-30 at 11 00 57" src="https://user-images.githubusercontent.com/4279/215448054-49c9dc0f-d63e-4884-9025-31675e654b65.png">

### After
<img width="1170" alt="Screenshot 2023-01-30 at 11 00 46" src="https://user-images.githubusercontent.com/4279/215448083-abf17bd8-ff64-4a2f-ab64-183820c24ea1.png">
<img width="1170" alt="Screenshot 2023-01-30 at 11 00 31" src="https://user-images.githubusercontent.com/4279/215448087-1a5498b4-4faf-4025-b385-6442002709fc.png">
<img width="1170" alt="Screenshot 2023-01-30 at 11 00 24" src="https://user-images.githubusercontent.com/4279/215448089-bdb1a750-b963-4a8d-9192-cf794429a779.png">

