### PR TITLE
Require query default value to be empty string, not None

### DIFF
--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -20,7 +20,7 @@ from judgments.utils import (
 def advanced_search(request):
     params = request.GET
     query_params = {
-        "query": params.get("query"),
+        "query": params.get("query", ""),
         "court": params.getlist("court"),
         "judge": params.get("judge"),
         "party": params.get("party"),

--- a/judgments/views/results.py
+++ b/judgments/views/results.py
@@ -22,7 +22,7 @@ def results(request):
     context = {"page_title": gettext("results.search.title")}
     try:
         params = request.GET
-        query = preprocess_query(params.get("query"))
+        query = preprocess_query(params.get("query", ""))
         page = str(as_integer(params.get("page"), minimum=1))
         per_page = str(
             as_integer(


### PR DESCRIPTION
This was causing the following error
https://app.rollbar.com/a/dxw/fix/item/tna-caselaw-public-ui/166