### PR TITLE
Install django-flags

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -3,6 +3,7 @@ Base settings to build other settings files upon.
 """
 from pathlib import Path
 
+import django
 import environ
 
 ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
@@ -48,6 +49,8 @@ DATABASES["default"]["ATOMIC_REQUESTS"] = True
 # https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-DEFAULT_AUTO_FIELD
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+FLAGS = {}
+
 # URLS
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#root-urlconf
@@ -67,6 +70,7 @@ DJANGO_APPS = [
     # "django.contrib.humanize", # Handy template tags
     "django.contrib.admin",
     # "django.forms",
+    "flags",
 ]
 
 LOCAL_APPS = [
@@ -161,7 +165,7 @@ TEMPLATES = [
         # https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-TEMPLATES-BACKEND
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         # https://docs.djangoproject.com/en/dev/ref/settings/#dirs
-        "DIRS": [str(APPS_DIR / "templates")],
+        "DIRS": [str(APPS_DIR / "templates"), django.__path__[0] + "/forms/templates"],
         # https://docs.djangoproject.com/en/dev/ref/settings/#app-dirs
         "APP_DIRS": True,
         "OPTIONS": {

--- a/config/urls.py
+++ b/config/urls.py
@@ -14,6 +14,9 @@ def redirect(request, uri):
 
 
 urlpatterns = [
+    # Django Admin, use {% url 'admin:index' %}
+    path(settings.ADMIN_URL, admin.site.urls),
+    # Your stuff: custom urls includes go here
     re_path("^(?P<uri>.*)/$", redirect),
     path(
         "transactional-licence-form",
@@ -55,9 +58,6 @@ urlpatterns = [
         views.CheckView.as_view(),
         name="check",
     ),
-    # Django Admin, use {% url 'admin:index' %}
-    path(settings.ADMIN_URL, admin.site.urls),
-    # Your stuff: custom urls includes go here
     path(
         "robots.txt",
         TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,6 +7,7 @@ whitenoise==6.4.0  # https://github.com/evansd/whitenoise
 # ------------------------------------------------------------------------------
 django==3.2.18  # pyup: < 4.0  # https://www.djangoproject.com/
 django-environ==0.10.0 # https://github.com/joke2k/django-environ
+django-flags==5.0.12 #  https://cfpb.github.io/django-flags/
 django-model-utils==4.3.1  # https://github.com/jazzband/django-model-utils
 
 requests~=2.28.2


### PR DESCRIPTION
## Changes in this PR:
Following instructions from https://cfpb.github.io/django-flags/

This requires access to the admin UI, enabling which exposed a couple of issues:

1) The admin urls in urls.py need to come *before* the redirect to remove the trailing slash, as the trailing slash is required in the admin urls (otherwise it tries to redirect to  eg /adminlogin instead of /admin/login for some reason)

2) The ADMIN_URL needs to *not* have a preceding slash

3) The django default templates need to be loaded for the admin UI to display

This PR fixes all the above, new flags can be added to FLAGS in `setttings/base.py` as required, then enabled in the admin.

## Trello card / Rollbar error (etc)
https://trello.com/b/OYgnaYZc/1-caselaw-beta