### PR TITLE
Fix format of date ranges supplied to date inputs

### DIFF
--- a/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
@@ -13,12 +13,12 @@
   <div class="structured-search__multi-fields-panel">
     <div class="structured-search__limit-to-container">
       <label for="from_date" class="structured-search__limit-to-label">From date</label>
-      <input class="structured-search__date-input" id="from_date" max="3-3-2022" min="02-01-2003" name="from"
+      <input class="structured-search__date-input" id="from_date" min="2003-01-02" name="from"
              placeholder="DD-MM-YYYY" type="date" value="{{context.from}}"/>
     </div>
     <div class="structured-search__limit-to-container">
       <label for="to_date" class="structured-search__limit-to-label">To date</label>
-      <input class="structured-search__date-input" id="to_date" max="3-3-2022" min="02-01-2003" name="to"
+      <input class="structured-search__date-input" id="to_date" min="2003-01-02" name="to"
              placeholder="DD-MM-YYYY" type="date" value="{{context.to}}">
     </div>
   </div>


### PR DESCRIPTION

## Changes in this PR:
This fixes [#630 - Calendar year missing on firefox browers](https://trello.com/c/hG5D5ivY/630-calendar-year-missing-on-firefox-browsers) - the issue was that the `min` and `max` dates specified used the wrong format ("DD-MM-YYYY" instead of "YYYY-MM-DD"). It appears that most browsers were clever enough to parse the other format, but FF had troubles. Have amended to the YYYY-MM-DD format which is specified in the standard.

## Trello card / Rollbar error (etc)
https://trello.com/c/hG5D5ivY/630-calendar-year-missing-on-firefox-browsers

## Screenshots of UI changes:
![image](https://user-images.githubusercontent.com/4279/225282444-8f98efe5-053a-42b2-8b6f-bdd3f45d5221.png)

