### PR TITLE
Fix for gutters and vertical pacing on mobiles

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_footer.scss
+++ b/ds_judgements_public_ui/sass/includes/_footer.scss
@@ -21,10 +21,11 @@
 .judgments-footer {
   background-color: $color__almost-black;
   color: $color__white;
-  padding: $spacer__unit;
 
-  &__container {
-    @include container;
+  font-size: 0.9rem;
+
+  @media (min-width: $grid__breakpoint-medium) {
+    font-size: 1rem;
   }
 
   &__links-container {
@@ -53,9 +54,13 @@
 
   &__base-paragraph {
     text-align: left;
-    margin: calc($spacer__unit * 2) 0 calc($spacer__unit * 3);
-    font-size: 0.9rem;
-    line-height: 1.75rem;
+    font-size: 0.8rem;
+    line-height: 1.2rem;
+
+    @media (min-width: $grid__breakpoint-medium) {
+      font-size: 0.9rem;
+      line-height: 1.4rem;
+    }
 
     @media (min-width: $grid__breakpoint-extra-large) {
       text-align: center;

--- a/ds_judgements_public_ui/sass/includes/_footer.scss
+++ b/ds_judgements_public_ui/sass/includes/_footer.scss
@@ -1,17 +1,13 @@
 .pre-footer {
   background-color: $color__light-grey;
 
-  &__container {
-    @include container;
-    padding: calc($spacer__unit * 2.5) 0;
+  text-align: center;
 
-    text-align: center;
-
-    h2 {
-      padding-top: 0;
-      font-weight: normal;
-      font-size: 1.3rem;
-    }
+  h2 {
+    padding-top: 0;
+    margin-bottom: 0;
+    font-weight: normal;
+    font-size: 1.3rem;
   }
 
   &__cta-button {

--- a/ds_judgements_public_ui/sass/includes/_footer.scss
+++ b/ds_judgements_public_ui/sass/includes/_footer.scss
@@ -39,13 +39,24 @@
     @include sr-only;
   }
 
+  h3 {
+    @media (max-width: $grid__breakpoint-medium) {
+      padding-top: calc($spacer__unit / 2);
+      margin-bottom: calc($spacer__unit / 3);
+    }
+  }
+
   ul {
     padding: 0;
   }
 
   li {
     list-style: none;
-    margin-bottom: calc($spacer__unit / 2);
+    margin-bottom: calc($spacer__unit / 4);
+
+    @media (min-width: $grid__breakpoint-medium) {
+      margin-bottom: calc($spacer__unit / 2);
+    }
   }
 
   a {
@@ -56,6 +67,7 @@
     text-align: left;
     font-size: 0.8rem;
     line-height: 1.2rem;
+    margin-top: $spacer__unit * 1.5;
 
     @media (min-width: $grid__breakpoint-medium) {
       font-size: 0.9rem;

--- a/ds_judgements_public_ui/sass/includes/_header.scss
+++ b/ds_judgements_public_ui/sass/includes/_header.scss
@@ -15,6 +15,12 @@
     display: flex;
     align-items: center;
 
+    &-flex-container {
+      @media only screen and (max-width: $grid__breakpoint-medium) {
+        flex-grow: 1;
+      }
+    }
+
     ol {
       list-style-type: none;
       padding: 0;

--- a/ds_judgements_public_ui/sass/includes/_header.scss
+++ b/ds_judgements_public_ui/sass/includes/_header.scss
@@ -1,10 +1,7 @@
 .page-header {
   background-color: $color__almost-black;
 
-  &__container {
-    @include container;
-    padding: calc($spacer__unit * 1.5) 0;
-
+  &__flex-container {
     display: flex;
     justify-content: space-between;
 

--- a/ds_judgements_public_ui/sass/includes/_layout.scss
+++ b/ds_judgements_public_ui/sass/includes/_layout.scss
@@ -21,3 +21,7 @@ body {
   margin: 0;
   font-family: $font__open-sans;
 }
+
+.container {
+  @include container;
+}

--- a/ds_judgements_public_ui/sass/includes/_layout.scss
+++ b/ds_judgements_public_ui/sass/includes/_layout.scss
@@ -1,21 +1,19 @@
 @mixin container {
-  padding: 0 $minimum_gutter_width;
+  padding: 0 $gutter_unit;
   margin: auto;
 
-  @media (min-width: $grid__breakpoint-small) {
-    max-width: $grid__breakpoint-small - ($minimum_gutter_width * 2);
-  }
+  max-width: $grid__breakpoint-small - ($gutter_unit * 1);
 
   @media (min-width: $grid__breakpoint-medium) {
-    max-width: $grid__breakpoint-medium - ($minimum_gutter_width * 2);
+    max-width: $grid__breakpoint-medium - ($gutter_unit * 1.5);
   }
 
   @media (min-width: $grid__breakpoint-large) {
-    max-width: $grid__breakpoint-large - ($minimum_gutter_width * 2);
+    max-width: $grid__breakpoint-large - ($gutter_unit * 2);
   }
 
   @media (min-width: $grid__breakpoint-extra-large) {
-    max-width: $grid__breakpoint-extra-large - ($minimum_gutter_width * 2);
+    max-width: $grid__breakpoint-extra-large - ($gutter_unit * 2);
   }
 }
 

--- a/ds_judgements_public_ui/sass/includes/_phase_banner.scss
+++ b/ds_judgements_public_ui/sass/includes/_phase_banner.scss
@@ -2,11 +2,6 @@
   background-color: $color__yellow;
   color: $color__black;
 
-  &__container {
-    @include container;
-    padding: calc($spacer__unit / 2) 0;
-  }
-
   &__notice {
     padding: 0.3em 0;
 

--- a/ds_judgements_public_ui/sass/includes/_spacing.scss
+++ b/ds_judgements_public_ui/sass/includes/_spacing.scss
@@ -1,0 +1,22 @@
+@for $i from 1 through 3 {
+  .my-#{$i} {
+    margin-top: $spacer__unit * $i;
+    margin-bottom: $spacer__unit * $i;
+  }
+  .mt-#{$i} {
+    margin-top: $spacer__unit * $i;
+  }
+  .mb-#{$i} {
+    margin-top: $spacer__unit * $i;
+  }
+  .py-#{$i} {
+    padding-top: $spacer__unit * $i;
+    padding-bottom: $spacer__unit * $i;
+  }
+  .pt-#{$i} {
+    padding-top: $spacer__unit * $i;
+  }
+  .pb-#{$i} {
+    padding-bottom: $spacer__unit * $i;
+  }
+}

--- a/ds_judgements_public_ui/sass/includes/_standard_text_template.scss
+++ b/ds_judgements_public_ui/sass/includes/_standard_text_template.scss
@@ -1,10 +1,6 @@
 .standard-text-template {
-  @include container;
-
   font-size: 1.1rem;
   line-height: 1.4em;
 
-  margin-top: calc($spacer__unit * 4);
-  margin-bottom: calc($spacer__unit * 4);
   min-height: 18rem;
 }

--- a/ds_judgements_public_ui/sass/includes/_variables.scss
+++ b/ds_judgements_public_ui/sass/includes/_variables.scss
@@ -22,7 +22,7 @@ $color__focus-blue-outline: $color__dark-blue;
 $color__cta-background: $color__aqua-blue;
 $color__cta-background-hover: $color__dark-blue;
 
-$minimum_gutter_width: 50px;
+$gutter_unit: 25px;
 $grid__breakpoint-small: 576px;
 $grid__breakpoint-medium: 768px;
 $grid__breakpoint-large: 992px;

--- a/ds_judgements_public_ui/sass/main.scss
+++ b/ds_judgements_public_ui/sass/main.scss
@@ -4,6 +4,7 @@
 
 // Core
 @import "includes/layout";
+@import "includes/spacing";
 @import "includes/typography";
 @import "includes/header";
 @import "includes/footer";

--- a/ds_judgements_public_ui/templates/403.html
+++ b/ds_judgements_public_ui/templates/403.html
@@ -16,7 +16,7 @@
       </nav>
     </div>
   </header>
-  <div class="standard-text-template">
+  <div class="standard-text-template container py-3">
     <h1>Forbidden</h1>
     <p>
       {% if exception %}

--- a/ds_judgements_public_ui/templates/404.html
+++ b/ds_judgements_public_ui/templates/404.html
@@ -16,7 +16,7 @@
       </nav>
     </div>
   </header>
-  <div class="standard-text-template">
+  <div class="standard-text-template container py-3">
     <h1>Page not found</h1>
     <p>If you typed the web address, check it is correct.</p>
     <p>If you pasted the web address, check you copied the entire address.</p>

--- a/ds_judgements_public_ui/templates/500.html
+++ b/ds_judgements_public_ui/templates/500.html
@@ -16,7 +16,7 @@
       </nav>
     </div>
   </header>
-  <div class="standard-text-template">
+  <div class="standard-text-template container py-3">
     <h1>Server Error</h1>
     <p>Sorry, there seems to be an error. Please try again soon.</p>
     <p>

--- a/ds_judgements_public_ui/templates/includes/breadcrumbs.html
+++ b/ds_judgements_public_ui/templates/includes/breadcrumbs.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 <div class="page-header__breadcrumb">
-  <nav class="page-header__breadcrumb-container" aria-label="Breadcrumb">
+  <nav class="page-header__breadcrumb-flex-container"
+       aria-label="Breadcrumb">
     <ol>
       <li>
         <span class="page-header__breadcrumb-you-are-in">You are in:</span>

--- a/ds_judgements_public_ui/templates/includes/footer.html
+++ b/ds_judgements_public_ui/templates/includes/footer.html
@@ -46,7 +46,7 @@
         </ul>
       </div>
     </div>
-    <p class="judgments-footer__base-paragraph mt-1">
+    <p class="judgments-footer__base-paragraph">
       All content is available under the
       <a class="judgments-footer__link"
          href="{% url "open_justice_licence" %}">Open Justice Licence</a>. For re-use that is not covered by the Open Justice Licence, please

--- a/ds_judgements_public_ui/templates/includes/footer.html
+++ b/ds_judgements_public_ui/templates/includes/footer.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <footer class="judgments-footer">
-  <div class="judgments-footer__container">
+  <div class="container pt-2 pb-1">
     <h2 class="judgments-footer__heading">Footer</h2>
     <div class="judgments-footer__links-container">
       <div>
@@ -46,7 +46,7 @@
         </ul>
       </div>
     </div>
-    <p class="judgments-footer__base-paragraph">
+    <p class="judgments-footer__base-paragraph mt-1">
       All content is available under the
       <a class="judgments-footer__link"
          href="{% url "open_justice_licence" %}">Open Justice Licence</a>. For re-use that is not covered by the Open Justice Licence, please

--- a/ds_judgements_public_ui/templates/includes/how_can_this_service_be_improved.html
+++ b/ds_judgements_public_ui/templates/includes/how_can_this_service_be_improved.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="pre-footer">
-  <div class="pre-footer__container">
+  <div class="container py-2">
     <h2>{% translate "service.improved" %}</h2>
     <a target="_blank"
        role="button"

--- a/ds_judgements_public_ui/templates/includes/phase_banner.html
+++ b/ds_judgements_public_ui/templates/includes/phase_banner.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="phase-banner" id="js-phase-banner">
-  <div class="phase-banner__container">
+  <div class="container py-1">
     <div class="phase-banner__notice">
       <strong class="phase-banner__phase">Alpha</strong>
       <p class="phase-banner__message">

--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -35,7 +35,7 @@
     {% include "includes/phase_banner.html" %}
     <header class="page-header">
       {% block header %}
-        <div class="page-header__container">
+        <div class="page-header__flex-container container py-1">
           {% include "includes/breadcrumbs.html" with current=context.page_title title=context.page_title link=request.path %}
           {% include "includes/logo.html" %}
         </div>

--- a/ds_judgements_public_ui/templates/layouts/judgment.html
+++ b/ds_judgements_public_ui/templates/layouts/judgment.html
@@ -29,7 +29,7 @@
     {% include "includes/gtm/gtm_body.html" %}
     {% include "includes/phase_banner.html" %}
     <header class="page-header">
-      <div class="page-header__container">
+      <div class="page-header__flex-container container py-1">
         {% include "includes/breadcrumbs.html" with current=context.page_title title=context.page_title link=request.path %}
         {% include "includes/logo.html" %}
       </div>

--- a/ds_judgements_public_ui/templates/layouts/static_content.html
+++ b/ds_judgements_public_ui/templates/layouts/static_content.html
@@ -6,7 +6,7 @@
   {{ context.page_title }} - {% translate "common.findcaselaw" %}
 {% endblock title %}
 {% block content %}
-  <div class="standard-text-template">
+  <div class="standard-text-template container py-3">
     <div id="start-of-document" class="entry-content clearfix">
       {% block static_content %}
       {% endblock static_content %}

--- a/ds_judgements_public_ui/templates/pages/home.html
+++ b/ds_judgements_public_ui/templates/pages/home.html
@@ -6,7 +6,7 @@
   {% translate "common.findcaselaw" %}
 {% endblock title %}
 {% block header %}
-  <div class="page-header__container">
+  <div class="page-header__flex-container container py-1">
     <div class="service-introduction">
       <span class="service-introduction__separator"></span>
       <h1 class="service-introduction__header">{% translate "common.findcaselaw" %}</h1>


### PR DESCRIPTION
A bunch of assorted CSS/layout fixes and tweaks which improve page gutters and vertical pacing, particularly in mobile views.

## Screenshots

### Home

![Home Old](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/84536669-0f2f-4f19-a379-675b500c44a9)

![Home New](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/22fa856f-6fb5-430f-8349-3482290888ed)

### Static content

![HTU Old](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/121e55e2-9081-4d17-95dd-a261bda11fc5)

![HTU New](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/b1d84439-1d71-4dec-83db-b077715f6bae)

### Footer

![HTU Foot Old](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/20d4658b-63e7-4b93-9707-dc3d1e14c158)

![HTU Foot New](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/8159ceac-6d9c-42ca-b42f-20aa0c6ffc36)
