### PR TITLE
If a date from the database is unparseable, use the raw string

### DIFF
--- a/judgments/models.py
+++ b/judgments/models.py
@@ -2,6 +2,7 @@ from os.path import dirname, join
 
 from caselawclient.Client import api_client
 from dateutil import parser as dateparser
+from dateutil.parser import ParserError
 from django.db import models
 from djxml import xmlmodels
 from ds_caselaw_utils.courts import CourtNotFoundException, courts
@@ -25,7 +26,11 @@ class SearchResult:
         self.uri = uri
         self.neutral_citation = neutral_citation
         self.name = name
-        self.date = dateparser.parse(date)
+
+        try:
+            self.date = dateparser.parse(date)
+        except ParserError:
+            self.date = date
         try:
             self.court = courts.get_by_code(court)
         except CourtNotFoundException:


### PR DESCRIPTION
Some judgments don't have a valid date attribute as understood by the `SearchResult` class. This means their date is set to `""`, which is unparseable. Since we try parse this string, it throws an error.

This PR catches the error and falls back to the raw date string. This will usually be an empty string, but could (in theory) be all kinds of unparseable stuff which nonetheless can be understood by a human.