### PR TITLE
Fixed styles on mobile view on advanced search page (stretched submit…

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -24,7 +24,7 @@
     max-width: 100%;
   }
 
-  &__full-text-panel {
+   &__full-text-panel {
     margin-top: $spacer__unit;
     margin-bottom: $spacer__unit;
     text-align: left;
@@ -250,7 +250,7 @@
   }
 
   input[type=text] {
-    width: 95%;
+    width: 75%;
   }
 
   input[type=submit] {
@@ -259,9 +259,55 @@
     padding-left: calc($spacer__unit * 3);
     margin-top: calc($spacer__unit * 0.5);
     margin-bottom: $spacer__unit;
-    width: 100%;
+    width: 50%;
+    position: relative;
+    left: 4px;
     @media (min-width: $grid__breakpoint-medium) {
-      width: auto;
+      width: auto;     
+    }
+  }
+  &__search-term-label.desktop {
+    @media (max-width: $grid__breakpoint-medium) {
+      display: none;
+    }
+    @include sr-only;
+
+  }
+
+  &__search-term-label.mobile {
+    @media (min-width: $grid__breakpoint-medium) {
+      display: none;
+    }
+  }
+
+  &__search-term-input {
+    @include text_field;
+    width: 80%;
+    min-height: calc($spacer__unit * 2);
+    font-size: 1.2rem;
+
+    @media (min-width: $grid__breakpoint-small) {
+      width: 20rem;
+    }
+
+    @media (min-width: $grid__breakpoint-medium) {
+      width: 25rem;
+    }
+
+    @media (min-width: $grid__breakpoint-extra-large) {
+      width: 35rem;
+    }
+
+    &.mobile {
+      @media (min-width: $grid__breakpoint-medium) {
+        display: none;
+      }
+    }
+
+    &.desktop {
+      @media (max-width: $grid__breakpoint-medium) {
+        display: none;
+      }
     }
   }
 

--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -263,7 +263,7 @@
     position: relative;
     left: 4px;
     @media (min-width: $grid__breakpoint-medium) {
-      width: auto;     
+      width: auto;
     }
   }
   &__search-term-label.desktop {

--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -15,6 +15,10 @@
     font-weight: normal;
     color: $color__almost-black;
     margin: calc($spacer__unit * 3) 0 0 0;
+    @media (max-width: $grid__breakpoint-medium) {
+      margin: 1rem 0 1rem 1rem;
+      line-height: 2.6rem;
+    }
   }
 
   &__container {
@@ -34,6 +38,7 @@
     @media (min-width: $grid__breakpoint-medium) {
       flex-direction: row;
       padding: calc($spacer__unit * 1.5) 0;
+      margin: auto;
     }
 
   }
@@ -251,6 +256,10 @@
 
   input[type=text] {
     width: 75%;
+    @media (max-width: $grid__breakpoint-medium) {
+      margin: auto 1rem;
+      width: auto;
+      }
   }
 
   input[type=submit] {
@@ -265,6 +274,10 @@
     @media (min-width: $grid__breakpoint-medium) {
       width: auto;
     }
+    @media (max-width: $grid__breakpoint-medium) {
+      margin: auto;
+      width: 10rem;
+      }
   }
   &__search-term-label.desktop {
     @media (max-width: $grid__breakpoint-medium) {
@@ -278,6 +291,9 @@
     @media (min-width: $grid__breakpoint-medium) {
       display: none;
     }
+    @media (max-width: $grid__breakpoint-medium) {
+      margin: auto 1rem;
+      }
   }
 
   &__search-term-input {
@@ -301,6 +317,9 @@
     &.mobile {
       @media (min-width: $grid__breakpoint-medium) {
         display: none;
+      }
+      @media (max-width: $grid__breakpoint-medium) {
+      margin: auto 1rem;
       }
     }
 

--- a/ds_judgements_public_ui/templates/pages/structured_search.html
+++ b/ds_judgements_public_ui/templates/pages/structured_search.html
@@ -17,11 +17,13 @@
     <div class="structured-search">
       <div class="structured-search__main-search">
         <div class="structured-search__container">
-          <h1 class="structured-search__main-search-header">Search everything for</h1>
+          <h1 class="structured-search__main-search-header">Advanced search</h1>
           <div class="structured-search__full-text-panel">
-            <input class="search-component__search-term-input" id="search_term" name="query" type="text" placeholder="{% translate "basicsearchform.placeholder" %}" value="">
-            <label for="search_term" class="structured-search__full-text-label">Search</label>
-            <input type="submit" value="Search">
+            <label for="search_term" class="structured-search__search-term-label desktop">{% translate "basicsearchform.label" %}</label>
+            <input class="structured-search__search-term-input desktop" id="search_term" name="query" type="text" value="" placeholder="{% translate "basicsearchform.placeholder" %}">
+            <label for="search_term" class="structured-search__search-term-label mobile">{% translate "basicsearchform.placeholder" %}</label>
+            <input class="structured-search__search-term-input mobile" id="search_term" name="query_mobile" type="text" value="" placeholder="{% translate "basicsearchform.label" %}">
+            <input type="submit" value="{%  translate "basicsearchform.cta" %}">
           </div>
         </div>
       </div>

--- a/ds_judgements_public_ui/templates/pages/structured_search.html
+++ b/ds_judgements_public_ui/templates/pages/structured_search.html
@@ -17,12 +17,12 @@
     <div class="structured-search">
       <div class="structured-search__main-search">
         <div class="structured-search__container">
-          <h1 class="structured-search__main-search-header">Advanced search</h1>
+          <h1 class="structured-search__main-search-header">Structured search</h1>
           <div class="structured-search__full-text-panel">
-            <label for="search_term" class="structured-search__search-term-label desktop">{% translate "basicsearchform.label" %}</label>
             <input class="structured-search__search-term-input desktop" id="search_term" name="query" type="text" value="" placeholder="{% translate "basicsearchform.placeholder" %}">
             <label for="search_term" class="structured-search__search-term-label mobile">{% translate "basicsearchform.placeholder" %}</label>
-            <input class="structured-search__search-term-input mobile" id="search_term" name="query_mobile" type="text" value="" placeholder="{% translate "basicsearchform.label" %}">
+            <label for="search_term" class="structured-search__full-text-label">Search</label>
+            <input class="structured-search__search-term-input mobile" id="search_term" name="query" type="text" value="" placeholder="Search">
             <input type="submit" value="{%  translate "basicsearchform.cta" %}">
           </div>
         </div>


### PR DESCRIPTION

<!-- Amend as appropriate -->

## Changes in this PR:
Fixed styles on mobile view on advanced search page 
## Trello card / Rollbar error (etc)
https://trello.com/c/En6jf7YV/451-pui-styles-on-mobile-view-on-advanced-search-page-stretched-buttons
## Screenshots of UI changes:

### Before
![old-mobile-structured-search](https://user-images.githubusercontent.com/75584408/220379855-99e7ae32-3812-47e5-85b3-d6b884ec7ccb.png)
### After

[structured-search-desktop-mobile.webm](https://user-images.githubusercontent.com/75584408/220749633-ed8c5bd5-a1a3-4f7c-ba54-b5cdca73a2b4.webm)



- [ ] Requires env variable(s) to be updated
