### PR TITLE
Add thousands separator to the number of search results

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -69,7 +69,7 @@ DJANGO_APPS = [
     # "django.contrib.sites",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    # "django.contrib.humanize", # Handy template tags
+    "django.contrib.humanize",
     "django.contrib.admin",
     # "django.forms",
     "flags",

--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -1,6 +1,6 @@
-{% load i18n %}
+{% load i18n humanize %}
 <div class="results__result-header">
-  <p class="results__results-intro">We found {{ context.total }} judgments</p>
+  <p class="results__results-intro">We found {{ context.total|intcomma }} judgments</p>
 </div>
 <div class="result-controls">
   <form method="get"


### PR DESCRIPTION
## Changes in this PR

This is a small change to make the number more easily readable for humans.

## Screenshots of UI changes:

### Before

<img width="1086" alt="Screenshot 2023-05-11 at 20 23 54" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/136eca2d-127a-4d07-bf79-8938cdb3590e">

### After

![80880fbb10c67699483bba4e7612e1fc](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/6849a87c-3505-4298-83db-8a98d503e96e)
