### PR TITLE
Improve tests that mock perform_advanced_search

### DIFF
--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -13,8 +13,23 @@ class TestAtomFeed(TestCase):
 
         response = self.client.get("/atom.xml")
         decoded_response = response.content.decode("utf-8")
-        # that there is a valid page
+
+        # that perform_advanced_search is called with the appropriate parameters
+        fake_advanced_search.assert_called_with(
+            court=None,
+            date_from=None,
+            date_to=None,
+            order="-date",
+            page=1,
+        )
+
+        # that there is a successful response
         self.assertEqual(response.status_code, 200)
+        # that it is an atom feed
+        self.assertEqual(
+            response["Content-Type"], "application/atom+xml; charset=utf-8"
+        )
+
         # that it has the correct site name
         self.assertIn("<name>The National Archives</name>", decoded_response)
         # that it is like an Atom XML document
@@ -24,7 +39,7 @@ class TestAtomFeed(TestCase):
         # and it contains actual content - neither neutral citation or court appear in the feed to test.
         self.assertIn("A SearchResult name!", decoded_response)
 
-    @patch("judgments.utils.perform_advanced_search")
+    @patch("judgments.feeds.perform_advanced_search")
     def test_bad_page_404(self, fake_advanced_search):
         # "?page=" 404s, not 500
         fake_advanced_search.return_value = fake_search_results()

--- a/judgments/tests/test_homepage.py
+++ b/judgments/tests/test_homepage.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from judgments.tests.test_search import fake_search_result, fake_search_results
+
+
+class TestHomepage(TestCase):
+    @patch("judgments.views.index.perform_advanced_search")
+    @patch("judgments.models.SearchResult.create_from_node")
+    def test_homepage(self, fake_result, fake_advanced_search):
+        fake_advanced_search.return_value = fake_search_results()
+        fake_result.return_value = fake_search_result()
+        response = self.client.get("/")
+        fake_advanced_search.assert_called_with(order="-date")
+        self.assertContains(
+            response,
+            "A SearchResult name!",
+        )

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -67,7 +67,7 @@ class TestPaginator(TestCase):
         self.assertEqual(paginator(1, 5), expected_result)
 
     @skip("This test works locally but fails on CI, to fix")
-    @patch("judgments.utils.perform_advanced_search")
+    @patch("judgments.views.advanced_search.perform_advanced_search")
     @patch("judgments.models.SearchResult.create_from_node")
     def test_pagination_links(self, fake_result, fake_advanced_search):
         fake_advanced_search.return_value = fake_search_results()


### PR DESCRIPTION
## Changes in this PR:
- Improve tests that mock perform_advanced_search by making sure we assert that it is called with appropriate params.

This is in preparation for the change where I will adjust `perform_advanced_search` to call api_client.advanced_search with an extra kwarg: collections=["judgment"].

Specifically index, atom_feed, browse, results, advanced_search use perform_advanced_search and so I have adjusted one test of each to assert the calls. Could be extended further for certain edge cases but not for now.

## Trello card / Rollbar error (etc)
https://trello.com/c/T6x6GXmc/803-ensure-judgments-dont-display-press-summaries-erroneously
## Screenshots of UI changes:
