### PR TITLE
Bugfix/796 exact phrase search bug

### DIFF
--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -51,6 +51,16 @@ def perform_advanced_search(
     return SearchResults.create_from_string(multipart_data.parts[0].text)
 
 
+def preprocess_query(query):
+    query = normalise_quotes(query)
+    query = remove_unquoted_stop_words(query)
+    return query
+
+
+def normalise_quotes(query):
+    return re.sub(r"[“”]", '"', query)
+
+
 def remove_unquoted_stop_words(query):
     """
     Remove stop words [the, and, of] from a search query, but only if they

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -13,7 +13,7 @@ from judgments.utils import (
     has_filters,
     paginator,
     perform_advanced_search,
-    remove_unquoted_stop_words,
+    preprocess_query,
 )
 
 
@@ -51,7 +51,7 @@ def advanced_search(request):
     context = {}
 
     try:
-        query_without_stop_words = remove_unquoted_stop_words(query_params["query"])
+        query_without_stop_words = preprocess_query(query_params["query"])
         model = perform_advanced_search(
             query=query_without_stop_words,
             court=query_params["court"],

--- a/judgments/views/results.py
+++ b/judgments/views/results.py
@@ -14,15 +14,15 @@ from judgments.utils import (
     has_filters,
     paginator,
     perform_advanced_search,
+    preprocess_query,
 )
 
 
 def results(request):
     context = {"page_title": gettext("results.search.title")}
-
     try:
         params = request.GET
-        query = params.get("query")
+        query = preprocess_query(params.get("query"))
         page = str(as_integer(params.get("page"), minimum=1))
         per_page = str(
             as_integer(


### PR DESCRIPTION
## Changes in this PR:
Normalise quotes in search strings

This fixes two related bugs that were raised by Trello card 796.

     - Firstly, when a search query is pasted in from somewhere (eg word, google docs) that applies 'smart quotes' formatting - the curly quote characters aren't picked up as 'quotes' by marklogic, and it appears that the phrasal search fails. This normalises them to regular ascii quotes beforehand, to ensure that they're respected by marklogic as phrases
     - Secondly, we've been removing stopwords (outside of quoted phrases) when searching from the basic search form, but not from the advanced form. This leads to an incinsistency in the results returned between the two.
     - Finally, our tests for removing stopwords assumed single quotes which *aren't* treated as quotes by marklogic - if we wanted them to be, then this would be a more difficult problem - possibly intractible given we can't identify single quotes meant as quotes from single quotes meant as apostrophes (eg in the phrase ('that's the problem'). This PR at least makes the behaviour consistent for both forms of english double quotes (I've assumed eg spanish-style angled quotes are out of scope, as they're not typically automatically changed in any software).

The result of this is that the search results returned will always be consistent across advanced and basic search, and double quotes will always be respected as phrases.
## Trello card / Rollbar error (etc)

https://trello.com/c/64eURjn6/796-pui-exact-phrase-search-results-arent-ordered-by-judgments-containing-the-exact-phrases

## Screenshots of UI changes:

### Before

![image](https://user-images.githubusercontent.com/4279/233439461-3f9611ad-e6ea-4044-9d2d-ca4aa3fac3b6.png)
![image](https://user-images.githubusercontent.com/4279/233439577-7be6580c-7518-45ca-bf28-8a97cc2ac805.png)


### After
<img width="1398" alt="Screenshot 2023-04-20 at 19 09 37" src="https://user-images.githubusercontent.com/4279/233439607-738b9733-67c7-4f38-8b0e-bbfcbb578135.png">
<img width="1354" alt="Screenshot 2023-04-20 at 19 07 06" src="https://user-images.githubusercontent.com/4279/233439742-43b4c3ed-0fb0-4d64-80fa-41f839dda649.png">

