### PR TITLE
Add urls for UKFTT

### DIFF
--- a/judgments/converters.py
+++ b/judgments/converters.py
@@ -25,7 +25,7 @@ class DateConverter:
 
 
 class CourtConverter:
-    regex = "ewhc|uksc|ukpc|ewca|ewcop|ewfc|ukut|eat"
+    regex = "ewhc|uksc|ukpc|ewca|ewcop|ewfc|ukut|eat|ukftt"
 
     def to_python(self, value):
         return value
@@ -35,7 +35,7 @@ class CourtConverter:
 
 
 class SubdivisionConverter:
-    regex = "civ|crim|admin|admlty|ch|comm|costs|fam|ipec|mercantile|pat|qb|kb|iac|lc|tcc|aac|scco"
+    regex = "civ|crim|admin|admlty|ch|comm|costs|fam|ipec|mercantile|pat|qb|kb|iac|lc|tcc|aac|scco|tc|grc"
 
     def to_python(self, value):
         return value


### PR DESCRIPTION
> We’ve had a particular problem with the atom feed getting First Tier Tribunal cases, because they don’t seem to conform to the pattern explained in your documentation.
> On the basis of the formula that seems to work for every other court or tribunal, we would expect the First Tier Tribunal - Tax Chamber feed to be as follows:
> https://caselaw.nationalarchives.gov.uk/ukftt/tc/atom.xml
> But this doesn’t work. Can you help?

https://dxw.slack.com/archives/C02TP2L2Z0F/p1676886142657019

This adds ukftt/tc and /grc to the paths which are recognised. We should in future consider deriving this information from the utils.