### PR TITLE
Use assets domain link if S3 PDF exists

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
@@ -4,7 +4,7 @@
   <div class="judgment-download-options__options-list">
     <div class="judgment-download-options__download-option">
       <h3>
-        <a href="{% url 'detail_pdf' context.judgment_uri %}">
+        <a href="{{ context.pdf_uri }}">
           {% translate "judgment.downloadoptions.pdf.cta" %}{{context.pdf_size}}
         </a>
       </h3>

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -8,7 +8,7 @@
     {% endif %}
 
     <div class="judgment-toolbar__download judgment-toolbar-download">
-      <a class="judgment-toolbar-download__option--pdf btn" role="button" draggable="false" href="{% url 'detail_pdf' context.judgment_uri %}">{% translate "judgment.downloadaspdf" %}{{context.pdf_size}}</a>
+      <a class="judgment-toolbar-download__option--pdf btn" role="button" draggable="false" href="{{ context.pdf_uri }}">{% translate "judgment.downloadaspdf" %}{{context.pdf_size}}</a>
       <p class="judgment-toolbar-download__download-options" role="note"><a href="#download-options">{% translate "judgment.downloadoptions.shortcutlink" %}</a></p>
     </div>
   </div>

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -67,28 +67,29 @@ def detail(request, judgment_uri):
     except MarklogicAPIError:
         raise Http404("Judgment was not found")
 
-    if is_published:
-        try:
-            results = api_client.eval_xslt(judgment_uri)
-            multipart_data = decoder.MultipartDecoder.from_response(results)
-            judgment = multipart_data.parts[0].text
-            context["judgment"] = judgment
-            context["page_title"] = api_client.get_judgment_name(judgment_uri)
-            context["judgment_uri"] = judgment_uri
-
-            context["pdf_size"] = get_pdf_size(judgment_uri)
-            if context["pdf_size"]:  # is "" if no PDF was found
-                context["pdf_uri"] = get_pdf_uri(judgment_uri)
-            else:
-                context["pdf_uri"] = reverse("detail_pdf", args=[judgment_uri])
-
-            context["back_link"] = get_back_link(request)
-        except MarklogicResourceNotFoundError:
-            raise Http404("Judgment was not found")
-        template = loader.get_template("judgment/detail.html")
-        return TemplateResponse(request, template, context={"context": context})
-    else:
+    if not is_published:
         raise Http404("This Judgment is not available")
+
+    try:
+        results = api_client.eval_xslt(judgment_uri)
+        multipart_data = decoder.MultipartDecoder.from_response(results)
+        judgment = multipart_data.parts[0].text
+        context["judgment"] = judgment
+        context["page_title"] = api_client.get_judgment_name(judgment_uri)
+        context["judgment_uri"] = judgment_uri
+
+        context["pdf_size"] = get_pdf_size(judgment_uri)
+        if context["pdf_size"]:  # is "" if no PDF was found
+            context["pdf_uri"] = get_pdf_uri(judgment_uri)
+        else:
+            context["pdf_uri"] = reverse("detail_pdf", args=[judgment_uri])
+
+        context["back_link"] = get_back_link(request)
+    except MarklogicResourceNotFoundError:
+        raise Http404("Judgment was not found")
+
+    template = loader.get_template("judgment/detail.html")
+    return TemplateResponse(request, template, context={"context": context})
 
 
 def detail_xml(_request, judgment_uri):

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -42,7 +42,10 @@ class PdfDetailView(WeasyTemplateResponseMixin, TemplateView):
 
 
 def get_best_pdf(request, judgment_uri):
-    """If there's a DOCX-derived PDF in the S3 bucket, return that.
+    """
+    Response for the legacy data.pdf endpoint, used by data reusers
+
+    If there's a DOCX-derived PDF in the S3 bucket, return that.
     Otherwise fall back and redirect to the weasyprint version."""
     pdf_uri = get_pdf_uri(judgment_uri)
     response = requests.get(pdf_uri)
@@ -72,7 +75,13 @@ def detail(request, judgment_uri):
             context["judgment"] = judgment
             context["page_title"] = api_client.get_judgment_name(judgment_uri)
             context["judgment_uri"] = judgment_uri
+
             context["pdf_size"] = get_pdf_size(judgment_uri)
+            if context["pdf_size"]:  # is "" if no PDF was found
+                context["pdf_uri"] = get_pdf_uri(judgment_uri)
+            else:
+                context["pdf_uri"] = reverse("detail_pdf", args=[judgment_uri])
+
             context["back_link"] = get_back_link(request)
         except MarklogicResourceNotFoundError:
             raise Http404("Judgment was not found")


### PR DESCRIPTION
Use [staging.]assets.caselaw.nationalarchives.gov.uk urls in preference to data.pdf -- added note that data.pdf is still relevant!

I'm not 100% sure this is the right answer -- it means we have two different PDF links.