### PR TITLE
added the words and phrase to the keyword sub headline

### DIFF
--- a/ds_judgements_public_ui/templates/pages/how_to_use_this_service.html
+++ b/ds_judgements_public_ui/templates/pages/how_to_use_this_service.html
@@ -162,7 +162,7 @@
       If you see a name that has been struck through on a judgment, this means that the person has withdrawn from the
       case before it was decided.
     </p>
-    <h4>Keyword</h4>
+    <h4>Keyword or phrase</h4>
     <p>You can search the full text of every judgment and decision using a specific word or short phrase.</p>
     <p>Spaces between words will act as an 'and'. Quotation marks will search using that exact phrase only.</p>
     <h4>Judge's name</h4>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Altered the headline 'Keyword' to say 'Keyword or phrase' on the How to use the service static page.
## Trello card / Rollbar error (etc)
https://trello.com/c/MPy2sG6V/795-pui-redraft-how-to-search-help-text
## Screenshots of UI changes:

### Before
<img width="910" alt="Screenshot 2023-05-11 at 09 41 39" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/fa07430b-5580-41c3-acde-52488d37a96d">

### After
<img width="917" alt="Screenshot 2023-05-11 at 09 41 26" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/4e8e1d12-6c9c-42d1-8573-7055be44af6e">

- [ ] Requires env variable(s) to be updated
