### PR TITLE
Add pytest-socket

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --ds=config.settings.test --reuse-db
+addopts = --ds=config.settings.test --reuse-db --disable-socket
 python_files = tests.py test_*.py
 filterwarnings =
     ignore::django.utils.deprecation.RemovedInDjango40Warning

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -10,6 +10,7 @@ mypy==1.1.1  # https://github.com/python/mypy
 django-stubs==1.15.0  # https://github.com/typeddjango/django-stubs
 pytest==7.2.2  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.6  # https://github.com/Frozenball/pytest-sugar
+pytest-socket==0.6.0 # https://github.com/miketheman/pytest-socket
 
 # Code quality
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This pytest plugin blocks any attempt for tests to contact the network at the socket level.

Our tests should never rely on making an external network call, but it's currently possible (and very easy in functional tests) to accidentally do just that without noticing. pytest-socket prevents any outgoing network calls and immediately raises an exception when they occur, so we can spot the problem and fix it.