### PR TITLE
Tweak mobile layout to ensure placeholder text is visible

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_search.scss
@@ -54,8 +54,18 @@
     padding-right: calc($spacer__unit * 3);
   }
 
-  &__search-term-label {
+  &__search-term-label.desktop {
+    @media (max-width: $grid__breakpoint-medium) {
+      display: none;
+    }
     @include sr-only;
+
+  }
+
+  &__search-term-label.mobile {
+    @media (min-width: $grid__breakpoint-medium) {
+      display: none;
+    }
   }
 
   &__search-term-input {
@@ -74,6 +84,18 @@
 
     @media (min-width: $grid__breakpoint-extra-large) {
       width: 35rem;
+    }
+
+    &.mobile {
+      @media (min-width: $grid__breakpoint-medium) {
+        display: none;
+      }
+    }
+
+    &.desktop {
+      @media (max-width: $grid__breakpoint-medium) {
+        display: none;
+      }
     }
   }
 

--- a/ds_judgements_public_ui/templates/includes/basic_search_form.html
+++ b/ds_judgements_public_ui/templates/includes/basic_search_form.html
@@ -4,8 +4,10 @@
     <h2 class="search-component__header--sr-only">{% translate "basicsearchform.title" %}</h2>
     <form action="{% url 'results' %}" role="search" aria-label="Search by keyword or neutral citation" id="analytics-basic-search">
 
-      <label for="search_term" class="search-component__search-term-label">{% translate "basicsearchform.label" %}</label>
-      <input class="search-component__search-term-input" id="search_term" name="query" type="text" value="" placeholder="{% translate "basicsearchform.placeholder" %}">
+      <label for="search_term" class="search-component__search-term-label desktop">{% translate "basicsearchform.label" %}</label>
+      <input class="search-component__search-term-input desktop" id="search_term" name="query" type="text" value="" placeholder="{% translate "basicsearchform.placeholder" %}">
+      <label for="search_term" class="search-component__search-term-label mobile">{% translate "basicsearchform.placeholder" %}</label>
+      <input class="search-component__search-term-input mobile" id="search_term" name="query" type="text" value="" placeholder="{% translate "basicsearchform.label" %}">
       {{ form.search_term }}
       <input type="submit" value="{%  translate "basicsearchform.cta" %}">
 

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -33,7 +33,7 @@ msgstr "Search"
 
 #: ds_judgements_public_ui/templates/includes/basic_search_form.html:8
 msgid "basicsearchform.placeholder"
-msgstr "Enter keyword, party name or neutral citation"
+msgstr "Enter keyword, party name or neutral&nbsp;citation"
 
 #: ds_judgements_public_ui/templates/includes/basic_search_form.html:10
 msgid "basicsearchform.cta"


### PR DESCRIPTION

## Changes in this PR:


Thanks to Terry for the inspiration that led to this solution, and help with some annoying typography tweaks - at the smallest breakpoint we swap the label and placeholder text, to ensure the full instructions are visible!


## Trello card / Rollbar error (etc)

https://trello.com/c/nLaavzHS/346-da-%E2%9C%8F%EF%B8%8F-pui-placeholder-text-in-search-bar-gets-cut-off-in-mobile-view

## Screenshots of UI changes:

### Before
<img width="390" alt="Screenshot 2023-01-30 at 13 47 37" src="https://user-images.githubusercontent.com/4279/215481167-973f37b2-ea7f-4bdd-85d4-9578063b44f2.png">

### After

<img width="390" alt="Screenshot 2023-01-30 at 13 31 18" src="https://user-images.githubusercontent.com/4279/215481056-f715a446-245d-494d-9a87-15e383fc6b94.png">
