### PR TITLE
Run CI on merge queue commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
     branches: ["master", "main"]
     paths-ignore: ["docs/**"]
 
+  merge_group:
+
 jobs:
   linter:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI does not currently run on commits in the merge queue, but since these are required things in the queue will inevitably fail and will not merge.