### PR TITLE
Add a 'back to top' link to static pages

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_help_end_document_marker.scss
+++ b/ds_judgements_public_ui/sass/includes/_help_end_document_marker.scss
@@ -1,11 +1,10 @@
-.judgment-end-document-marker {
+.help-end-document-marker {
     width: 100%;
-    border: 1px dashed $color__black;
-    border-top: none;
+    border-top: 4px solid $color__yellow;
     height: $spacer__unit;
     max-width: 90%;
     margin: auto;
-    margin-bottom: calc($spacer__unit * 7);
+    margin-bottom: calc($spacer__unit * 8);
     text-align: center;
     @media (min-width: $grid__breakpoint-medium) {
       max-width: 40rem;
@@ -20,9 +19,9 @@
         background-color: white;
         padding: calc($spacer__unit * 0.5);
         padding-top: calc($spacer__unit * 0.3);
+        margin-top: 0.5rem;
 
         a {
-            display: none;
             margin-top: 1.5rem;
 
             &::before {

--- a/ds_judgements_public_ui/sass/includes/_standard_text_template.scss
+++ b/ds_judgements_public_ui/sass/includes/_standard_text_template.scss
@@ -9,7 +9,7 @@
   }
 
   margin-top: calc($spacer__unit * 4);
-  margin-bottom: calc($spacer__unit * 8);
+  margin-bottom: calc($spacer__unit * 4);
   min-height: 18rem;
 
   h1, h2, h3 {

--- a/ds_judgements_public_ui/sass/main.scss
+++ b/ds_judgements_public_ui/sass/main.scss
@@ -29,4 +29,5 @@
 @import "includes/cookie_consent/cookie-consent";
 @import "includes/homepage_browse";
 @import "includes/what_to_expect";
+@import "includes/help_end_document_marker";
 @import "includes/js_enabled";

--- a/ds_judgements_public_ui/static/js/src/modules/document_navigation_links.js
+++ b/ds_judgements_public_ui/static/js/src/modules/document_navigation_links.js
@@ -35,7 +35,7 @@ $(() => {
     );
 
     let footerBackLink = document.querySelector(
-        ".end-document-marker__top-link a"
+        ".judgment-end-document-marker__top-link a"
     );
 
     if (footerBackLink) {

--- a/ds_judgements_public_ui/templates/includes/help_end_document_marker.html
+++ b/ds_judgements_public_ui/templates/includes/help_end_document_marker.html
@@ -1,0 +1,5 @@
+<div class="help-end-document-marker" id="end-of-document">
+  <div class="help-end-document-marker__top-link">
+    <a href="#start-of-document">Back to top</a>
+  </div>
+</div>

--- a/ds_judgements_public_ui/templates/includes/judgment_end_document_marker.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_end_document_marker.html
@@ -1,5 +1,5 @@
-<div class="end-document-marker" id="end-of-document">
-  <div class="end-document-marker__top-link">
+<div class="judgment-end-document-marker" id="end-of-document">
+  <div class="judgment-end-document-marker__top-link">
     <span>End of document</span>
     <br />
     <a href="#start-of-document">Back to top</a>

--- a/ds_judgements_public_ui/templates/pages/accessibility_statement.html
+++ b/ds_judgements_public_ui/templates/pages/accessibility_statement.html
@@ -7,7 +7,7 @@
 {% endblock title %}
 {% block content %}
   {% translate "accessibilitystatement.title" as page_title %}
-  <header class="page-header">
+  <header class="page-header" id="start-of-document">
     {% include "includes/breadcrumbs.html" with current=page_title title=page_title link=request.path %}
     {% include "includes/logo.html" %}
   </header>
@@ -134,4 +134,5 @@
       </p>
     </div>
   </div>
+  {% include "includes/help_end_document_marker.html" %}
 {% endblock content %}

--- a/ds_judgements_public_ui/templates/pages/how_to_use_this_service.html
+++ b/ds_judgements_public_ui/templates/pages/how_to_use_this_service.html
@@ -7,7 +7,7 @@
 {% endblock title %}
 {% block content %}
   {% translate "howtousethisservice.title" as page_title %}
-  <header class="page-header">
+  <header class="page-header" id="start-of-document">
     {% include "includes/breadcrumbs.html" with current=page_title title=page_title link=request.path %}
     {% include "includes/logo.html" %}
   </header>
@@ -304,4 +304,5 @@
       <a href="mailto:{% translate "caselaw.email" %}">{% translate "caselaw.email" %}</a>.
     </p>
   </div>
+  {% include "includes/help_end_document_marker.html" %}
 {% endblock content %}

--- a/ds_judgements_public_ui/templates/pages/open_justice_licence.html
+++ b/ds_judgements_public_ui/templates/pages/open_justice_licence.html
@@ -7,7 +7,7 @@
 {% endblock title %}
 {% block content %}
   {% translate "openjusticelicence.title" as page_title %}
-  <header class="page-header">
+  <header class="page-header" id="start-of-document">
     {% include "includes/breadcrumbs.html" with current=page_title title=page_title link=request.path %}
     {% include "includes/logo.html" %}
   </header>
@@ -186,4 +186,5 @@
       on The National Archives website.
     </p>
   </div>
+  {% include "includes/help_end_document_marker.html" %}
 {% endblock content %}

--- a/ds_judgements_public_ui/templates/pages/terms_of_use.html
+++ b/ds_judgements_public_ui/templates/pages/terms_of_use.html
@@ -7,7 +7,7 @@
 {% endblock title %}
 {% block content %}
   {% translate "terms.title" as page_title %}
-  <header class="page-header">
+  <header class="page-header" id="start-of-document">
     {% include "includes/breadcrumbs.html" with current=page_title title=page_title link=request.path %}
     {% include "includes/logo.html" %}
   </header>
@@ -122,4 +122,5 @@
       </p>
     </section>
   </div>
+  {% include "includes/help_end_document_marker.html" %}
 {% endblock content %}

--- a/ds_judgements_public_ui/templates/pages/transactional_licence.html
+++ b/ds_judgements_public_ui/templates/pages/transactional_licence.html
@@ -7,7 +7,7 @@
 {% endblock title %}
 {% block content %}
   {% translate "transactionallicenceform.title" as page_title %}
-  <header class="page-header">
+  <header class="page-header" id="start-of-document">
     {% include "includes/breadcrumbs.html" with current=page_title title=page_title link=request.path %}
     {% include "includes/logo.html" %}
   </header>
@@ -292,4 +292,5 @@
       </li>
     </ul>
   </div>
+  {% include "includes/help_end_document_marker.html" %}
 {% endblock content %}

--- a/ds_judgements_public_ui/templates/pages/what_to_expect.html
+++ b/ds_judgements_public_ui/templates/pages/what_to_expect.html
@@ -8,7 +8,7 @@
 {% endblock title %}
 {% block content %}
   {% translate "whattoexpect.title" as page_title %}
-  <header class="page-header">
+  <header class="page-header" id="start-of-document">
     {% include "includes/breadcrumbs.html" with current=page_title title=page_title link=request.path %}
     {% include "includes/logo.html" %}
   </header>
@@ -567,4 +567,5 @@
       <a href="mailto:{% translate "caselaw.email" %}">{% translate "caselaw.email" %}</a>.
     </p>
   </div>
+  {% include "includes/help_end_document_marker.html" %}
 {% endblock content %}


### PR DESCRIPTION
## Changes in this PR:

For ease of navigation.

This is added to  the accessibility statement, how to use this service, open justice licence, terms of use, transactional licence, and what to expect pages.

## Screenshots of UI changes:
<img width="757" alt="Screenshot 2023-04-06 at 12 08 04" src="https://user-images.githubusercontent.com/4279/230350537-a9a9bf6c-10b1-404a-9883-5a413b1ff721.png">
