### PR TITLE
Add space between snippet chunks

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgments_listing.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgments_listing.scss
@@ -30,6 +30,7 @@
   &__matches {
     p {
       display: inline;
+      padding-right: 0.5rem;
     }
   }
 


### PR DESCRIPTION
This has been bugging me forever -- note the space between CAT 35 and LORD, or MACUR and MR

### before

<img width="965" alt="image" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/85497046/81d47a28-0194-40ca-a611-86888ec929cd">

### after

<img width="957" alt="image" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/85497046/e2fbf1d5-b397-489e-87ce-32810883e763">

### before

<img width="991" alt="image" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/85497046/8f3398bf-0c8f-44e1-8bf4-37e6d791c9a6">

### after

<img width="958" alt="image" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/85497046/2dd974be-e1a1-4472-a23e-552867f20d0c">

(Possibly this should be an ellipsis or an obvious non-text symbol, but I think this is a strong enough improvement to include as-is.)