### PR TITLE
Do not assume that a 'context' element exists in response.context_data

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -41,7 +41,7 @@ class FeedbackLinkMiddleware:
             "full_url": request.build_absolute_uri(),
         }
 
-        if "query" in response.context_data["context"]:
+        if "query" in response.context_data.get("context", {}):
             params["search_term"] = response.context_data["context"]["query"]
 
         if "feedback_survey_type" in response.context_data:


### PR DESCRIPTION
This lead to WeasyPrinted PDFs 500ing.
https://my.slack.com/archives/C03C1P4377C/p1681229610647699

