### PR TITLE
Fix broken sort button

### DIFF
--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -35,6 +35,6 @@
         <option value="50" {% if context.per_page == "50" %}selected='selected'{% endif %}>50</option>
       </select>
     </div>
-    <input aria-label="Sort judgments" type="submit" value="Go" class="results-controls__button">
+    <input aria-label="Sort judgments" type="submit" value="Go" class="result-controls__button">
   </form>
 </div>


### PR DESCRIPTION
## Changes in this PR:

Regresion introduced in ae0ebe2055 - a typo in a classname that removed the button styling!

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before
<img width="538" alt="Screenshot 2023-01-31 at 11 32 24" src="https://user-images.githubusercontent.com/4279/215738042-c34a7d47-f58b-45bc-9bc5-d8c02b77fb3a.png">

### After
<img width="225" alt="Screenshot 2023-01-31 at 11 40 25" src="https://user-images.githubusercontent.com/4279/215738053-ab85d665-d22e-4b18-beac-d8a5d34d850b.png">

