### PR TITLE
Use full court name in search results and applied filters ...

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_results_search_component.scss
+++ b/ds_judgements_public_ui/sass/includes/_results_search_component.scss
@@ -264,12 +264,13 @@
     text-decoration: none;
     padding: calc($spacer__unit / 2) calc($spacer__unit / 2) calc($spacer__unit / 2) $spacer__unit;
 
-    &:visited {
+    &:hover {
+      background: $color__yellow;
       color: $color__black;
     }
 
-    &:hover {
-      background: $color__yellow;
+    &:visited {
+      color: $color__black;
     }
 
     &:focus {

--- a/ds_judgements_public_ui/templates/includes/recent_judgments.html
+++ b/ds_judgements_public_ui/templates/includes/recent_judgments.html
@@ -9,11 +9,11 @@
             <span class="judgment-listing__title">
               <a href="{% url 'detail' item.uri %}">{{ item.name }}</a>
             </span>
-            <span class="judgment-listing__court">{% translate "judgments.court" %} {{ item.court }}</span>
+            <span class="judgment-listing__court">{{ item.court.name }}</span>
           </span>
           <span>
             <span class="judgment-listing__neutralcitation">{{ item.neutral_citation }}</span>
-            <span class="judgment-listing__date">{{ item.date }}</span>
+            <span class="judgment-listing__date">{{ item.date|date }}</span>
           </span>
         </li>
       {% endfor %}

--- a/ds_judgements_public_ui/templates/includes/results_applied_filters.html
+++ b/ds_judgements_public_ui/templates/includes/results_applied_filters.html
@@ -28,9 +28,8 @@
                  class="results-search-component__removable-options-link"
                  href="{% url 'advanced_search' %}?{{ context.query_params|remove_court:court }}"
                  title="{{ court|get_court_name }}">
-                <span class="results-search-component__removable-options-key">{{ key|capfirst }}:</span>
                 <span class="results-search-component__removable-options-value">
-                  <span class="results-search-component__removable-options-value-text">{{ court }}</span>
+                  <span class="results-search-component__removable-options-value-text">{{ court|get_court_name }}</span>
                 </span>
               </a>
             </li>

--- a/ds_judgements_public_ui/templates/includes/results_list.html
+++ b/ds_judgements_public_ui/templates/includes/results_list.html
@@ -8,11 +8,11 @@
           <span class="judgment-listing__title">
             <a href="{% url 'detail' item.uri %}">{{ item.name }}</a>
           </span>
-          <span class="judgment-listing__court">{% translate "judgments.court" %} {{ item.court }}</span>
+          <span class="judgment-listing__court">{{ item.court.name }}</span>
         </span>
         <span>
           <span class="judgment-listing__neutralcitation">{{ item.neutral_citation }}</span>
-          <span class="judgment-listing__date">{{ item.date }}</span>
+          <span class="judgment-listing__date">{{ item.date|date }}</span>
         </span>
       </span>
       {% if item.matches %}

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -124,8 +124,7 @@ class LatestJudgmentsFeed(Feed):
         return datetime.datetime.fromisoformat(date_string)
 
     def item_pubdate(self, item: SearchResult) -> datetime.datetime:
-        date_string = item.date or "1970-01-01"
-        return datetime.datetime.fromisoformat(date_string)
+        return item.date
 
     def feed_extra_kwargs(self, obj):
         extra_kwargs = super().item_extra_kwargs(obj)

--- a/judgments/models.py
+++ b/judgments/models.py
@@ -1,8 +1,10 @@
 from os.path import dirname, join
 
 from caselawclient.Client import api_client
+from dateutil import parser as dateparser
 from django.db import models
 from djxml import xmlmodels
+from ds_caselaw_utils import courts
 from lxml import etree
 
 
@@ -23,8 +25,11 @@ class SearchResult:
         self.uri = uri
         self.neutral_citation = neutral_citation
         self.name = name
-        self.date = date
-        self.court = court
+        self.date = dateparser.parse(date)
+        try:
+            self.court = courts.get_by_code(court)
+        except KeyError:
+            self.court = None
         self.matches = matches
         self.author = author
         self.last_modified = last_modified

--- a/judgments/models.py
+++ b/judgments/models.py
@@ -4,7 +4,7 @@ from caselawclient.Client import api_client
 from dateutil import parser as dateparser
 from django.db import models
 from djxml import xmlmodels
-from ds_caselaw_utils import courts
+from ds_caselaw_utils.courts import CourtNotFoundException, courts
 from lxml import etree
 
 
@@ -28,7 +28,7 @@ class SearchResult:
         self.date = dateparser.parse(date)
         try:
             self.court = courts.get_by_code(court)
-        except KeyError:
+        except CourtNotFoundException:
             self.court = None
         self.matches = matches
         self.author = author

--- a/judgments/templatetags/court_utils.py
+++ b/judgments/templatetags/court_utils.py
@@ -1,6 +1,7 @@
 from django import template
 from django.utils.safestring import mark_safe
-from ds_caselaw_utils import courts as all_courts
+from ds_caselaw_utils.courts import CourtNotFoundException
+from ds_caselaw_utils.courts import courts as all_courts
 
 from judgments.models import CourtDates
 
@@ -11,7 +12,7 @@ register = template.Library()
 def get_court_name(court):
     try:
         court_object = all_courts.get_by_param(court)
-    except KeyError:
+    except CourtNotFoundException:
         return ""
     return court_object.name
 

--- a/judgments/templatetags/court_utils.py
+++ b/judgments/templatetags/court_utils.py
@@ -9,8 +9,9 @@ register = template.Library()
 
 @register.filter
 def get_court_name(court):
-    court_object = all_courts.get_by_param(court)
-    if court_object is None:
+    try:
+        court_object = all_courts.get_by_param(court)
+    except KeyError:
         return ""
     return court_object.name
 

--- a/judgments/tests.py
+++ b/judgments/tests.py
@@ -3,6 +3,7 @@ from os import environ
 from unittest import skip
 from unittest.mock import Mock, patch
 
+from dateutil import parser as dateparser
 from django.test import TestCase
 from lxml import etree
 
@@ -197,8 +198,8 @@ class TestSearchResult(TestCase):
         )
         self.assertEqual("ukut/lc/2022/241", search_result.uri)
         self.assertEqual("[2022] UKUT 241 (LC)", search_result.neutral_citation)
-        self.assertEqual("UKUT-LC", search_result.court)
-        self.assertEqual("2022-09-09", search_result.date)
+        self.assertEqual("UKUT-LC", search_result.court.code)
+        self.assertEqual(dateparser.parse("2022-09-09"), search_result.date)
         self.assertEqual("2022-10-10", search_result.transformation_date)
 
     @patch("judgments.models.api_client")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,6 @@ lxml~=4.9.2
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client~=5.2.6
-ds-caselaw-utils~=0.4.4
+ds-caselaw-utils~=0.5.0
 rollbar
 django-weasyprint==2.2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,6 @@ lxml~=4.9.2
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client~=5.2.6
-ds-caselaw-utils~=0.5.0
+ds-caselaw-utils~=1.0.0
 rollbar
 django-weasyprint==2.2.0


### PR DESCRIPTION
…and human formatted dates in search results

## Changes in this PR:

This improves readability of search results in a few different respects - using full court names everywhere, and dates formatted in human-readable style.

(This one was a @timcowlishaw and @Donna-H co-production)

## Trello card / Rollbar error (etc)

https://trello.com/c/SJ79Bqk5/772-%F0%9F%94%8D-pui-replace-court-code-with-full-court-name-in-search-result-listing
https://trello.com/c/QKkEAnJp/767-%F0%9F%94%8D-pui-use-a-standard-human-readable-date-format-everywhere-we-show-dates-across-pui
and
https://trello.com/c/5wCZuSKW/763-%F0%9F%94%8D-pui-use-court-name-instead-of-court-abbreviation-in-applied-filter-dropdowns

## Screenshots of UI changes:

### Befo
<img width="1405" alt="Screenshot 2023-04-06 at 15 50 05" src="https://user-images.githubusercontent.com/4279/230398271-a0bf5a81-ae3f-4c9d-988a-7e60b3a007c6.png">
re

### After
<img width="1284" alt="Screenshot 2023-04-06 at 14 50 11" src="https://user-images.githubusercontent.com/4279/230398323-fc886ad4-001f-4eb6-9564-bd5404324e16.png">

<img width="448" alt="Screenshot 2023-04-06 at 15 47 15" src="https://user-images.githubusercontent.com/4279/230398348-ae902401-a6bb-4152-a6dc-9d37845b0a96.png">

<img width="448" alt="Screenshot 2023-04-06 at 15 47 08" src="https://user-images.githubusercontent.com/4279/230398355-3d9dcf81-70d4-4a32-8082-eeadcf900c9c.png">

