### PR TITLE
design change for structured search panels

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -5,6 +5,7 @@
     padding: calc($spacer__unit * 1.5) 0 calc($spacer__unit * 1.5);
     margin: 0 0 $spacer__unit;
     text-align: center;
+    border-top: 4px solid $color__yellow;
   }
 
   &__main-search-header {
@@ -59,7 +60,7 @@
 
   &__limit-to-label {
     display: block;
-    margin-bottom: 1rem;
+    margin-bottom: 0rem;
     font-size: 1rem;
     font-weight: bold;
   }
@@ -128,17 +129,19 @@
   }
 
   &__specific-field-container {
-    background-color: $color__yellow;
+    background-color: $color__light-grey;
     padding: $spacer__unit;
     display: flex;
     flex-direction: column;
+    border-top: 4px solid $color__yellow;
   }
 
   &__limit-to-container {
-    background-color: $color__yellow;
+    background-color: $color__light-grey;
     padding: $spacer__unit;
     display: flex;
     flex-direction: column;
+    border-top: 4px solid $color__yellow;
   }
 
   &__submit-container {


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Update design of structured search panel so that it..

- was more easy on the eye, (better visibility of search options).
- reduced depth by taking out the form label margin, 
- retained a light touch of yellow sign post each panel.

## Trello card / Rollbar error (etc)
https://trello.com/c/f26ashyA/758-%F0%9F%94%8D-pui-browse-design-an-alternative-look-and-feel-for-the-advanced-search-form-that-doesnt-use-the-bright-yellow-background
## Screenshots of UI changes:

### Before
![Screenshot 2023-04-05 at 10 52 07](https://user-images.githubusercontent.com/102584881/230046505-c220bfc3-26e4-4a44-b16a-09f1fd83a357.png)

### After
![Screenshot 2023-04-05 at 10 48 33](https://user-images.githubusercontent.com/102584881/230046358-3559ecb3-5e42-47a9-9ae2-f7a5cf2ee068.png)

- [ ] Requires env variable(s) to be updated
