### PR TITLE
Fix advanced search bug

### DIFF
--- a/ds_judgements_public_ui/templates/pages/structured_search.html
+++ b/ds_judgements_public_ui/templates/pages/structured_search.html
@@ -22,7 +22,7 @@
             <input class="structured-search__search-term-input desktop" id="search_term" name="query" type="text" value="" placeholder="{% translate "basicsearchform.placeholder" %}">
             <label for="search_term" class="structured-search__search-term-label mobile">{% translate "basicsearchform.placeholder" %}</label>
             <label for="search_term" class="structured-search__full-text-label">Search</label>
-            <input class="structured-search__search-term-input mobile" id="search_term" name="query" type="text" value="" placeholder="Search">
+            <input class="structured-search__search-term-input mobile" id="search_term" name="query_mobile" type="text" value="" placeholder="Search">
             <input type="submit" value="{%  translate "basicsearchform.cta" %}">
           </div>
         </div>

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -60,6 +60,34 @@ class TestSearchResults(TestCase):
             '<span class="results-search-component__removable-options-value-text">waltham forest</span>',
         )
 
+    @patch("judgments.views.results.perform_advanced_search")
+    @patch("judgments.models.SearchResult.create_from_node")
+    def test_judgment_advanced_search_desktop(self, fake_result, fake_advanced_search):
+        fake_advanced_search.return_value = fake_search_results()
+        fake_result.return_value = fake_search_result()
+        # The judgment search results view takes the query term from the (desktop) query input
+        response = self.client.get(
+            "/judgments/advanced_search?query=waltham+forest&query_mobile="
+        )
+        self.assertContains(
+            response,
+            '<span class="results-search-component__removable-options-value-text">waltham forest</span>',
+        )
+
+    @patch("judgments.views.results.perform_advanced_search")
+    @patch("judgments.models.SearchResult.create_from_node")
+    def test_judgment_advanced_search_mobile(self, fake_result, fake_advanced_search):
+        fake_advanced_search.return_value = fake_search_results()
+        fake_result.return_value = fake_search_result()
+        # The judgment search results view takes the query term from the mobile query input
+        response = self.client.get(
+            "/judgments/advanced_search?query=&query_mobile=waltham+forest"
+        )
+        self.assertContains(
+            response,
+            '<span class="results-search-component__removable-options-value-text">waltham forest</span>',
+        )
+
 
 class TestAtomFeed(TestCase):
     @patch("judgments.feeds.perform_advanced_search")

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -34,8 +34,10 @@ def fake_search_result():
 class TestSearchResults(TestCase):
     @patch("judgments.views.results.perform_advanced_search")
     @patch("judgments.models.SearchResult.create_from_node")
-    def test_judgment_results_desktop(self, fake_result, fake_advanced_search):
+    @patch("judgments.utils.perform_advanced_search")
+    def test_judgment_results_desktop(self, f3, fake_result, fake_advanced_search):
         fake_advanced_search.return_value = fake_search_results()
+        f3.r = fake_search_results()
         fake_result.return_value = fake_search_result()
         # The judgment search results view takes the query term from the (desktop) query input
         response = self.client.get(
@@ -60,7 +62,7 @@ class TestSearchResults(TestCase):
             '<span class="results-search-component__removable-options-value-text">waltham forest</span>',
         )
 
-    @patch("judgments.views.results.perform_advanced_search")
+    @patch("judgments.views.advanced_search.perform_advanced_search")
     @patch("judgments.models.SearchResult.create_from_node")
     def test_judgment_advanced_search_desktop(self, fake_result, fake_advanced_search):
         fake_advanced_search.return_value = fake_search_results()
@@ -74,7 +76,7 @@ class TestSearchResults(TestCase):
             '<span class="results-search-component__removable-options-value-text">waltham forest</span>',
         )
 
-    @patch("judgments.views.results.perform_advanced_search")
+    @patch("judgments.views.advanced_search.perform_advanced_search")
     @patch("judgments.models.SearchResult.create_from_node")
     def test_judgment_advanced_search_mobile(self, fake_result, fake_advanced_search):
         fake_advanced_search.return_value = fake_search_results()

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -20,7 +20,7 @@ from judgments.utils import (
 def advanced_search(request):
     params = request.GET
     query_params = {
-        "query": params.get("query"),
+        "query": params.get("query") or params.get("query_mobile"),
         "court": params.getlist("court"),
         "judge": params.get("judge"),
         "party": params.get("party"),
@@ -51,7 +51,7 @@ def advanced_search(request):
     context = {}
 
     try:
-        query_without_stop_words = remove_unquoted_stop_words(params.get("query"))
+        query_without_stop_words = remove_unquoted_stop_words(query_params["query"])
         model = perform_advanced_search(
             query=query_without_stop_words,
             court=query_params["court"],
@@ -65,7 +65,7 @@ def advanced_search(request):
             date_to=query_params["to"],
             per_page=per_page,
         )
-
+        context["query"] = query_params["query"]
         context["search_results"] = [
             SearchResult.create_from_node(result) for result in model.results
         ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --ds=config.settings.test --reuse-db
+addopts = --ds=config.settings.test --reuse-db --disable-socket
 python_files = tests.py test_*.py
 filterwarnings =
     ignore::django.utils.deprecation.RemovedInDjango40Warning

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -10,6 +10,7 @@ mypy==1.1.1  # https://github.com/python/mypy
 django-stubs==1.15.0  # https://github.com/typeddjango/django-stubs
 pytest==7.2.2  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.6  # https://github.com/Frozenball/pytest-sugar
+pytest-socket==0.6.0 # https://github.com/miketheman/pytest-socket
 
 # Code quality
 # ------------------------------------------------------------------------------


### PR DESCRIPTION

## Changes in this PR:

This fixes the bug identified by Nicki where the advanced search page failed to filter by query term. The issue was an oversight when making earlier changes to the query form apperance on mobile - in order to show the placeholder text only on desktop, we need to provide two different inputs (one for mobile, one for desktop), and selectively show each one with CSS. This in turn means they need different IDs, or the one that is second in the markup will 'overwrite' the one that is first at submit time. This is what happened here - both fields were named 'query' and therefore the (blank) mobile field was used in preference to the (filled) desktop one.

Have fixed by renaming the mobile field, and added a test to ensure the correct behaviour.

It's been mentioned that perhaps there's no need to use placeholder text at any breakpoint, which would remove a lot of incidental technical complexity here, and stop these kinds of things from happening again. Will leave that for another day, but it'd be a very worthwhile simplification i think!



## Trello card / Rollbar error (etc)

https://trello.com/c/moe7NdzX/594-pui-odd-search-behaviour
