### PR TITLE
Fix regression in searching from homepage

### DIFF
--- a/ds_judgements_public_ui/templates/includes/basic_search_form.html
+++ b/ds_judgements_public_ui/templates/includes/basic_search_form.html
@@ -7,7 +7,7 @@
       <label for="search_term" class="search-component__search-term-label desktop">{% translate "basicsearchform.label" %}</label>
       <input class="search-component__search-term-input desktop" id="search_term" name="query" type="text" value="" placeholder="{% translate "basicsearchform.placeholder" %}">
       <label for="search_term" class="search-component__search-term-label mobile">{% translate "basicsearchform.placeholder" %}</label>
-      <input class="search-component__search-term-input mobile" id="search_term" name="query" type="text" value="" placeholder="{% translate "basicsearchform.label" %}">
+      <input class="search-component__search-term-input mobile" id="search_term" name="query_m" type="text" value="" placeholder="{% translate "basicsearchform.label" %}">
       {{ form.search_term }}
       <input type="submit" value="{%  translate "basicsearchform.cta" %}">
 

--- a/judgments/views/results.py
+++ b/judgments/views/results.py
@@ -22,7 +22,7 @@ def results(request):
 
     try:
         params = request.GET
-        query = params.get("query")
+        query = params.get("query") or params.get("query_m")
         page = str(as_integer(params.get("page"), minimum=1))
         per_page = str(
             as_integer(


### PR DESCRIPTION

## Changes in this PR:

PR #535 introduced a regression - in order to change the placeholder text based on the CSS breakpoint, we introduced two query input fields with different placeholders, which are set to display: none; selectively at different breakpoints.

The problem was, both had the same ID, so the second in the markup always overwrites the query parameter, meaning that the query term wasn't passed through in the request on desktop!

To fix this, I've renamed the mobile field to `query_m`, and made a small change in the results view to take the query from here if the desktop field is empty.

<