### PR TITLE
Provoke AWS into sending Content-Length header

### DIFF
--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -112,7 +112,9 @@ def detail_xml(_request, judgment_uri):
 
 def get_pdf_size(judgment_uri):
     """Return the size of the S3 PDF for a judgment as a string in brackets, or an empty string if unavailable"""
-    response = requests.head(get_pdf_uri(judgment_uri))
+    response = requests.head(
+        get_pdf_uri(judgment_uri), headers={"Accept-Encoding": None}
+    )
     content_length = response.headers.get("Content-Length", None)
     if content_length:
         filesize = filesizeformat(int(content_length))


### PR DESCRIPTION
head used to get content lengths, but does not any more, unless Accept-Encoding is unset, presumably because compressed files might have different lengths (unsure if a requests or AWS change)