### PR TITLE
add court date ranges alongside court filters

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -244,7 +244,10 @@
   &__court-option-label {
     margin-left: calc(0.5 * $spacer__unit);
   }
-
+  &__court-date-range {
+    color: $color__dark-grey;
+    font-size: 0.9rem;
+  }
   &__date-input {
     @include text_field;
     margin-bottom: 0;

--- a/ds_judgements_public_ui/templates/includes/browse_by_court.html
+++ b/ds_judgements_public_ui/templates/includes/browse_by_court.html
@@ -10,7 +10,7 @@
             <li class="judgment-browse__list-item">
               <a class="judgment-browse__link"
                  href="{% url "advanced_search" %}?court={{ court.canonical_param }}">{{ court.list_name }}</a>
-              <span class="judgment-browse__year-range">{{ court|get_court_date_range }}</span>
+              <span class="judgment-browse__year-range">&mdash; {{ court|get_court_date_range }}</span>
             </li>
           {% endfor %}
         </ul>
@@ -25,7 +25,7 @@
             <li class="judgment-browse__list-item">
               <a class="judgment-browse__link"
                  href="{% url "advanced_search" %}?court={{ tribunal.canonical_param }}">{{ tribunal.list_name }}</a>
-              <span class="judgment-browse__year-range">{{ tribunal|get_court_date_range }}</span>
+              <span class="judgment-browse__year-range">&mdash; {{ tribunal|get_court_date_range }}</span>
             </li>
           {% endfor %}
         </ul>

--- a/ds_judgements_public_ui/templates/includes/courts_options.html
+++ b/ds_judgements_public_ui/templates/includes/courts_options.html
@@ -9,7 +9,7 @@
              {% for alias in context.court %}{% if alias in court.param_aliases %}checked="checked"{% endif %}
              {% endfor %} />
       <span class="structured-search__court-option-label">{{ court.name }}
-        <span style="color:#555; font-size: 0.9rem">&mdash; {{ court|get_court_date_range }}</span>
+        <span class="structured-search__court-date-range">&mdash; {{ court|get_court_date_range }}</span>
       </span>
     </label>
   </div>

--- a/ds_judgements_public_ui/templates/includes/courts_options.html
+++ b/ds_judgements_public_ui/templates/includes/courts_options.html
@@ -1,3 +1,4 @@
+{% load query_filters court_utils %}
 {% for court in context.courts %}
   <div class="structured-search__court-option">
     <label for="court_{{ court.canonical_param }}">
@@ -7,7 +8,9 @@
              id="court_{{ court.canonical_param }}"
              {% for alias in context.court %}{% if alias in court.param_aliases %}checked="checked"{% endif %}
              {% endfor %} />
-      <span class="structured-search__court-option-label">{{ court.name }}</span>
+      <span class="structured-search__court-option-label">{{ court.name }}
+        <span style="color:#555; font-size: 0.9rem">&mdash; {{ court|get_court_date_range }}</span>
+      </span>
     </label>
   </div>
 {% endfor %}

--- a/ds_judgements_public_ui/templates/pages/about_this_service.html
+++ b/ds_judgements_public_ui/templates/pages/about_this_service.html
@@ -70,11 +70,11 @@
         <li>
           <span>{{ group.name }}</span>
           <ul>
-            {% for court in group.courts %}<li>{{ court.list_name }} {{ court|get_court_date_range }}</li>{% endfor %}
+            {% for court in group.courts %}<li>{{ court.list_name }} &mdash;{{ court|get_court_date_range }}</li>{% endfor %}
           </ul>
         </li>
       {% else %}
-        {% for court in group.courts %}<li>{{ court.list_name }} {{ court|get_court_date_range }}</li>{% endfor %}
+        {% for court in group.courts %}<li>{{ court.list_name }} &mdash;{{ court|get_court_date_range }}</li>{% endfor %}
       {% endif %}
     {% endfor %}
   </ul>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Displaying court date ranges in context alongside the existing and new (hierarchical) court filters on about page, browse and structured search.
## Trello card / Rollbar error (etc)
https://trello.com/c/tLHaCVSW/757-%F0%9F%94%8D-pui-browse-displaying-court-date-ranges-in-context-alongside-search-filters-but-see-857
## Screenshots of UI changes:

### Before
![about-before](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/868100ac-bc23-4cef-a78e-9c11b90b84bf)
![browse-before](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/78e9cacd-c21d-4cbf-b3a9-d71c4400014f)
![structure-before](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/177474b7-dd65-4b6a-b9c4-e548b40601d6)

### After
![about-after](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/19903490-a821-4dd7-9db0-2af7bde370ad)
![browse-after](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/c6f0fb61-4645-47ec-9864-2e1ad5925f03)
![structure-after](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/13e9948a-96b8-4ade-9439-ff008996ff66)
![results-filter](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/3784379e-341a-4378-af6d-29a69a9ca3cd)

- [ ] Requires env variable(s) to be updated
