### PR TITLE
Use ASSETS_CDN_BASE_URL nstead of synthesising s3 URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,12 @@ ROLLBAR_ACCESS_TOKEN=
 ROLLBAR_ENV=development
 WSGI_AUTH_EXCLUDE_PATHS=/check
 XSLT_IMAGE_LOCATION=
+DJANGO_DEBUG=True
+# These are deprecated and replaced with ASSETS_ENDPOINT
 PUBLIC_ASSET_BUCKET=tna-caselaw-assets-staging
 S3_REGION=eu-west-2
-DJANGO_DEBUG=True
+# note: this is the *live* assets endpoint -- staging does not
+# typically have the DOCX or PDF available in S3.
+ASSETS_CDN_BASE_URL=https://assets.caselaw.nationalarchives.gov.uk
+# but you would use this staging URL if you wanted it:
+# ASSETS_CDN_BASE_URL=https://tna-caselaw-assets-staging.s3.eu-west-2.amazonaws.com

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -131,7 +131,11 @@ def get_pdf_uri(judgment_uri):
     env = environ.Env()
     """Create a string saying where the S3 PDF will be for a judgment uri"""
     pdf_path = f'{judgment_uri}/{judgment_uri.replace("/", "_")}.pdf'
-    return f'https://{env("PUBLIC_ASSET_BUCKET")}.s3.{env("S3_REGION")}.amazonaws.com/{pdf_path}'
+    assets = env("ASSETS_CDN_BASE_URL", default=None)
+    if assets:
+        return f"{assets}/{pdf_path}"
+    else:
+        return f'https://{env("PUBLIC_ASSET_BUCKET")}.s3.{env("S3_REGION")}.amazonaws.com/{pdf_path}'
 
 
 def display_back_link(back_link):


### PR DESCRIPTION
## Changes in this PR:

We want to point the PDF request to a new URL, but we are currently sythesising the S3 URL out of the bucket name and region. We point at the value of the `ASSETS_CDN_BASE_URL` environment variable, but fall back if absent.

- [x] Is ~~`ASSETS_ENDPOINT`~~ the right name? `S3_`? `_DOMAIN`? Changed to `ASSETS_CDN_BASE_URL`.
- [ ] Should we just bite the bullet and delete the old code?

## Trello card / Rollbar error (etc)

https://trello.com/c/jk2t4lI2/404-bau-update-production-s3-endpoint-to-use-cloudfront

** We will need to add the `ASSETS_CDN_BASE_URL` environment variable to use this new functionality; it should fall back to the previous environment variables if they exist.
