### PR TITLE
fix 1px offset on homepage search button

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_search.scss
@@ -50,6 +50,11 @@
 
   input[type=submit] {
     @include call-to-action-button;
+    @media (min-width: $grid__breakpoint-medium) {
+      position: relative;
+      top: -1px;
+      margin-left: calc($spacer__unit * 0.5);
+    }
     padding-left: calc($spacer__unit * 3);
     padding-right: calc($spacer__unit * 3);
   }


### PR DESCRIPTION
## Changes in this PR:

Fixes the weird 1px offset that the search button has relative to the text field on the homepage text box, and increases the gutter a little bit so the active button outline doesn't overlap the search field.

## Trello card / Rollbar error (etc)

https://trello.com/c/AJ83U4jQ/363-da-fix-weird-spacing-on-search-box-on-homepage

## Screenshots of UI changes:

### Before
<img width="838" alt="Screenshot 2023-01-31 at 11 52 23" src="https://user-images.githubusercontent.com/4279/215741294-cce938fb-06b9-4e59-8f8f-304a2d413bf7.png">

### After
<img width="838" alt="Screenshot 2023-01-31 at 11 54 48" src="https://user-images.githubusercontent.com/4279/215741276-7d923927-f2c3-4401-a01e-e1937aeaea93.png">
