### PR TITLE
Suppress WeasyPrint log spam

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,5 @@ S3_REGION=eu-west-2
 ASSETS_CDN_BASE_URL=https://assets.caselaw.nationalarchives.gov.uk
 # but you would use this staging URL if you wanted it:
 # ASSETS_CDN_BASE_URL=https://tna-caselaw-assets-staging.s3.eu-west-2.amazonaws.com
+
+# SHOW_WEASYPRINT_LOGS=True

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -15,6 +15,10 @@ from django_weasyprint import WeasyTemplateResponseMixin
 
 from judgments.utils import display_back_link, get_judgment_by_uri, get_pdf_uri
 
+# suppress weasyprint log spam
+if os.environ.get("SHOW_WEASYPRINT_LOGS") != "True":
+    logging.getLogger("weasyprint").handlers = []
+
 
 def get_published_judgment_by_uri(judgment_uri: str) -> Judgment:
     try:


### PR DESCRIPTION
Weasyprint tells us a lot of information about the internal workings of the PDF / CSS problems. We broadly don't care, and when people are crawling the back-catalog of PDFs they trigger many lines of logs per PDF hit, and we're hitting our Papertrail limit.

Sets an environment variable `SHOW_WEASYPRINT_LOGS` which should be set to True to permit WeasyPrint logs; this environment variable is optional.