### PR TITLE
change help text position

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_mixins.scss
+++ b/ds_judgements_public_ui/sass/includes/_mixins.scss
@@ -123,7 +123,7 @@
   border: 2px solid $color__dark-grey;
   padding: calc($spacer__unit / 2);
   margin-bottom: $spacer__unit;
-  margin-top: calc($spacer__unit / 2);
+  margin-top: calc($spacer__unit / 4);
   background-color: $color__white;
   width: 80%;
   font-family: $font__open-sans;

--- a/ds_judgements_public_ui/sass/includes/_mixins.scss
+++ b/ds_judgements_public_ui/sass/includes/_mixins.scss
@@ -123,7 +123,7 @@
   border: 2px solid $color__dark-grey;
   padding: calc($spacer__unit / 2);
   margin-bottom: $spacer__unit;
-  margin-top: calc($spacer__unit / 4);
+  margin-top: calc($spacer__unit / 2);
   background-color: $color__white;
   width: 80%;
   font-family: $font__open-sans;

--- a/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
@@ -116,27 +116,27 @@
   <div class="structured-search__specific-field-container">
     <fieldset>
       <label for="party_name" class="structured-search__limit-to-label">Party name</label>
+      <p class="structured-search__help-text" id="party_name-help-text">For example a claimant, defendant or other party</p>
       <input class="structured-search__limit-to-input"
              id="party_name"
              name="party"
              type="text"
              value="{{ context.party }}"
              aria-describedby="party_name-help-text" />
-      <p class="structured-search__help-text" id="party_name-help-text">For example a claimant, defendant or other party</p>
     </fieldset>
   </div>
   <div class="structured-search__specific-field-container">
     <fieldset>
       <label for="judge_name" class="structured-search__limit-to-label">Judge name</label>
+      <p class="structured-search__help-text" id="judge_name-help-text">
+        For example 'Smith', 'Judge Smith' or 'Lord Justice Smith'
+      </p>
       <input class="structured-search__limit-to-input"
              id="judge_name"
              name="judge"
              type="text"
              value="{{ context.judge }}"
              aria-describedby="judge_name-help-text" />
-      <p class="structured-search__help-text" id="judge_name-help-text">
-        For example 'Smith', 'Judge Smith' or 'Lord Justice Smith'
-      </p>
     </fieldset>
   </div>
 </div>

--- a/ds_judgements_public_ui/templates/includes/structured_search_additional_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/structured_search_additional_inputs.html
@@ -2,16 +2,17 @@
   <div class="structured-search__multi-fields-panel">
     <div class="structured-search__specific-field-container">
       <label for="neutral_citation" class="structured-search__limit-to-label">Neutral citation</label>
+      <p class="structured-search__help-text" id="neutral_citation-help-text">For example [2021] EWCA Crim 1785</p>
       <input class="structured-search__limit-to-input"
              id="neutral_citation"
              name="neutral_citation"
              type="text"
              value="{{ context.neutral_citation }}"
              aria-describedby="neutral_citation-help-text" />
-      <p class="structured-search__help-text" id="neutral_citation-help-text">For example [2021] EWCA Crim 1785</p>
     </div>
     <div class="structured-search__limit-to-container">
       <label for="specific_keywords" class="structured-search__limit-to-label">Containing specific keywords</label>
+      <p class="structured-search__help-text" id="neutral_citation-help-text">For example, London Borough of...</p>
       <input class="structured-search__limit-to-input"
              id="specific_keywords"
              name="specific_keyword"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Change help text position to adhere to GDS
## Trello card / Rollbar error (etc)
https://trello.com/c/NU1ZhWGa/830-help-text-change-position-inline-with-gds-styling-in-all-instances-on-pui-awaiting-768
## Screenshots of UI changes:

### Before
![image](https://user-images.githubusercontent.com/75584408/235703433-db97536f-b55c-4a34-84ab-e1e37ffde1f6.png)


### After
![image](https://user-images.githubusercontent.com/75584408/235710873-8c81d3d7-26b4-419f-8451-cd0eccc829a8.png)



- [ ] Requires env variable(s) to be updated
