### PR TITLE
Change date selectors to year/month/date text inputs

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -50,7 +50,8 @@ DATABASES["default"]["ATOMIC_REQUESTS"] = True
 # https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-DEFAULT_AUTO_FIELD
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-FLAGS: Dict[str, Any] = {}
+# Feature flags for django-flags
+FLAGS: Dict[str, Any] = {"TEXT_DATE_INPUT": []}
 
 # URLS
 # ------------------------------------------------------------------------------

--- a/ds_judgements_public_ui/sass/includes/_global.scss
+++ b/ds_judgements_public_ui/sass/includes/_global.scss
@@ -2,3 +2,13 @@ body {
   margin: 0;
   font-family: $font__open-sans;
 }
+
+input[type="number"] {
+  -moz-appearance: textfield;
+}
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}

--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -53,7 +53,8 @@
 
   &__limit-to-input {
     @include text_field;
-    width: 70%;
+    width: 95%;
+    margin-top: calc(0.5 * $spacer__unit);
     margin-bottom: 0;
   }
 
@@ -66,6 +67,10 @@
 
   &__single-field-panel {
     padding-top: $spacer__unit;
+
+    @media (max-width: $grid__breakpoint-medium) {
+      padding-top: 0;
+    }
 
     @media (min-width: $grid__breakpoint-medium) {
       display: grid;
@@ -97,6 +102,9 @@
 
   &__multi-fields-panel {
     padding-top: $spacer__unit;
+    @media (max-width: $grid__breakpoint-medium) {
+      padding-top: 0;
+    }
 
 
     @media (min-width: $grid__breakpoint-medium) {
@@ -133,6 +141,9 @@
     display: flex;
     flex-direction: column;
     border-top: 4px solid $color__yellow;
+    @media (max-width: $grid__breakpoint-medium) {
+      margin-bottom: 1rem;
+    }
   }
 
   &__limit-to-container {
@@ -141,6 +152,9 @@
     display: flex;
     flex-direction: column;
     border-top: 4px solid $color__yellow;
+    @media (max-width: $grid__breakpoint-medium) {
+      margin-bottom: 1rem;
+    }
   }
 
   &__submit-container {
@@ -233,22 +247,29 @@
 
   &__date-input {
     @include text_field;
-    width: 95%;
+    margin-bottom: 0;
+    width: 100% !important;
+    box-sizing: border-box;
+  }
+
+  &__date-input-group {
+    display: flex;
+    gap: calc(0.5 * $spacer__unit);
+    & :nth-of-type(1) {
+      width: 10%;
+    }
+    & :nth-of-type(2){
+      width: 10%;
+    }
+    & :nth-of-type(3){
+      width: 20%;
+    }
   }
 
   fieldset {
     border: none;
     padding: 0;
     margin: 0;
-  }
-
-  input[type=text] {
-    width: 95%;
-    @media (max-width: $grid__breakpoint-medium) {
-      width: 75%;
-      margin: auto 1px;
-      width: auto;
-      }
   }
 
   &__update-filters-button {

--- a/ds_judgements_public_ui/static/js/src/app.js
+++ b/ds_judgements_public_ui/static/js/src/app.js
@@ -1,3 +1,4 @@
 import "./modules/manage_filters";
 import "./modules/manage_aria_buttons";
 import "./modules/document_navigation_links";
+import "./modules/date_input";

--- a/ds_judgements_public_ui/static/js/src/modules/date_input.js
+++ b/ds_judgements_public_ui/static/js/src/modules/date_input.js
@@ -1,0 +1,26 @@
+import $ from "jquery";
+
+function constrainInputToMinMax() {
+    const input = $(this);
+    var lastValidValue = input.value;
+    input.on("input", (event) => {
+        const validity = input[0].validity;
+        if (validity.badInput) {
+            this.value = lastValidValue;
+        } else if (validity.rangeOverflow) {
+            this.value = this.max;
+        } else {
+            lastValidValue = this.value;
+        }
+    });
+}
+
+function setupDateInput() {
+    const wrapper = $(this);
+    const inputs = wrapper.find("input");
+    inputs.each(constrainInputToMinMax);
+}
+
+$(() => {
+    $(".js-date-input").each(setupDateInput);
+});

--- a/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
@@ -1,38 +1,120 @@
-<fieldset>
-  <div class="structured-search__single-field-panel">
-    <div class="structured-search__limit-to-container">
+{% load court_utils feature_flags %}
+{% flag_enabled 'TEXT_DATE_INPUT' as text_date_input %}
+<div class="structured-search__single-field-panel">
+  <div class="structured-search__limit-to-container">
+    <fieldset>
       <label for="court" class="structured-search__limit-to-label">From specific courts or tribunals</label>
       <div class="structured-search__court-options" id="court">{% include "includes/courts_options.html" %}</div>
-    </div>
+    </fieldset>
   </div>
-</fieldset>
-<fieldset>
-  <div class="structured-search__multi-fields-panel">
-    <div class="structured-search__limit-to-container">
-      <label for="from_date" class="structured-search__limit-to-label">From date</label>
-      <input class="structured-search__date-input"
-             id="from_date"
-             min="2003-01-02"
-             name="from"
-             placeholder="DD-MM-YYYY"
-             type="date"
-             value="{{ context.from }}" />
-    </div>
-    <div class="structured-search__limit-to-container">
+</div>
+<div class="structured-search__multi-fields-panel">
+  <div class="structured-search__limit-to-container">
+    <fieldset>
+      <legend>
+        <span class="structured-search__limit-to-label" name="from_date">From date</span>
+      </legend>
+      {% if text_date_input %}
+        <div class="structured-search__date-input-group js-date-input">
+          <div>
+            <label for="from_day" class="structured-search__help-text">Day</label>
+            <input class="structured-search__date-input"
+                   id="from_day"
+                   name="from_day"
+                   type="number"
+                   min="1"
+                   max="31"
+                   step="1"
+                   value="{{ context.from }}"/>
+          </div>
+          <div>
+            <label for="from_month" class="structured-search__help-text">Month</label>
+            <input class="structured-search__date-input"
+                   id="from_month"
+                   name="from_month"
+                   type="number"
+                   min="1"
+                   max="12"
+                   step="1"
+                   value="{{ context.from }}"/>
+          </div>
+          <div>
+            <label for="from_year" class="structured-search__help-text">Year</label>
+            <input class="structured-search__date-input"
+                   id="from_year"
+                   name="from_year"
+                   type="number"
+                   min="{% get_first_judgment_year %}"
+                   max="{% get_last_judgment_year %}"
+                   step="1"
+                   value="{{ context.from }}"/>
+          </div>
+        </div>
+      {% else %}
+        <input class="structured-search__date-input"
+               id="from_date"
+               min="2003-01-02"
+               name="from"
+               placeholder="DD-MM-YYYY"
+               type="date"
+               value="{{ context.from }}"/>
+      {% endif %}
+    </fieldset>
+  </div>
+  <div class="structured-search__limit-to-container">
+    <fieldset>
       <label for="to_date" class="structured-search__limit-to-label">To date</label>
-      <input class="structured-search__date-input"
-             id="to_date"
-             min="2003-01-02"
-             name="to"
-             placeholder="DD-MM-YYYY"
-             type="date"
-             value="{{ context.to }}" />
-    </div>
+      {% if text_date_input %}
+        <div class="structured-search__date-input-group js-date-input">
+          <div>
+            <label for="to_day" class="structured-search__help-text">Day</label>
+            <input class="structured-search__date-input"
+                   id="to_day"
+                   name="to_day"
+                   type="number"
+                   min="1"
+                   max="31"
+                   step="1"
+                   value="{{ context.from }}"/>
+          </div>
+          <div>
+            <label for="to_month" class="structured-search__help-text">Month</label>
+            <input class="structured-search__date-input"
+                   id="to_month"
+                   name="to_month"
+                   type="number"
+                   min="1"
+                   max="12"
+                   step="1"
+                   value="{{ context.from }}"/>
+          </div>
+          <div>
+            <label for="to_year" class="structured-search__help-text">Year</label>
+            <input class="structured-search__date-input"
+                   id="to_year"
+                   name="to_year"
+                   type="number"
+                   min="{% get_first_judgment_year %}"
+                   max="{% get_last_judgment_year %}"
+                   step="1"
+                   value="{{ context.from }}"/>
+          </div>
+        </div>
+      {% else %}
+        <input class="structured-search__date-input"
+               id="to_date"
+               min="2003-01-02"
+               name="to"
+               placeholder="DD-MM-YYYY"
+               type="date"
+               value="{{ context.to }}"/>
+      {% endif %}
+    </fieldset>
   </div>
-</fieldset>
-<fieldset>
-  <div class="structured-search__multi-fields-panel">
-    <div class="structured-search__specific-field-container">
+</div>
+<div class="structured-search__multi-fields-panel">
+  <div class="structured-search__specific-field-container">
+    <fieldset>
       <label for="party_name" class="structured-search__limit-to-label">Party name</label>
       <input class="structured-search__limit-to-input"
              id="party_name"
@@ -41,8 +123,10 @@
              value="{{ context.party }}"
              aria-describedby="party_name-help-text" />
       <p class="structured-search__help-text" id="party_name-help-text">For example a claimant, defendant or other party</p>
-    </div>
-    <div class="structured-search__specific-field-container">
+    </fieldset>
+  </div>
+  <div class="structured-search__specific-field-container">
+    <fieldset>
       <label for="judge_name" class="structured-search__limit-to-label">Judge name</label>
       <input class="structured-search__limit-to-input"
              id="judge_name"
@@ -53,9 +137,9 @@
       <p class="structured-search__help-text" id="judge_name-help-text">
         For example 'Smith', 'Judge Smith' or 'Lord Justice Smith'
       </p>
-    </div>
+    </fieldset>
   </div>
-</fieldset>
+</div>
 <div class="structured-search__submit-container">
   <input type="submit"
          class="structured-search__update-filters-button"

--- a/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
@@ -25,7 +25,7 @@
                    min="1"
                    max="31"
                    step="1"
-                   value="{{ context.from }}"/>
+                   value="{{ context.from }}" />
           </div>
           <div>
             <label for="from_month" class="structured-search__help-text">Month</label>
@@ -36,7 +36,7 @@
                    min="1"
                    max="12"
                    step="1"
-                   value="{{ context.from }}"/>
+                   value="{{ context.from }}" />
           </div>
           <div>
             <label for="from_year" class="structured-search__help-text">Year</label>
@@ -47,7 +47,7 @@
                    min="{% get_first_judgment_year %}"
                    max="{% get_last_judgment_year %}"
                    step="1"
-                   value="{{ context.from }}"/>
+                   value="{{ context.from }}" />
           </div>
         </div>
       {% else %}
@@ -57,7 +57,7 @@
                name="from"
                placeholder="DD-MM-YYYY"
                type="date"
-               value="{{ context.from }}"/>
+               value="{{ context.from }}" />
       {% endif %}
     </fieldset>
   </div>
@@ -75,7 +75,7 @@
                    min="1"
                    max="31"
                    step="1"
-                   value="{{ context.from }}"/>
+                   value="{{ context.from }}" />
           </div>
           <div>
             <label for="to_month" class="structured-search__help-text">Month</label>
@@ -86,7 +86,7 @@
                    min="1"
                    max="12"
                    step="1"
-                   value="{{ context.from }}"/>
+                   value="{{ context.from }}" />
           </div>
           <div>
             <label for="to_year" class="structured-search__help-text">Year</label>
@@ -97,7 +97,7 @@
                    min="{% get_first_judgment_year %}"
                    max="{% get_last_judgment_year %}"
                    step="1"
-                   value="{{ context.from }}"/>
+                   value="{{ context.from }}" />
           </div>
         </div>
       {% else %}
@@ -107,7 +107,7 @@
                name="to"
                placeholder="DD-MM-YYYY"
                type="date"
-               value="{{ context.to }}"/>
+               value="{{ context.to }}" />
       {% endif %}
     </fieldset>
   </div>

--- a/judgments/models.py
+++ b/judgments/models.py
@@ -7,6 +7,7 @@ from caselawclient.Client import api_client
 from dateutil import parser as dateparser
 from dateutil.parser import ParserError
 from django.db import models
+from django.db.models import Max, Min
 from djxml import xmlmodels
 from ds_caselaw_utils.courts import CourtNotFoundException, courts
 from lxml import etree
@@ -144,3 +145,13 @@ class CourtDates(models.Model):
     param = models.CharField(max_length=64, primary_key=True)
     start_year = models.IntegerField(blank=False)
     end_year = models.IntegerField(blank=False)
+
+    @staticmethod
+    def min_year():
+        result = CourtDates.objects.aggregate(Min("start_year"))
+        return result["start_year__min"]
+
+    @staticmethod
+    def max_year():
+        result = CourtDates.objects.aggregate(Max("end_year"))
+        return result["end_year__max"]

--- a/judgments/templatetags/court_utils.py
+++ b/judgments/templatetags/court_utils.py
@@ -1,3 +1,6 @@
+import logging
+from datetime import date
+
 from django import template
 from django.utils.safestring import mark_safe
 from ds_caselaw_utils.courts import CourtNotFoundException
@@ -15,6 +18,26 @@ def get_court_name(court):
     except CourtNotFoundException:
         return ""
     return court_object.name
+
+
+@register.simple_tag
+def get_first_judgment_year():
+    if min_year := CourtDates.min_year():
+        return min_year
+    else:
+        logging.warning("CourtDates table is empty! using fallback min_year.")
+        return min(court.start_year for court in all_courts.get_selectable())
+
+
+@register.simple_tag
+def get_last_judgment_year():
+    if max_year := CourtDates.max_year():
+        return max_year
+    else:
+        logging.warning("CourtDates table is empty! using fallback max_year.")
+        # The dates in all_courts don't work as a fallback, as they can't
+        # be relied on to be up to date.
+        return date.today().year
 
 
 @register.filter

--- a/judgments/test_date_parsing.py
+++ b/judgments/test_date_parsing.py
@@ -1,0 +1,130 @@
+from typing import Dict
+
+from django.test import TestCase
+
+from judgments.utils import parse_date_parameter
+
+
+class TestDateParsing(TestCase):
+    def test_when_a_date_is_provided(self):
+        """
+        When a parameter is provided with the given name, return that value itself.
+        """
+        params = {"date": "2019-12-02"}
+        parsed = parse_date_parameter(params, "date")
+        self.assertEqual(parsed, "2019-12-02")
+
+    def test_provided_date_takes_precedence(self):
+        """
+        When a parameter is provided with the given name, return that value, even if day month and year are provided.
+        """
+        params = {
+            "date": "2019-12-02",
+            "date_day": "3",
+            "date_month": "1",
+            "date_year": "2020",
+        }
+        parsed = parse_date_parameter(params, "date")
+        self.assertEqual(parsed, "2019-12-02")
+
+    def test_a_blank_date_does_not_count_as_provided(self):
+        """
+        When a blank parameter is provided with the given name, use the day month year parameters for preference.
+        """
+        params = {"date": "", "date_day": "3", "date_month": "1", "date_year": "2020"}
+        parsed = parse_date_parameter(params, "date")
+        self.assertEqual(parsed, "2020-01-03")
+
+    def test_constructs_a_date_from_date_parts(self):
+        """
+        When no date is provided directly, it constructs one from the given day month and year.
+        """
+        params = {"date_day": "3", "date_month": "1", "date_year": "2020"}
+        parsed = parse_date_parameter(params, "date")
+        self.assertEqual(parsed, "2020-01-03")
+
+    def test_returns_none_if_no_date_provided(self):
+        """
+        When no date or date parts are provided, it returns None.
+        """
+        params: Dict[str, str] = {}
+        parsed = parse_date_parameter(params, "date")
+        self.assertIsNone(parsed)
+
+    def test_returns_beginning_of_month_when_no_day(self):
+        """
+        When a year and month are provided, but no day, it defaults to the first day of the month.
+        """
+        params = {"date_month": "5", "date_year": "2020"}
+        parsed = parse_date_parameter(params, "date")
+        self.assertEqual(parsed, "2020-05-01")
+
+    def test_returns_january_when_no_month(self):
+        """
+        When a year is provided but no month or day, it defaults to the first day of January of that year.
+        """
+        params = {"date_year": "2020"}
+        parsed = parse_date_parameter(params, "date")
+        self.assertEqual(parsed, "2020-01-01")
+
+    def test_returns_none_if_year_is_blank(self):
+        """When a year parameter is provided but empty, it returns none"""
+        params = {"date_year": ""}
+        parsed = parse_date_parameter(params, "date")
+        self.assertIsNone(parsed)
+
+    def test_blank_months_and_days_count_as_undefined(self):
+        """Blank months and days are treated as undefined, and default to the first month / day."""
+        params = {"date_year": "2009", "date_month": "", "date_day": ""}
+        parsed = parse_date_parameter(params, "date")
+        self.assertEqual(parsed, "2009-01-01")
+
+    def test_returns_december_when_no_month_and_default_to_last_selected(self):
+        """
+        When a year is provided but no month or day, and the default_to_last
+        option is passed, it defaults to the last day of december of that year.
+        """
+        params = {"date_year": "2020"}
+        parsed = parse_date_parameter(params, "date", default_to_last=True)
+        self.assertEqual(parsed, "2020-12-31")
+
+    def test_returns_lastday_long_month_when_year_and_month_given(self):
+        """
+        When a year and a long 31 days month is provided, but no day, and the default_to_last
+        option is passed, it defaults to the last day of the month.
+        """
+        params = {"date_month": "5", "date_year": "2020"}
+        parsed = parse_date_parameter(params, "date", default_to_last=True)
+        self.assertEqual(parsed, "2020-05-31")
+
+    def test_returns_lastday_short_month_when_year_and_month_given(self):
+        """
+        When a year and a short 28 days month is provided, but no day, and the default_to_last
+        option is passed, it defaults to the last day of the month.
+        """
+        params = {"date_month": "2", "date_year": "2021"}
+        parsed = parse_date_parameter(params, "date", default_to_last=True)
+        self.assertEqual(parsed, "2021-02-28")
+
+    def test_returns_lastday_month_when_leap_year_and_month_given(self):
+        """
+        When a leap year and month is provided, but no day, and the default_to_last
+        option is passed, it defaults to the last day of the month.
+        """
+        params = {"date_month": "2", "date_year": "2020"}
+        parsed = parse_date_parameter(params, "date", default_to_last=True)
+        self.assertEqual(parsed, "2020-02-29")
+
+    def test_raises_error_when_a_silly_month_is_given(self):
+        """
+        When a silly month number (ie >=13) is given, it raises an error.
+        """
+        params = {"date_month": "13", "date_day": "1", "date_year": "2020"}
+        self.assertRaises(ValueError, parse_date_parameter, params, "date")
+
+    def test_raises_error_when_a_silly_day_is_given(self):
+        """
+        When a silly month number (ie > the number of days in the given month) is given, it raises an error.
+        """
+        params = {"date_month": "04", "date_day": "31", "date_year": "2020"}
+        self.assertRaises(ValueError, parse_date_parameter, params, "date")

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from test_search import fake_search_result, fake_search_results
 
 from judgments import converters, utils
+from judgments.models import CourtDates
 from judgments.utils import as_integer, display_back_link, paginator
 
 
@@ -88,6 +89,22 @@ class TestJudgment(TestCase):
         decoded_response = response.content.decode("utf-8")
         self.assertIn("Page not found", decoded_response)
         self.assertEqual(response.status_code, 404)
+
+
+class TestCourtDates(TestCase):
+    def setUp(self):
+        CourtDates.objects.create(
+            param="earliest_starting_court", start_year=2001, end_year=2020
+        )
+        CourtDates.objects.create(
+            param="last_ending_court", start_year=2005, end_year=2023
+        )
+
+    def test_min_year(self):
+        self.assertEqual(CourtDates.min_year(), 2001)
+
+    def test_max_year(self):
+        self.assertEqual(CourtDates.max_year(), 2023)
 
 
 class TestPaginator(TestCase):

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -1,5 +1,6 @@
 import math
 import re
+from calendar import monthrange
 from datetime import datetime
 from urllib.parse import urlparse
 
@@ -167,3 +168,35 @@ def has_filters(query_params, exclude=["order", "per_page"]):
     be they query string, court, date, or party.
     """
     return len(set(k for (k, v) in query_params.items() if v) - set(exclude)) > 0
+
+
+def parameter_provided(params, parameter_name):
+    value = params.get(parameter_name)
+    return value and len(value)
+
+
+def parse_parameter_as_int(params, parameter_name, default=None):
+    if parameter_provided(params, parameter_name):
+        return int(params.get(parameter_name))
+    else:
+        return default
+
+
+def parse_date_parameter(params, param_name, default_to_last=False):
+    year_param_name = f"{param_name}_year"
+    month_param_name = f"{param_name}_month"
+    day_param_name = f"{param_name}_day"
+
+    if parameter_provided(params, param_name):
+        return params[param_name]
+    elif parameter_provided(params, year_param_name):
+        year = parse_parameter_as_int(params, year_param_name, default=1)
+
+        default_month = 12 if default_to_last else 1
+        month = parse_parameter_as_int(params, month_param_name, default=default_month)
+
+        default_day = monthrange(year, month)[1] if default_to_last else 1
+        day = parse_parameter_as_int(params, day_param_name, default=default_day)
+
+        dt = datetime(year, month, day)
+        return dt.strftime("%Y-%m-%d")

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -11,6 +11,7 @@ from judgments.utils import (
     as_integer,
     has_filters,
     paginator,
+    parse_date_parameter,
     perform_advanced_search,
     preprocess_query,
 )
@@ -18,6 +19,19 @@ from judgments.utils import (
 
 def advanced_search(request):
     params = request.GET
+
+    try:
+        from_date = parse_date_parameter(params, "from")
+    except ValueError:
+        from_date = None  # TODO - we need to add a mechanism
+        # for informing user of input validation errors
+        # - see https://trello.com/c/vsN1NKLu
+
+    try:
+        to_date = parse_date_parameter(params, "to", default_to_last=True)
+    except ValueError:
+        to_date = None  # TODO - as above, see https://trello.com/c/vsN1NKLu
+
     query_params = {
         "query": params.get("query", ""),
         "court": params.getlist("court"),
@@ -26,8 +40,8 @@ def advanced_search(request):
         "neutral_citation": params.get("neutral_citation"),
         "specific_keyword": params.get("specific_keyword"),
         "order": params.get("order", ""),
-        "from": params.get("from"),
-        "to": params.get("to"),
+        "from": from_date,
+        "to": to_date,
         "per_page": params.get("per_page"),
     }
     page = str(as_integer(params.get("page"), minimum=1))


### PR DESCRIPTION
## Changes in this PR:
With js and server side validation. Currently validation errors are not displayed, the filter is just ignored - this will be addressed in future work.

This lives behind the TEXT_DATE_INPUT feature flag, which will have to be enabled to see it :-)

## Changes in this PR:

## Trello card / Rollbar error (etc)
https://trello.com/c/72rPrOKi/768-%F0%9F%94%8D-pui-try-out-using-seperate-month-year-inputs-instead-of-a-calendar-picker-on-advanced-search
## Screenshots of UI changes:

### Before
![before-date](https://user-images.githubusercontent.com/75584408/234052449-51612a01-05a5-450c-ba26-ba0329c613fc.png)


### After
![after-date](https://user-images.githubusercontent.com/75584408/234052942-e2137086-7991-4ccf-9af5-f2fad7cca573.png)

