### PR TITLE
Update API client to v6.1.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ requests-toolbelt~=0.10.1
 lxml~=4.9.2
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=6.0.0
+ds-caselaw-marklogic-api-client~=6.1.0
 ds-caselaw-utils~=1.0.0
 rollbar
 django-weasyprint==2.2.0


### PR DESCRIPTION
This client version has some loosened dependency versions, which should make resolution of dependencies for PUI easier