### PR TITLE
fixed line height for H1/H2/H3 headlines for support pages

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_standard_text_template.scss
+++ b/ds_judgements_public_ui/sass/includes/_standard_text_template.scss
@@ -19,18 +19,20 @@
 
   h1 {
     font-size: 2.2rem;
+    line-height: 2.4rem;
     margin: 0 0 calc($spacer__unit * 2);
-    line-height: 2.8rem;
   }
 
   h2 {
     font-size: 1.8rem;
+    line-height: 2rem;
     margin: 0 0 calc($spacer__unit * 1.25);
     padding: calc($spacer__unit * 2) 0 0;
   }
 
   h3 {
     font-size: 1.5rem;
+    line-height: 1.8rem;
     padding: calc($spacer__unit * 1.25) 0 0;
     margin: 0 0 calc($spacer__unit * 1.25);
   }


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
fixed line height for H1/H2/H3 headlines for support pages so when these wrapped the text was not touching between each line of text.
## Trello card / Rollbar error (etc)
Sub task for this card https://trello.com/c/MPy2sG6V/795-pui-redraft-how-to-search-help-text
## Screenshots of UI changes:

### Before
![Screenshot 2023-05-05 at 14 40 23](https://user-images.githubusercontent.com/102584881/236476305-55997e82-4abc-4def-befc-3b10c5a96a54.png)
![Screenshot 2023-05-05 at 14 40 14](https://user-images.githubusercontent.com/102584881/236476307-7028cf9d-5a0f-46d8-8bad-68c4bb899c33.png)

### After
![Screenshot 2023-05-05 at 14 35 36](https://user-images.githubusercontent.com/102584881/236476115-3b9391c1-8b49-45a9-9963-ae7555ac8f62.png)
- [ ] Requires env variable(s) to be updated
