### PR TITLE
PUI - toolbar refine design

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -9,13 +9,13 @@
     margin: auto;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
-    align-items: stretch;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    align-content: center;
 
-
-    @media (min-width: $grid__breakpoint-small) {
-      flex-direction: row;
-      align-items: flex-start;
+    > h1 {
+      color: black;
     }
 
     > div {
@@ -55,57 +55,27 @@
       padding: calc($spacer__unit / 2) calc($spacer__unit * 1.5);
     }
   }
-
-  &__return-link {
-
-    text-align: left;
-
-    a {
-      background: transparent url($fa_chevron_left_aqua_blue) 1.5rem 0.65rem no-repeat;
-      background-size: 0.75rem;
-      color: $color__aqua-blue;
-      padding: calc($spacer__unit / 2) calc($spacer__unit * 3);
-      margin: 0;
-      display: inline-block;
-      text-decoration: underline;
-
-      &:hover {
-        text-decoration: none;
-      }
-
-
-      @media (min-width: $grid__breakpoint-small) {
-        background: transparent url($fa_chevron_left_aqua_blue) 0rem 0.65rem no-repeat;
-        padding: calc($spacer__unit / 2) calc($spacer__unit * 1.2);
-        background-size: 0.75rem;
-      }
-    }
-  }
 }
 
 .judgment-toolbar-download {
 
   margin: 0 auto;
 
-  @media (min-width: $grid__breakpoint-small) {
-    margin-left: auto;
-    margin-right: 0;
-  }
 
   &__option--pdf {
-    margin: 0 !important;
+    //margin: 0 !important;
     text-align: center;
   }
 
   &__download-options {
     color: $color__dark-grey;
     font-size: 0.75rem;
-    margin: calc($spacer__unit * 0.25) 0 0 0;
+    //margin: calc($spacer__unit * 0.25) 0 0 0;
 
     a {
       background-color: transparent;
       color: $color__aqua-blue;
-      padding: 0;
+      padding: 20px;
       display: inline;
       text-decoration: underline;
 

--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -55,6 +55,31 @@
       padding: calc($spacer__unit / 2) calc($spacer__unit * 1.5);
     }
   }
+  &__return-link {
+
+    text-align: left;
+
+    a {
+      background: transparent url($fa_chevron_left_aqua_blue) 1.5rem 0.65rem no-repeat;
+      background-size: 0.75rem;
+      color: $color__aqua-blue;
+      padding: calc($spacer__unit / 2) calc($spacer__unit * 3);
+      margin: 0;
+      display: inline-block;
+      text-decoration: underline;
+
+      &:hover {
+        text-decoration: none;
+      }
+
+
+      @media (min-width: $grid__breakpoint-small) {
+        background: transparent url($fa_chevron_left_aqua_blue) 0rem 0.65rem no-repeat;
+        padding: calc($spacer__unit / 2) calc($spacer__unit * 1.2);
+        background-size: 0.75rem;
+      }
+    }
+  }
 }
 
 .judgment-toolbar-download {
@@ -63,21 +88,21 @@
 
 
   &__option--pdf {
-    //margin: 0 !important;
     text-align: center;
   }
 
   &__download-options {
     color: $color__dark-grey;
     font-size: 0.75rem;
-    //margin: calc($spacer__unit * 0.25) 0 0 0;
+
 
     a {
       background-color: transparent;
       color: $color__aqua-blue;
-      padding: 20px;
+      padding: 1px;
       display: inline;
       text-decoration: underline;
+      font-size: 2rem;
 
       &:hover {
         text-decoration: none;

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -1,11 +1,7 @@
-{% load i18n %}
+{% load static i18n %}
 <div class="judgment-toolbar">
   <div class="judgment-toolbar__container">
-    {% if context.back_link %}
-      <div class="judgment-toolbar__return-link">
-        <a href="{{ context.back_link }}">{% translate "judgment.back" %}</a>
-      </div>
-    {% endif %}
+    <span>{{ context.judgment_title }} {{ context.judgment_ncn }}</span>
     <div class="judgment-toolbar__download judgment-toolbar-download">
       <a class="judgment-toolbar-download__option--pdf btn"
          role="button"

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -1,6 +1,10 @@
-{% load static i18n %}
+{% load i18n %}
 <div class="judgment-toolbar">
+  <div class="judgment-toolbar__return-link">
+    <a href="{{ context.back_link }}">{% translate "judgment.back" %}</a>
+  </div>
   <div class="judgment-toolbar__container">
+    {% if context.back_link %}{% endif %}
     <span>{{ context.judgment_title }} {{ context.judgment_ncn }}</span>
     <div class="judgment-toolbar__download judgment-toolbar-download">
       <a class="judgment-toolbar-download__option--pdf btn"

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -70,6 +70,8 @@ def detail(request, judgment_uri):
     context["judgment"] = judgment.content_as_html("")  # "" is most recent version
     context["page_title"] = judgment.name
     context["judgment_uri"] = judgment.uri
+    context["judgment_title"] = judgment.name
+    context["judgment_ncn"] = judgment.neutral_citation
 
     context["pdf_size"] = get_pdf_size(judgment.uri)
     context["pdf_uri"] = (

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -152,10 +152,6 @@ msgid "judgment.bailii"
 msgstr "The British and Irish Legal Information Institute"
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
-msgid "judgment.back"
-msgstr "Back to search results"
-
-#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.downloadaspdf"
 msgstr "Download as PDF"
 

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -152,6 +152,10 @@ msgid "judgment.bailii"
 msgstr "The British and Irish Legal Information Institute"
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+msgid "judgment.back"
+msgstr "Back to search results"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.downloadaspdf"
 msgstr "Download as PDF"
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Add judgment name and NCN to toolbar based on design, reposition the 'More download options' link
## Trello card / Rollbar error (etc)
https://trello.com/c/0JalmFTE/925-pui-toolbar-refine-design-1st
## Screenshots of UI changes:

### Before
![old-mobile-toolbar](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/e2d0fe21-1cbe-4860-9483-caf45ce697f6)
![old-toolbar-pui-desktop](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/f9f309db-ebea-41a2-8248-a4f70f59c700)

### After
![new-mobile-toolbar-pui](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/58e6a51e-a791-4585-b7bb-af1a20088687)
![new-toolbar-pui-desktop](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/f9eeb8d5-7499-4a8f-b2fd-644de01a2448)

- [ ] Requires env variable(s) to be updated
