### PR TITLE
fixed text input font size to 1 rem

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_mixins.scss
+++ b/ds_judgements_public_ui/sass/includes/_mixins.scss
@@ -126,6 +126,8 @@
   margin-top: calc($spacer__unit / 2);
   background-color: $color__white;
   width: 80%;
+  font-family: $font__open-sans;
+  font-size: 1rem;
 
   &:focus {
     @include focus-default


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Fixed the font size and font family for all `text-input` to be 1rem and Open-sans.
## Trello card / Rollbar error (etc)
https://trello.com/c/FqycYBUz/789-pui-increase-form-input-text-size-to-1-rem
## Screenshots of UI changes:

### Before
![Screenshot 2023-04-17 at 17 10 12](https://user-images.githubusercontent.com/102584881/232545606-8c29da25-1e7b-437e-91c2-44f7a71e288a.png)

### After
![Screenshot 2023-04-17 at 17 02 21](https://user-images.githubusercontent.com/102584881/232545075-91ce0ce8-5d31-4e61-b46a-340137e6894f.png)

- [ ] Requires env variable(s) to be updated
