### PR TITLE
update result listing positions ncn,court,date

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgments_listing.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgments_listing.scss
@@ -40,21 +40,11 @@
     font-family: $font__roboto;
   }
 
-  &__neutralcitation {
-    font-size: 0.9rem;
-  }
-
-  &__date {
-    display: block;
-    font-size: 0.9rem;
-    color: $color__dark-grey;
-
-    @media (min-width: $grid__breakpoint-medium) {
-      text-align: right;
-    }
-  }
-
   &__court {
+    font-size: 0.9rem;
+  }
+
+  &__neutralcitation {
     display: block;
     font-size: 0.9rem;
     color: $color__dark-grey;
@@ -67,6 +57,17 @@
       margin-top: 0;
     }
   }
+
+  &__date {
+    display: block;
+    font-size: 0.9rem;
+    color: $color__dark-grey;
+
+    @media (min-width: $grid__breakpoint-medium) {
+      text-align: right;
+    }
+  }
+
 
   &__result-term-matching {
     display: block;

--- a/ds_judgements_public_ui/templates/includes/recent_judgments.html
+++ b/ds_judgements_public_ui/templates/includes/recent_judgments.html
@@ -9,14 +9,11 @@
             <span class="judgment-listing__title">
               <a href="{% url 'detail' item.uri %}">{{ item.name }}</a>
             </span>
-            <span class="judgment-listing__neutralcitation">
-              Neutral citation:
-              {{ item.neutral_citation }}
-            </span>
+            <span class="judgment-listing__court">{% translate "judgments.court" %} {{ item.court }}</span>
           </span>
           <span>
-            <span class="judgment-listing__date">{% translate "judgments.date" %} {{ item.date }}</span>
-            <span class="judgment-listing__court">{% translate "judgments.court" %} {{ item.court }}</span>
+            <span class="judgment-listing__neutralcitation">{{ item.neutral_citation }}</span>
+            <span class="judgment-listing__date">{{ item.date }}</span>
           </span>
         </li>
       {% endfor %}

--- a/ds_judgements_public_ui/templates/includes/results_list.html
+++ b/ds_judgements_public_ui/templates/includes/results_list.html
@@ -8,22 +8,19 @@
           <span class="judgment-listing__title">
             <a href="{% url 'detail' item.uri %}">{{ item.name }}</a>
           </span>
-          <span class="judgment-listing__neutralcitation">
-            Neutral citation:
-            {{ item.neutral_citation }}
-          </span>
-        </span>
-        <span>
-          <span class="judgment-listing__date">{% translate "judgments.date" %} {{ item.date }}</span>
           <span class="judgment-listing__court">{% translate "judgments.court" %} {{ item.court }}</span>
         </span>
-      </span>
-      {% if item.matches %}
-        <span class="judgment-listing__result-term-matching">Matching text sample:</span>
-        <span class="judgment-listing__matches">
-          {% autoescape off %}
-            {{ item.matches }}
-          {% endautoescape %}
+        <span>
+          <span class="judgment-listing__neutralcitation">{{ item.neutral_citation }}</span>
+          <span class="judgment-listing__date">{{ item.date }}</span>
+        </span>
+        {% if item.matches %}
+          <span class="judgment-listing__result-term-matching">Matching text sample:</span>
+          <span class="judgment-listing__matches">
+            {% autoescape off %}
+              {{ item.matches }}
+            {% endautoescape %}
+          </span>
         </span>
       {% endif %}
     </li>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Judgment title and NEUTRAL CITATION go in the first row (so Neutral Citation takes the place of Date, currently). This aids with copying and pasting (done frequently by expert users, as the layout naturally follows the accepted citation format.

COURT NAME and DATE go in the second row (taking the place of neutral citation and court in the current design). This aids quick scanning of the results by court, as the court names are ranged left flush against the margin (a more likely case than scanning by neutral citation, as we already offer the opportunity to search for a Neutral Citation directly)

Dates remain aligned with the ‘date sort’ selector above the list to make the connection between them clear.

Removing the labels “Neutral citation:”, “Date:” as all are now clear from context.
## Trello card / Rollbar error (etc)
https://trello.com/c/JLGFTtWs/766-%F0%9F%94%8D-pui-browse-redesign-search-result-listing-position

## Screenshots of UI changes:

### Before
![before-results-position](https://user-images.githubusercontent.com/75584408/230132718-7de81b78-f429-4521-8aa5-c7ebc90d1c64.png)
### After
![after-position-results](https://user-images.githubusercontent.com/75584408/230132854-f4855b8c-2a1c-42ef-866f-3cdbcb0b651a.png)

- [ ] Requires env variable(s) to be updated
