### PR TITLE
Move PUI judgment detail view to use Judgment model

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -257,3 +257,8 @@ LOGGING = {
 # ------------------------------------------------------------------------------
 APPEND_SLASH = False
 WHITENOISE_MAX_AGE = 900  # set Cache-Control header on static-served images
+
+MARKLOGIC_HOST = env("MARKLOGIC_HOST", default=None)
+MARKLOGIC_USER = env("MARKLOGIC_USER", default=None)
+MARKLOGIC_PASSWORD = env("MARKLOGIC_PASSWORD", default=None)
+MARKLOGIC_USE_HTTPS = env("MARKLOGIC_USE_HTTPS", default=False)

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -1,0 +1,44 @@
+from typing import Any
+from unittest.mock import Mock
+
+from caselawclient.models.judgments import Judgment
+
+
+class JudgmentFactory:
+    # "name_of_attribute": ("name of incoming param", "default value")
+    PARAMS_MAP: dict[str, Any] = {
+        "uri": "test/2023/123",
+        "name": "Judgment v Judgement",
+        "neutral_citation": "[2023] Test 123",
+        "court": "Court of Testing",
+        "judgment_date_as_string": "2023-02-03",
+        "is_published": False,
+        "is_sensitive": False,
+        "is_anonymised": False,
+        "has_supplementary_materials": False,
+        "is_failure": False,
+        "source_name": "Example Uploader",
+        "source_email": "uploader@example.com",
+        "consignment_reference": "TDR-12345",
+        "assigned_to": "",
+        "versions": [],
+    }
+
+    @classmethod
+    def build(cls, **kwargs) -> Judgment:
+        judgment_mock = Mock(spec=Judgment, autospec=True)
+
+        if "html" in kwargs:
+            judgment_mock.return_value.content_as_html.return_value = kwargs.pop("html")
+        else:
+            judgment_mock.return_value.content_as_html.return_value = (
+                "<p>This is a judgment.</p>"
+            )
+
+        for param, value in cls.PARAMS_MAP.items():
+            if param in kwargs:
+                setattr(judgment_mock.return_value, param, kwargs[param])
+            else:
+                setattr(judgment_mock.return_value, param, value)
+
+        return judgment_mock()

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -28,12 +28,18 @@ class JudgmentFactory:
     def build(cls, **kwargs) -> Judgment:
         judgment_mock = Mock(spec=Judgment, autospec=True)
 
-        if "html" in kwargs:
-            judgment_mock.return_value.content_as_html.return_value = kwargs.pop("html")
-        else:
-            judgment_mock.return_value.content_as_html.return_value = (
-                "<p>This is a judgment.</p>"
-            )
+        judgment_mock.return_value.content_as_html.return_value = kwargs.pop(
+            "html",
+            "<p>This is a judgment in HTML.</p>",
+        )
+
+        judgment_mock.return_value.content_as_xml.return_value = kwargs.pop(
+            "xml",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<judgment>
+<p>This is a judgment in XML.</p><
+/judgment>""",
+        )
 
         for param, value in cls.PARAMS_MAP.items():
             if param in kwargs:

--- a/judgments/tests/test_factories.py
+++ b/judgments/tests/test_factories.py
@@ -1,0 +1,46 @@
+import pytest
+from factories import JudgmentFactory
+
+
+class TestJudgmentFactory:
+    def test_default_uri(self):
+        # The default URI gets a test where others don't because without a URI judgments fall apart
+        judgment = JudgmentFactory.build()
+
+        assert type(judgment.uri) == str
+        assert judgment.uri != ""
+
+    @pytest.mark.parametrize(
+        "parameter, value",
+        [
+            ("uri", "test/2022/321"),
+            ("name", "Some Test Name"),
+            ("neutral_citation", "[2022] Test 321"),
+            ("court", "The Test Court"),
+            ("judgment_date_as_string", "2022-03-04"),
+            ("is_published", True),
+            ("is_sensitive", True),
+            ("is_anonymised", True),
+            ("has_supplementary_materials", True),
+            ("is_failure", True),
+            ("source_name", "Uploader Test"),
+            ("source_email", "test@example.com"),
+            ("consignment_reference", "TDR-54321"),
+            ("assigned_to", "Assignee"),
+            ("versions", ["1", "2"]),
+        ],
+    )
+    def test_params(self, parameter, value):
+        judgment = JudgmentFactory.build(**{parameter: value})
+
+        assert getattr(judgment, parameter) == value
+
+    def test_html(self):
+        judgment = JudgmentFactory.build(html="<h1>Testing HTML</h1>")
+
+        assert judgment.content_as_html("") == "<h1>Testing HTML</h1>"
+
+    def test_xml(self):
+        judgment = JudgmentFactory.build(xml="<h1>Testing XML</h1>")
+
+        assert judgment.content_as_xml("") == "<h1>Testing XML</h1>"

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -78,11 +78,16 @@ class TestJudgment(TestCase):
         # We don't use the Download as PDF text because there's an issue with localisated strings on CI
         self.assertEqual(response.status_code, 200)
 
-    @skip("requires network")
-    def test_good_response(self):
-        response = self.client.get("/ewca/civ/2004/637")
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_good_response(self, mock_judgment, mock_pdf_size):
+        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
+
+        mock_pdf_size.return_value = "1234KB"
+
+        response = self.client.get("/test/2023/123")
         decoded_response = response.content.decode("utf-8")
-        self.assertIn("[2004] EWCA Civ 637", decoded_response)
+        self.assertIn("<p>This is a judgment.</p>", decoded_response)
         self.assertEqual(response.status_code, 200)
 
     @skip("requires network")

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -27,7 +27,7 @@ class TestJudgment(TestCase):
 
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
-        self.assertIn("<p>This is a judgment.</p>", decoded_response)
+        self.assertIn("<p>This is a judgment in HTML.</p>", decoded_response)
         self.assertIn(
             '<meta name="robots" content="noindex,nofollow" />', decoded_response
         )
@@ -245,11 +245,11 @@ class TestRobotsDirectives(TestCase):
         self.assertContains(response, "CAT")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
-    @patch("judgments.views.detail.api_client.get_judgment_xml")
-    def test_xml(self, mock_xml):
-        mock_xml.return_value = "<cat></cat>"
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_xml(self, mock_judgment):
+        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
         response = self.client.get("/eat/2023/1/data.xml")
-        self.assertContains(response, "cat")
+        self.assertContains(response, "This is a judgment in XML.")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
     @pytest.mark.local("Needs static file in CI")

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -12,80 +12,26 @@ from test_search import fake_search_result, fake_search_results
 from judgments import converters, utils
 from judgments.models import CourtDates
 from judgments.utils import as_integer, display_back_link, paginator
+from judgments.views.detail import get_pdf_size
 
 
 class TestJudgment(TestCase):
-    @patch("judgments.views.detail.requests.head")
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_valid_content(self, mock_judgment, head):
-        if "ASSETS_CDN_BASE_URL" not in environ:
-            raise RuntimeError("ensure ASSETS_CDN_BASE_URL is set in .env!")
-        head.return_value.headers = {"Content-Length": "1234567890"}
-        head.return_value.status_code = 200
-
-        mock_judgment.return_value = JudgmentFactory.build(uri="ewca/civ/2004/632")
-
-        response = self.client.get("/ewca/civ/2004/632")
-        decoded_response = response.content.decode("utf-8")
-        self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
-        self.assertIn(environ["ASSETS_CDN_BASE_URL"], decoded_response)
-        self.assertIn("ewca_civ_2004_632.pdf", decoded_response)
-        self.assertNotIn("data.pdf", decoded_response)
-        self.assertIn("(1.1\xa0GB)", decoded_response)
-        # We don't use the Download as PDF text because there's an issue with localisated strings on CI
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(
-            '<meta name="robots" content="noindex,nofollow" />', decoded_response
-        )
-
-    @patch("judgments.views.detail.requests.head")
-    @patch("judgments.views.detail.decoder.MultipartDecoder")
-    @patch("judgments.views.detail.api_client")
-    def test_valid_content_no_filesize(self, client, decoder, head):
-        if "ASSETS_CDN_BASE_URL" not in environ:
-            raise RuntimeError("ensure ASSETS_CDN_BASE_URL is set in .env!")
-        head.return_value.headers = {}
-        head.return_value.status_code = 200
-        client.eval_xslt.return_value = "eval_xslt"
-        decoder.MultipartDecoder.from_response.return_value.parts[0].text = "part0text"
-        client.get_judgment_name.return_value = "judgment metadata"
-
-        response = self.client.get("/ewca/civ/2004/632")
-        decoded_response = response.content.decode("utf-8")
-        self.assertIn(environ["ASSETS_CDN_BASE_URL"], decoded_response)
-        self.assertIn("ewca_civ_2004_632.pdf", decoded_response)
-        self.assertNotIn("data.pdf", decoded_response)
-        self.assertIn("(unknown size)", decoded_response)
-        # We don't use the Download as PDF text because there's an issue with localisated strings on CI
-        self.assertEqual(response.status_code, 200)
-
-    @patch("judgments.views.detail.requests.head")
-    @patch("judgments.views.detail.decoder.MultipartDecoder")
-    @patch("judgments.views.detail.api_client")
-    def test_no_valid_pdf(self, client, decoder, head):
-        head.return_value.headers = {}
-        head.return_value.status_code = 404
-        client.eval_xslt.return_value = "eval_xslt"
-        decoder.MultipartDecoder.from_response.return_value.parts[0].text = "part0text"
-        client.get_judgment_name.return_value = "judgment metadata"
-
-        response = self.client.get("/ewca/civ/2004/632")
-        decoded_response = response.content.decode("utf-8")
-        self.assertIn("data.pdf", decoded_response)
-        self.assertNotIn("2004_632.pdf", decoded_response)
-        # We don't use the Download as PDF text because there's an issue with localisated strings on CI
-        self.assertEqual(response.status_code, 200)
-
     @patch("judgments.views.detail.get_pdf_size")
     @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_good_response(self, mock_judgment, mock_pdf_size):
+    def test_published_judgment_response(self, mock_judgment, mock_pdf_size):
         mock_judgment.return_value = JudgmentFactory.build(is_published=True)
-
         mock_pdf_size.return_value = "1234KB"
 
         response = self.client.get("/test/2023/123")
         decoded_response = response.content.decode("utf-8")
+
+        self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
+
         self.assertIn("<p>This is a judgment.</p>", decoded_response)
+        self.assertIn(
+            '<meta name="robots" content="noindex,nofollow" />', decoded_response
+        )
+
         self.assertEqual(response.status_code, 200)
 
     @patch("judgments.views.detail.get_judgment_by_uri")
@@ -123,6 +69,50 @@ class TestCourtDates(TestCase):
 
     def test_max_year(self):
         self.assertEqual(CourtDates.max_year(), 2023)
+
+
+class TestJudgmentPdfLinkText(TestCase):
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    @patch.dict(environ, {"ASSETS_CDN_BASE_URL": "https://example.com"})
+    def test_pdf_link_with_size(self, mock_judgment, mock_pdf_size):
+        """
+        `get_pdf_size` serves several purposes; it can _either_ return a string with the size of a PDF if one exists
+        in S3, _or_ return a string saying "unknown size" if the file exists but S3 doesn't tell us the size, _or_
+        return an empty string. This tests the case where it returns a non-empty string (either a file size or
+        "unknown"), in which case we should link to the file in S3 via our assets URL and display the size string.
+        """
+
+        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
+        mock_pdf_size.return_value = " (1234KB)"
+
+        response = self.client.get("/test/2023/123")
+        decoded_response = response.content.decode("utf-8")
+
+        self.assertIn(
+            "https://example.com/test/2023/123/test_2023_123.pdf", decoded_response
+        )
+        self.assertNotIn("data.pdf", decoded_response)
+        self.assertIn("(1234KB)", decoded_response)
+
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    @patch.dict(environ, {"ASSETS_CDN_BASE_URL": "https://example.com"})
+    def test_pdf_link_with_no_size(self, mock_judgment, mock_pdf_size):
+        """
+        `get_pdf_size` serves several purposes; it can _either_ return a string with the size of a PDF if one exists
+        in S3, _or_ return a string saying "unknown size" if the file exists but S3 doesn't tell us the size, _or_
+        return an empty string. This tests the case where it returns an empty string (implying that the file doesn't
+        exist in S3), so we should link to our generated PDF instead and not S3."""
+
+        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
+        mock_pdf_size.return_value = ""
+
+        response = self.client.get("/test/2023/123")
+        decoded_response = response.content.decode("utf-8")
+
+        self.assertNotIn("test_2023_123.pdf", decoded_response)
+        self.assertIn("/test/2023/123/data.pdf", decoded_response)
 
 
 class TestPaginator(TestCase):
@@ -303,6 +293,44 @@ class TestBackLink(TestCase):
     def test_no_referrer(self):
         # When there is no referrer, the back link is not displayed:
         self.assertIs(display_back_link(None), False)
+
+
+class TestGetPdfSize(TestCase):
+    @patch("judgments.views.detail.get_pdf_uri")
+    @patch("judgments.views.detail.requests.head")
+    def test_returns_valid_size(self, mock_head, mock_get_pdf_uri):
+        mock_head.return_value.headers = {"Content-Length": "1234567890"}
+        mock_head.return_value.status_code = 200
+        mock_get_pdf_uri.return_value = "http://example.com/test.pdf"
+
+        assert get_pdf_size("") == " (1.1\xa0GB)"
+        mock_head.assert_called_with(
+            "http://example.com/test.pdf", headers={"Accept-Encoding": None}
+        )
+
+    @patch("judgments.views.detail.get_pdf_uri")
+    @patch("judgments.views.detail.requests.head")
+    def test_pdf_exists_with_no_size(self, mock_head, mock_get_pdf_uri):
+        mock_head.return_value.headers = {}
+        mock_head.return_value.status_code = 200
+        mock_get_pdf_uri.return_value = "http://example.com/test.pdf"
+
+        assert get_pdf_size("") == " (unknown size)"
+        mock_head.assert_called_with(
+            "http://example.com/test.pdf", headers={"Accept-Encoding": None}
+        )
+
+    @patch("judgments.views.detail.get_pdf_uri")
+    @patch("judgments.views.detail.requests.head")
+    def test_no_pdf_exists(self, mock_head, mock_get_pdf_uri):
+        mock_head.return_value.headers = {}
+        mock_head.return_value.status_code = 404
+        mock_get_pdf_uri.return_value = "http://example.com/test.pdf"
+
+        assert get_pdf_size("") == ""
+        mock_head.assert_called_with(
+            "http://example.com/test.pdf", headers={"Accept-Encoding": None}
+        )
 
 
 def test_min_max():

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -5,7 +5,9 @@ from datetime import datetime
 from urllib.parse import urlparse
 
 import environ
-from caselawclient.Client import RESULTS_PER_PAGE, api_client
+from caselawclient.Client import RESULTS_PER_PAGE, MarklogicApiClient, api_client
+from caselawclient.models.judgments import Judgment
+from django.conf import settings
 from requests_toolbelt.multipart import decoder
 
 from .fixtures.stop_words import stop_words
@@ -200,3 +202,14 @@ def parse_date_parameter(params, param_name, default_to_last=False):
 
         dt = datetime(year, month, day)
         return dt.strftime("%Y-%m-%d")
+
+
+def get_judgment_by_uri(judgment_uri: str) -> Judgment:
+    api_client = MarklogicApiClient(
+        host=settings.MARKLOGIC_HOST,
+        username=settings.MARKLOGIC_USER,
+        password=settings.MARKLOGIC_PASSWORD,
+        use_https=settings.MARKLOGIC_USE_HTTPS,
+    )
+
+    return Judgment(judgment_uri, api_client)

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 import requests
-from caselawclient.Client import MarklogicResourceNotFoundError, api_client
+from caselawclient.Client import MarklogicResourceNotFoundError
 from django.conf import settings
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
@@ -88,11 +88,17 @@ def detail(request, judgment_uri):
 
 def detail_xml(_request, judgment_uri):
     try:
-        judgment_xml = api_client.get_judgment_xml(judgment_uri)
+        judgment = get_judgment_by_uri(judgment_uri)
     except MarklogicResourceNotFoundError:
         raise Http404("Judgment was not found")
+
+    if not judgment.is_published:
+        raise Http404("This Judgment is not available")
+
+    judgment_xml = judgment.content_as_xml()
+
     response = HttpResponse(judgment_xml, content_type="application/xml")
-    response["Content-Disposition"] = f"attachment; filename={judgment_uri}.xml"
+    response["Content-Disposition"] = f"attachment; filename={judgment.uri}.xml"
     return response
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,3 +20,7 @@ ds-caselaw-marklogic-api-client~=6.1.0
 ds-caselaw-utils~=1.0.0
 rollbar
 django-weasyprint==2.2.0
+
+# Type stubs
+mypy-boto3-s3==1.26.116
+mypy-boto3-sns==1.26.69


### PR DESCRIPTION
This moves retrieval of a single judgment (as either HTML or PDF) to use the new unified model from the API library, instead of hand-rolling the queries.