### PR TITLE
FCL 29b: Ensure tests support new exceptions from custom-api-client

### DIFF
--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -1,0 +1,130 @@
+from os import environ
+from unittest.mock import patch
+
+from django.test import TestCase
+from factories import JudgmentFactory
+
+from judgments.views.detail import get_pdf_size
+
+
+class TestJudgment(TestCase):
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_published_judgment_response(self, mock_judgment, mock_pdf_size):
+        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
+        mock_pdf_size.return_value = "1234KB"
+
+        response = self.client.get("/test/2023/123")
+        decoded_response = response.content.decode("utf-8")
+
+        self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
+
+        self.assertIn("<p>This is a judgment in HTML.</p>", decoded_response)
+        self.assertIn(
+            '<meta name="robots" content="noindex,nofollow" />', decoded_response
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_judgment_not_published_404_response(self, mock_judgment):
+        mock_judgment.return_value = JudgmentFactory.build(is_published=False)
+
+        response = self.client.get("/test/2023/123")
+
+        decoded_response = response.content.decode("utf-8")
+        self.assertIn("Page not found", decoded_response)
+        self.assertEqual(response.status_code, 404)
+
+    @patch(
+        "caselawclient.models.judgments.Judgment.judgment_exists",
+        return_value=False,
+    )
+    def test_judgment_not_found_404_response(self, exists):
+        response = self.client.get("/test/2023/123")
+
+        decoded_response = response.content.decode("utf-8")
+        self.assertIn("Page not found", decoded_response)
+        self.assertEqual(response.status_code, 404)
+
+
+class TestJudgmentPdfLinkText(TestCase):
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    @patch.dict(environ, {"ASSETS_CDN_BASE_URL": "https://example.com"})
+    def test_pdf_link_with_size(self, mock_judgment, mock_pdf_size):
+        """
+        `get_pdf_size` serves several purposes; it can _either_ return a string with the size of a PDF if one exists
+        in S3, _or_ return a string saying "unknown size" if the file exists but S3 doesn't tell us the size, _or_
+        return an empty string. This tests the case where it returns a non-empty string (either a file size or
+        "unknown"), in which case we should link to the file in S3 via our assets URL and display the size string.
+        """
+
+        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
+        mock_pdf_size.return_value = " (1234KB)"
+
+        response = self.client.get("/test/2023/123")
+        decoded_response = response.content.decode("utf-8")
+
+        self.assertIn(
+            "https://example.com/test/2023/123/test_2023_123.pdf", decoded_response
+        )
+        self.assertNotIn("data.pdf", decoded_response)
+        self.assertIn("(1234KB)", decoded_response)
+
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    @patch.dict(environ, {"ASSETS_CDN_BASE_URL": "https://example.com"})
+    def test_pdf_link_with_no_size(self, mock_judgment, mock_pdf_size):
+        """
+        `get_pdf_size` serves several purposes; it can _either_ return a string with the size of a PDF if one exists
+        in S3, _or_ return a string saying "unknown size" if the file exists but S3 doesn't tell us the size, _or_
+        return an empty string. This tests the case where it returns an empty string (implying that the file doesn't
+        exist in S3), so we should link to our generated PDF instead and not S3."""
+
+        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
+        mock_pdf_size.return_value = ""
+
+        response = self.client.get("/test/2023/123")
+        decoded_response = response.content.decode("utf-8")
+
+        self.assertNotIn("test_2023_123.pdf", decoded_response)
+        self.assertIn("/test/2023/123/data.pdf", decoded_response)
+
+
+class TestGetPdfSize(TestCase):
+    @patch("judgments.views.detail.get_pdf_uri")
+    @patch("judgments.views.detail.requests.head")
+    def test_returns_valid_size(self, mock_head, mock_get_pdf_uri):
+        mock_head.return_value.headers = {"Content-Length": "1234567890"}
+        mock_head.return_value.status_code = 200
+        mock_get_pdf_uri.return_value = "http://example.com/test.pdf"
+
+        assert get_pdf_size("") == " (1.1\xa0GB)"
+        mock_head.assert_called_with(
+            "http://example.com/test.pdf", headers={"Accept-Encoding": None}
+        )
+
+    @patch("judgments.views.detail.get_pdf_uri")
+    @patch("judgments.views.detail.requests.head")
+    def test_pdf_exists_with_no_size(self, mock_head, mock_get_pdf_uri):
+        mock_head.return_value.headers = {}
+        mock_head.return_value.status_code = 200
+        mock_get_pdf_uri.return_value = "http://example.com/test.pdf"
+
+        assert get_pdf_size("") == " (unknown size)"
+        mock_head.assert_called_with(
+            "http://example.com/test.pdf", headers={"Accept-Encoding": None}
+        )
+
+    @patch("judgments.views.detail.get_pdf_uri")
+    @patch("judgments.views.detail.requests.head")
+    def test_no_pdf_exists(self, mock_head, mock_get_pdf_uri):
+        mock_head.return_value.headers = {}
+        mock_head.return_value.status_code = 404
+        mock_get_pdf_uri.return_value = "http://example.com/test.pdf"
+
+        assert get_pdf_size("") == ""
+        mock_head.assert_called_with(
+            "http://example.com/test.pdf", headers={"Accept-Encoding": None}
+        )

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -33,7 +33,7 @@ class TestGetPublishedJudgment:
 
 class TestJudgment(TestCase):
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
+    @patch("judgments.views.detail.get_published_judgment_by_uri")
     def test_published_judgment_response(self, mock_judgment, mock_pdf_size):
         mock_judgment.return_value = JudgmentFactory.build(is_published=True)
         mock_pdf_size.return_value = "1234KB"
@@ -50,31 +50,10 @@ class TestJudgment(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_judgment_not_published_404_response(self, mock_judgment):
-        mock_judgment.return_value = JudgmentFactory.build(is_published=False)
-
-        response = self.client.get("/test/2023/123")
-
-        decoded_response = response.content.decode("utf-8")
-        self.assertIn("Page not found", decoded_response)
-        self.assertEqual(response.status_code, 404)
-
-    @patch(
-        "caselawclient.models.judgments.Judgment.judgment_exists",
-        return_value=False,
-    )
-    def test_judgment_not_found_404_response(self, exists):
-        response = self.client.get("/test/2023/123")
-
-        decoded_response = response.content.decode("utf-8")
-        self.assertIn("Page not found", decoded_response)
-        self.assertEqual(response.status_code, 404)
-
 
 class TestJudgmentPdfLinkText(TestCase):
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
+    @patch("judgments.views.detail.get_published_judgment_by_uri")
     @patch.dict(environ, {"ASSETS_CDN_BASE_URL": "https://example.com"})
     def test_pdf_link_with_size(self, mock_judgment, mock_pdf_size):
         """
@@ -97,7 +76,7 @@ class TestJudgmentPdfLinkText(TestCase):
         self.assertIn("(1234KB)", decoded_response)
 
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
+    @patch("judgments.views.detail.get_published_judgment_by_uri")
     @patch.dict(environ, {"ASSETS_CDN_BASE_URL": "https://example.com"})
     def test_pdf_link_with_no_size(self, mock_judgment, mock_pdf_size):
         """

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -1,5 +1,4 @@
 import re
-from os import environ
 from unittest import skip
 from unittest.mock import patch
 
@@ -11,48 +10,6 @@ from test_search import fake_search_result, fake_search_results
 from judgments import converters, utils
 from judgments.models import CourtDates
 from judgments.utils import as_integer, display_back_link, paginator
-from judgments.views.detail import get_pdf_size
-
-
-class TestJudgment(TestCase):
-    @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_published_judgment_response(self, mock_judgment, mock_pdf_size):
-        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
-        mock_pdf_size.return_value = "1234KB"
-
-        response = self.client.get("/test/2023/123")
-        decoded_response = response.content.decode("utf-8")
-
-        self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
-
-        self.assertIn("<p>This is a judgment in HTML.</p>", decoded_response)
-        self.assertIn(
-            '<meta name="robots" content="noindex,nofollow" />', decoded_response
-        )
-
-        self.assertEqual(response.status_code, 200)
-
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_judgment_not_published_404_response(self, mock_judgment):
-        mock_judgment.return_value = JudgmentFactory.build(is_published=False)
-
-        response = self.client.get("/test/2023/123")
-
-        decoded_response = response.content.decode("utf-8")
-        self.assertIn("Page not found", decoded_response)
-        self.assertEqual(response.status_code, 404)
-
-    @patch(
-        "caselawclient.models.judgments.Judgment.judgment_exists",
-        return_value=False,
-    )
-    def test_judgment_not_found_404_response(self, exists):
-        response = self.client.get("/test/2023/123")
-
-        decoded_response = response.content.decode("utf-8")
-        self.assertIn("Page not found", decoded_response)
-        self.assertEqual(response.status_code, 404)
 
 
 class TestCourtDates(TestCase):
@@ -69,50 +26,6 @@ class TestCourtDates(TestCase):
 
     def test_max_year(self):
         self.assertEqual(CourtDates.max_year(), 2023)
-
-
-class TestJudgmentPdfLinkText(TestCase):
-    @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    @patch.dict(environ, {"ASSETS_CDN_BASE_URL": "https://example.com"})
-    def test_pdf_link_with_size(self, mock_judgment, mock_pdf_size):
-        """
-        `get_pdf_size` serves several purposes; it can _either_ return a string with the size of a PDF if one exists
-        in S3, _or_ return a string saying "unknown size" if the file exists but S3 doesn't tell us the size, _or_
-        return an empty string. This tests the case where it returns a non-empty string (either a file size or
-        "unknown"), in which case we should link to the file in S3 via our assets URL and display the size string.
-        """
-
-        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
-        mock_pdf_size.return_value = " (1234KB)"
-
-        response = self.client.get("/test/2023/123")
-        decoded_response = response.content.decode("utf-8")
-
-        self.assertIn(
-            "https://example.com/test/2023/123/test_2023_123.pdf", decoded_response
-        )
-        self.assertNotIn("data.pdf", decoded_response)
-        self.assertIn("(1234KB)", decoded_response)
-
-    @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    @patch.dict(environ, {"ASSETS_CDN_BASE_URL": "https://example.com"})
-    def test_pdf_link_with_no_size(self, mock_judgment, mock_pdf_size):
-        """
-        `get_pdf_size` serves several purposes; it can _either_ return a string with the size of a PDF if one exists
-        in S3, _or_ return a string saying "unknown size" if the file exists but S3 doesn't tell us the size, _or_
-        return an empty string. This tests the case where it returns an empty string (implying that the file doesn't
-        exist in S3), so we should link to our generated PDF instead and not S3."""
-
-        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
-        mock_pdf_size.return_value = ""
-
-        response = self.client.get("/test/2023/123")
-        decoded_response = response.content.decode("utf-8")
-
-        self.assertNotIn("test_2023_123.pdf", decoded_response)
-        self.assertIn("/test/2023/123/data.pdf", decoded_response)
 
 
 class TestPaginator(TestCase):
@@ -273,6 +186,8 @@ class TestRobotsDirectives(TestCase):
 
 
 class TestBackLink(TestCase):
+    # sometimes we pass the referring page into the details view to make sure the Back
+    # link works properly
     def test_referrer_is_results_page(self):
         # When there is a referrer, and it is a results page,
         # the back link is displayed:
@@ -293,44 +208,6 @@ class TestBackLink(TestCase):
     def test_no_referrer(self):
         # When there is no referrer, the back link is not displayed:
         self.assertIs(display_back_link(None), False)
-
-
-class TestGetPdfSize(TestCase):
-    @patch("judgments.views.detail.get_pdf_uri")
-    @patch("judgments.views.detail.requests.head")
-    def test_returns_valid_size(self, mock_head, mock_get_pdf_uri):
-        mock_head.return_value.headers = {"Content-Length": "1234567890"}
-        mock_head.return_value.status_code = 200
-        mock_get_pdf_uri.return_value = "http://example.com/test.pdf"
-
-        assert get_pdf_size("") == " (1.1\xa0GB)"
-        mock_head.assert_called_with(
-            "http://example.com/test.pdf", headers={"Accept-Encoding": None}
-        )
-
-    @patch("judgments.views.detail.get_pdf_uri")
-    @patch("judgments.views.detail.requests.head")
-    def test_pdf_exists_with_no_size(self, mock_head, mock_get_pdf_uri):
-        mock_head.return_value.headers = {}
-        mock_head.return_value.status_code = 200
-        mock_get_pdf_uri.return_value = "http://example.com/test.pdf"
-
-        assert get_pdf_size("") == " (unknown size)"
-        mock_head.assert_called_with(
-            "http://example.com/test.pdf", headers={"Accept-Encoding": None}
-        )
-
-    @patch("judgments.views.detail.get_pdf_uri")
-    @patch("judgments.views.detail.requests.head")
-    def test_no_pdf_exists(self, mock_head, mock_get_pdf_uri):
-        mock_head.return_value.headers = {}
-        mock_head.return_value.status_code = 404
-        mock_get_pdf_uri.return_value = "http://example.com/test.pdf"
-
-        assert get_pdf_size("") == ""
-        mock_head.assert_called_with(
-            "http://example.com/test.pdf", headers={"Accept-Encoding": None}
-        )
 
 
 def test_min_max():

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -4,7 +4,6 @@ from unittest import skip
 from unittest.mock import patch
 
 import pytest
-from caselawclient.Client import MarklogicResourceNotFoundError
 from django.test import TestCase
 from factories import JudgmentFactory
 from test_search import fake_search_result, fake_search_results
@@ -44,10 +43,11 @@ class TestJudgment(TestCase):
         self.assertIn("Page not found", decoded_response)
         self.assertEqual(response.status_code, 404)
 
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_judgment_not_found_404_response(self, mock_judgment):
-        mock_judgment.side_effect = MarklogicResourceNotFoundError()
-
+    @patch(
+        "caselawclient.models.judgments.Judgment.judgment_exists",
+        return_value=False,
+    )
+    def test_judgment_not_found_404_response(self, exists):
         response = self.client.get("/test/2023/123")
 
         decoded_response = response.content.decode("utf-8")

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -212,4 +212,5 @@ def get_judgment_by_uri(judgment_uri: str) -> Judgment:
         use_https=settings.MARKLOGIC_USE_HTTPS,
     )
 
+    # raises a JudgmentNotFoundError if it doesn't exist
     return Judgment(judgment_uri, api_client)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ requests-toolbelt~=1.0.0
 lxml~=4.9.2
 django-xml~=3.0.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=6.1.0
+ds-caselaw-marklogic-api-client~=7.0.0
 ds-caselaw-utils~=1.0.0
 rollbar
 django-weasyprint==2.2.0


### PR DESCRIPTION
Requires 7.0 of the custom-api-client