### PR TITLE
Mock CSS for Weasyprint so tests run in CI.

### DIFF
--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -8,7 +8,22 @@ from django.test import TestCase
 from django.urls.exceptions import Resolver404
 from factories import JudgmentFactory
 
-from judgments.views.detail import get_pdf_size, get_published_judgment_by_uri
+from judgments.views.detail import (
+    PdfDetailView,
+    get_pdf_size,
+    get_published_judgment_by_uri,
+)
+
+
+class TestWeasyWithoutCSS(TestCase):
+    @patch.object(PdfDetailView, "pdf_stylesheets", [])
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_weasy_without_css_runs_in_ci(self, mock_judgment):
+        judgment = JudgmentFactory.build(is_published=True)
+        mock_judgment.return_value = judgment
+        response = self.client.get("/eat/2023/1/generated.pdf")
+        assert response.status_code == 200
+        assert b"%PDF-1.7" in response.content
 
 
 class TestGetPublishedJudgment:

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -2,7 +2,6 @@ import re
 from unittest import skip
 from unittest.mock import patch
 
-import pytest
 from django.test import TestCase
 from factories import JudgmentFactory
 from test_search import fake_search_result, fake_search_results
@@ -10,6 +9,7 @@ from test_search import fake_search_result, fake_search_results
 from judgments import converters, utils
 from judgments.models import CourtDates
 from judgments.utils import as_integer, display_back_link, paginator
+from judgments.views.detail import PdfDetailView
 
 
 class TestCourtDates(TestCase):
@@ -165,7 +165,7 @@ class TestRobotsDirectives(TestCase):
         self.assertContains(response, "This is a judgment in XML.")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
-    @pytest.mark.local("Needs static file in CI")
+    @patch.object(PdfDetailView, "pdf_stylesheets", [])
     @patch("judgments.views.detail.PdfDetailView.get_context_data")
     def test_weasy_pdf(self, mock_context):
         mock_context.return_value = {"judgment": "<cat>KITTEN</cat>"}


### PR DESCRIPTION
We had a problem where weasyprint being upgraded lead to problems, our tests for that only ran locally.