### PR TITLE
Set X-Robots-Tag response header to noindex,nofollow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: docker-compose run --rm django python manage.py migrate --settings=config.settings.test
 
       - name: Run Django Tests with coverage
-        run: docker-compose run django coverage run -m pytest
+        run: docker-compose run django coverage run -m pytest -m "not local"
 
       - name: Generate coverage XML
         run: docker-compose run django coverage xml

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -1,6 +1,32 @@
 from urllib.parse import urlencode
 
+from django.urls import resolve
 from django.utils.cache import patch_cache_control
+
+# these should match the names in config/urls.py
+INDEXABLE_VIEWS = [
+    "home",
+    "transactional_licence_form",
+    "what_to_expect",
+    "how_to_use_this_service",
+    "accessibility_statement",
+    "open_justice_licence",
+    "terms_of_use",
+]
+
+
+class RobotsTagMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # One-time configuration and initialization.
+
+    def __call__(self, request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+        response = self.get_response(request)
+        if resolve(request.path).view_name not in INDEXABLE_VIEWS:
+            response.headers["X-Robots-Tag"] = "noindex,nofollow"
+        return response
 
 
 class CacheHeaderMiddleware:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -129,6 +129,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "config.middleware.CacheHeaderMiddleware",
+    "config.middleware.RobotsTagMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.common.BrokenLinkEmailsMiddleware",

--- a/ds_judgements_public_ui/templates/robots.txt
+++ b/ds_judgements_public_ui/templates/robots.txt
@@ -1,6 +1,16 @@
+User-Agent: Googlebot
+User-Agent: bingbot
+Allow: /
+Allow: /transactional-licence-form
+Allow: /what-to-expect
+Allow: /how-to-use-this-service
+Allow: /accessibility-statement
+Allow: /open-justice-licence
+Allow: /terms-of-use
+Disallow: /$
+
 User-Agent: *
 Disallow: /
-Allow: /$
 Allow: /transactional-licence-form
 Allow: /what-to-expect
 Allow: /how-to-use-this-service

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -3,6 +3,7 @@ from os import environ
 from unittest import skip
 from unittest.mock import patch
 
+import pytest
 from django.test import TestCase
 from test_search import fake_search_result, fake_search_results
 
@@ -223,6 +224,7 @@ class TestRobotsDirectives(TestCase):
         self.assertContains(response, "cat")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
+    @pytest.mark.local("Needs static file in CI")
     @patch("judgments.views.detail.PdfDetailView.get_context_data")
     def test_weasy_pdf(self, mock_context):
         mock_context.return_value = {"judgment": "<cat>KITTEN</cat>"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ addopts = --ds=config.settings.test --reuse-db --disable-socket
 python_files = tests.py test_*.py
 filterwarnings =
     ignore::django.utils.deprecation.RemovedInDjango40Warning
+markers =
+    local: does not work in CI


### PR DESCRIPTION
We add a middleware layer to add a `X-Robots-Tag` header to the outgoing response.

There's a bunch of tests to make sure that we're getting correct headers for a pdfs and XML as well.