### PR TITLE
added a seprator to repeating search results text

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgments_listing.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgments_listing.scss
@@ -30,7 +30,19 @@
   &__matches {
     p {
       display: inline;
-      padding-right: 0.5rem;
+    }
+  }
+
+  &__matches {
+    p:after {
+      content: " | ";
+      color: #888888;
+    }
+  }
+
+  &__matches {
+    p:last-child:after {
+      content: "";
     }
   }
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Added a visual indicator to separate search results when there is more than one being returned within a judgment.
## Trello card / Rollbar error (etc)
https://trello.com/c/dVboWSNL/918-pui-design-a-visual-separator-for-search-queries-that-appear-more-than-once-on-a-single-judgment
## Screenshots of UI changes:

### Before
![Screenshot 2023-05-16 at 14 55 41](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/b8cf99be-0d66-46b8-8946-087b5ae43335)

### After
![Screenshot 2023-05-16 at 14 55 05](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/ef509d09-09e6-455e-ae6d-1d45710e18f8)

- [ ] Requires env variable(s) to be updated
