### PR TITLE
Tighten URL regex

### DIFF
--- a/judgments/models.py
+++ b/judgments/models.py
@@ -27,7 +27,7 @@ class SearchResult:
         content_hash="",
         transformation_date="",
     ) -> None:
-        self.uri: str = uri
+        self.uri: str = uri.removesuffix(".xml")
         self.neutral_citation: str = neutral_citation
         self.name: str = name
         self.date: Optional[datetime]

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -30,6 +30,11 @@ class TestGetPublishedJudgment:
         with pytest.raises(Http404):
             get_published_judgment_by_uri("not-a-judgment")
 
+    def test_judgment_url_with_trailing_stuff_fails_to_resolve(self, client):
+        response = client.get("/eat/2022/1/kitten")
+        with pytest.raises(Resolver404):
+            response.resolver_match.func
+
 
 class TestJudgment(TestCase):
     @patch("judgments.views.detail.get_pdf_size")

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -5,6 +5,7 @@ import pytest
 from caselawclient.errors import JudgmentNotFoundError
 from django.http import Http404
 from django.test import TestCase
+from django.urls.exceptions import Resolver404
 from factories import JudgmentFactory
 
 from judgments.views.detail import get_pdf_size, get_published_judgment_by_uri
@@ -12,13 +13,13 @@ from judgments.views.detail import get_pdf_size, get_published_judgment_by_uri
 
 class TestGetPublishedJudgment:
     @patch("judgments.views.detail.get_judgment_by_uri")
-    def judgment_is_published(self, mock_judgment):
+    def test_judgment_is_published(self, mock_judgment):
         judgment = JudgmentFactory.build(is_published=True)
         mock_judgment.return_value = judgment
         assert get_published_judgment_by_uri("2022/eat/1") == judgment
 
     @patch("judgments.views.detail.get_judgment_by_uri")
-    def judgment_is_unpublished(self, mock_judgment):
+    def test_judgment_is_unpublished(self, mock_judgment):
         mock_judgment.return_value = JudgmentFactory.build(is_published=False)
         with pytest.raises(Http404):
             get_published_judgment_by_uri("2099/eat/1")
@@ -26,7 +27,7 @@ class TestGetPublishedJudgment:
     @patch(
         "judgments.views.detail.get_judgment_by_uri", side_effect=JudgmentNotFoundError
     )
-    def judgment_missing(self):
+    def test_judgment_missing(self, mock_judgment):
         with pytest.raises(Http404):
             get_published_judgment_by_uri("not-a-judgment")
 

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -39,18 +39,20 @@ urlpatterns = [
         name="feed",
     ),
     re_path(
-        r"(?P<judgment_uri>.*/\d{4}/\d+)/data.pdf",
+        r"^(?P<judgment_uri>.*/\d{4}/\d+)/data.pdf$",
         get_best_pdf,
         name="detail_pdf",
     ),
     re_path(
-        r"(?P<judgment_uri>.*/\d{4}/\d+)/generated.pdf",
+        r"^(?P<judgment_uri>.*/\d{4}/\d+)/generated.pdf$",
         PdfDetailView.as_view(),
         name="weasy_pdf",
     ),
-    re_path(r"(?P<judgment_uri>.*/\d{4}/\d+)/data.xml", detail_xml, name="detail_xml"),
-    re_path(r"(?P<judgment_uri>.*/\d{4}/\d+)/data.html", detail, name="detail"),
-    re_path(r"(?P<judgment_uri>.*/\d{4}/\d+)", detail, name="detail"),
+    re_path(
+        r"^(?P<judgment_uri>.*/\d{4}/\d+)/data.xml$", detail_xml, name="detail_xml"
+    ),
+    re_path(r"^(?P<judgment_uri>.*/\d{4}/\d+)/data.html$", detail, name="detail"),
+    re_path(r"^(?P<judgment_uri>.*/\d{4}/\d+)/?$", detail, name="detail"),
     path("judgments/results", results, name="results"),
     path("judgments/advanced_search", advanced_search, name="advanced_search"),
     path("", index, name="home"),


### PR DESCRIPTION
re_path checks if a URL matches a regular expression, but partial matches are still matches; examples typically are bracketted in `^`...`$` .

https://docs.djangoproject.com/en/4.2/ref/urls/#django.urls.re_path

We bracket our URLs this way so that `/eat/2022/1/press-summary/1` does not link to the judgment in future.

More controversially, we rewrite the URIs in some search results which were coming back as `/eat/2022/1.xml` to omit the trailing .xml which now fails to have a reverse (since that's not a valid website URI.)

~~This could do with a test.~~ Tested.