### PR TITLE
Check status code rather than depending on size

### DIFF
--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -116,10 +116,13 @@ def get_pdf_size(judgment_uri):
         get_pdf_uri(judgment_uri), headers={"Accept-Encoding": None}
     )
     content_length = response.headers.get("Content-Length", None)
+    if response.status_code >= 400:
+        return ""
     if content_length:
         filesize = filesizeformat(int(content_length))
         return f" ({filesize})"
-    return ""
+    logging.warn(f"Unable to determine PDF size for {judgment_uri}")
+    return " (unknown size)"
 
 
 def get_back_link(request):


### PR DESCRIPTION
The Content-Size of the S3 document is frail: we should be explicitly checking the status code instead.