### PR TITLE
Add dragon's magic Google link so we can configure how search engines work

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -62,6 +62,12 @@ urlpatterns = [
         "robots.txt",
         TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
     ),
+    path(
+        "googleb0ce3f99fae65e7c.html",
+        TemplateView.as_view(
+            template_name="googleb0ce3f99fae65e7c.html", content_type="text/html"
+        ),
+    ),
     path("", include("judgments.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 

--- a/ds_judgements_public_ui/templates/googleb0ce3f99fae65e7c.html
+++ b/ds_judgements_public_ui/templates/googleb0ce3f99fae65e7c.html
@@ -1,0 +1,1 @@
+google-site-verification: googleb0ce3f99fae65e7c.html


### PR DESCRIPTION
Allow dragon to configure the website (caselaw.nationalarchives.gov.uk) via https://search.google.com/search-console