### PR TITLE
took out search label to let users find thier own way

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_buttons.scss
+++ b/ds_judgements_public_ui/sass/includes/_buttons.scss
@@ -1,0 +1,43 @@
+.button-cta {
+    @include call-to-action-button;
+    border: 2px solid $color__cta-background;
+
+    &:disabled,  &[aria-disabled="true"] {
+      background-color: $color__dark-grey;
+      &:focus, &:hover {
+        outline: none;
+        background-color: $color__dark-grey;
+        color: $color__white;
+        text-decoration: none;
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  .button-secondary {
+    @include call-to-action-button;
+    background-color: $color__white;
+    color: $color__cta-background;
+    border: 2px solid $color__cta-background;
+
+    &:visited {
+      color: $color__cta-background;
+    }
+
+    &:focus, &:hover {
+      color: white;
+    }
+
+    &:disabled,  &[aria-disabled="true"] {
+      color: $color__dark-grey;
+      background-color: transparent;
+      border-color: $color__grey;
+      &:focus, &:hover {
+        outline: none;
+        background-color: transparent;
+        color: $color__dark-grey;
+        text-decoration: none;
+        cursor: not-allowed;
+      }
+    }
+  }

--- a/ds_judgements_public_ui/sass/includes/_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_search.scss
@@ -105,4 +105,9 @@
     margin: calc($spacer__unit / 3) 0 calc($spacer__unit / 2) 0;
     font-size: 0.8rem;
   }
+
+  &__main-label {
+    text-align: left;
+    margin: calc($spacer__unit / 3) 0 calc($spacer__unit / 2) 0;
+  }
 }

--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -2,7 +2,7 @@
 
   &__main-search {
     background-color: $color__light-grey;
-    padding: calc($spacer__unit * 1.5) 0 calc($spacer__unit * 1.5);
+    padding: calc($spacer__unit * 1) 0 calc($spacer__unit * 1.5);
     margin: 0 0 $spacer__unit;
     text-align: center;
   }
@@ -14,7 +14,7 @@
     font-family: $font__roboto;
     font-weight: normal;
     color: $color__almost-black;
-    margin: calc($spacer__unit * 3) 0 0 0;
+    margin: calc($spacer__unit * 1) 0 0 0;
     @media (max-width: $grid__breakpoint-medium) {
       margin: 1px $spacer__unit;
       line-height: 2.6rem;

--- a/ds_judgements_public_ui/sass/main.scss
+++ b/ds_judgements_public_ui/sass/main.scss
@@ -31,3 +31,4 @@
 @import "includes/what_to_expect";
 @import "includes/help_end_document_marker";
 @import "includes/js_enabled";
+@import "includes/buttons";

--- a/ds_judgements_public_ui/templates/includes/search_term_component.html
+++ b/ds_judgements_public_ui/templates/includes/search_term_component.html
@@ -9,6 +9,10 @@
          type="text"
          value="{{ query }}"
          placeholder="{% translate "basicsearchform.placeholder" %}"/>
-  <p class="search-term-component__help-text">{% translate "basicsearchform.helptext" %}</p>
+  {% if show_help_text %}
+    <p class="search-term-component__help-text">
+      <a href='{% url "how_to_use_this_service" %}#section-search'>{% translate "basic.search.helptext" %}</a>
+    </p>
+  {% endif %}
 </div>
-<input type="submit" value="{% translate "basicsearchform.cta" %}" />
+<input type="submit" value="{% translate "basicsearchform.cta" %}"/>

--- a/ds_judgements_public_ui/templates/pages/how_to_use_this_service.html
+++ b/ds_judgements_public_ui/templates/pages/how_to_use_this_service.html
@@ -15,7 +15,7 @@
     <h1>How to use the Find Case Law service</h1>
     <p>
       <small>Last updated on
-        <time datetime="27-05-2022">27th May 2022</time>
+        <time datetime="13-04-2023">13th April 2023</time>
       </small>
     </p>
     <div class="anchor-links">
@@ -28,7 +28,7 @@
           <a href="#section-no-advice">We do not provide legal advice</a>
         </li>
         <li class="anchor-links__list-option">
-          <a href="#section-find">Find a judgment or decision</a>
+          <a href="#section-search">How to search</a>
         </li>
         <li class="anchor-links__list-option">
           <a href="#section-understanding">Understanding a judgment or decision</a>
@@ -69,7 +69,7 @@
         <a href="https://www.weareadvocate.org.uk">Advocate</a>
       </li>
     </ul>
-    <h2 id="section-find">Find a judgment or decision</h2>
+    <h2 id="section-search">How to search</h2>
     <p>
       You can search the full text of every judgment and decision. You can also search and browse judgments by neutral
       citation, court, party, judge and within a date range. These options can be combined on the

--- a/ds_judgements_public_ui/templates/pages/structured_search.html
+++ b/ds_judgements_public_ui/templates/pages/structured_search.html
@@ -18,7 +18,7 @@
         <div class="structured-search__container">
           <h1 class="structured-search__main-search-header">Structured search</h1>
           <div class="structured-search__full-text-panel search-term-component">
-            {% include "includes/search_term_component.html" %}
+            {% include "includes/search_term_component.html" with show_help_text=True %}
           </div>
         </div>
       </div>

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -197,9 +197,11 @@ msgstr "Search"
 msgid "basicsearchform.placeholder"
 msgstr "Search..."
 
+
+
 #: ds_judgements_public_ui/templates/includes/search_term_component.html
-msgid "basicsearchform.helptext"
-msgstr "Enter keyword, party name or neutral&nbsp;citation"
+msgid "basic.search.helptext"
+msgstr "How to search"
 
 #: ds_judgements_public_ui/templates/includes/search_term_component.html
 msgid "basicsearchform.cta"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

- Having reviewed the original requirements, we decided to try and take the label and the help text away from the main search box for both the home screen and the structured search screen.
- I have also reduced some excess margin to help reduce scrolling and display more page content at the top.
- **Please note, to keep this PR small, I will be revisiting the "_Filter by court, date or person_" text design on a new card after this one.**

## Trello card / Rollbar error (etc)
https://trello.com/c/65C8ohkh/761-%F0%9F%94%8D-pui-browse-make-search-instructions-label-more-prominent-add-instructions-for-phrasal-search
## Screenshots of UI changes:

### Before
![Screenshot 2023-04-11 at 16 17 50](https://user-images.githubusercontent.com/102584881/231209707-de0b1110-379c-4ebe-b36f-648249fbb081.png)
![Screenshot 2023-04-11 at 16 17 36](https://user-images.githubusercontent.com/102584881/231209731-6c3f3ce1-eb03-41a2-8143-b08c24113268.png)

### After
<img width="1382" alt="Screenshot 2023-04-11 at 16 10 34" src="https://user-images.githubusercontent.com/102584881/231209247-e13b3a83-6789-4763-a4ce-bcf916310b31.png">
<img width="1379" alt="Screenshot 2023-04-11 at 16 10 07" src="https://user-images.githubusercontent.com/102584881/231209308-2b91ff79-b24d-475e-a242-7483af8412a7.png">

- [ ] Requires env variable(s) to be updated
