### PR TITLE
Set views and static content to have 1hr cache headers

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -1,0 +1,21 @@
+from django.utils.cache import patch_cache_control
+
+
+class CacheHeaderMiddleware:
+    # via https://docs.djangoproject.com/en/4.1/topics/http/middleware/
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # One-time configuration and initialization.
+
+    def __call__(self, request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+
+        response = self.get_response(request)
+        patch_cache_control(response, max_age=3600, public=True)
+
+        # Code to be executed for each request/response after
+        # the view is called.
+
+        return response

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -123,6 +123,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
+    "config.middleware.CacheHeaderMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.common.BrokenLinkEmailsMiddleware",
@@ -247,3 +248,4 @@ LOGGING = {
 # Your stuff...
 # ------------------------------------------------------------------------------
 APPEND_SLASH = False
+WHITENOISE_MAX_AGE = 3600  # set Cache-Control header on static-served images

--- a/config/tests.py
+++ b/config/tests.py
@@ -12,3 +12,15 @@ class TestRedirect(TestCase):
         url = "/2022/202"
         response = self.client.get(url)
         assert response.status_code == 404
+
+
+class TestCacheHeaders(TestCase):
+    def test_static_headers(self):
+        url = "/static/images/tna_logo.svg"
+        response = self.client.get(url)
+        assert response.headers["Cache-Control"] == "max-age=3600, public"
+
+    def test_view_headers(self):
+        url = "/what-to-expect"
+        response = self.client.get(url)
+        assert response.headers["Cache-Control"] == "max-age=3600, public"


### PR DESCRIPTION
We configure Whitenoise for the assets and set up a middleware for the cache headers.

1 hour value based on legislation.gov.uk -- do we want s-maxage and no-transform? 