### PR TITLE
Improvements to 'no results' and 'end of results' messaging

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgments_listing.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgments_listing.scss
@@ -1,5 +1,9 @@
 .judgment-listing {
   &__list {
+    &--last-page {
+      margin-bottom: 0;
+    }
+
     padding: 0;
     list-style-type: none;
 
@@ -7,6 +11,10 @@
       padding: $spacer__unit calc($spacer__unit / 4) $spacer__unit
         calc($spacer__unit / 4);
       border-bottom: 1px dotted $color__yellow;
+
+      &:last-child {
+        border-bottom: none;
+      }
     }
   }
 

--- a/ds_judgements_public_ui/sass/includes/_no_results_message.scss
+++ b/ds_judgements_public_ui/sass/includes/_no_results_message.scss
@@ -1,0 +1,19 @@
+.no-results-message {
+  background-color: $color__light-grey;
+  padding: $spacer__unit;
+  margin-bottom: $spacer__unit;
+  border-top: 4px solid $color__yellow;
+  border-bottom: 4px solid $color__yellow;
+  font-size: 0.9rem;
+  h2 {
+    position: initial;
+    height: initial;
+    width: initial;
+    padding-top: 0;
+  }
+
+  @media (min-width: $grid__breakpoint-large) {
+    padding-left: calc(5 * $spacer__unit);
+    padding-right: calc(5 * $spacer__unit);
+  }
+}

--- a/ds_judgements_public_ui/sass/main.scss
+++ b/ds_judgements_public_ui/sass/main.scss
@@ -38,3 +38,4 @@
 @import "includes/standard_text_template";
 @import "includes/structured_search";
 @import "includes/what_to_expect";
+@import "includes/no_results_message";

--- a/ds_judgements_public_ui/templates/includes/no_results_message.html
+++ b/ds_judgements_public_ui/templates/includes/no_results_message.html
@@ -1,0 +1,32 @@
+<div class="no-results-message">
+  <h2>
+    {% if title %}
+      {{ title }}
+    {% else %}
+      No results have been found
+    {% endif %}
+  </h2>
+  <p>
+    If you're unable to find a particular judgment, you may wish to check
+    <a href="{% url 'about_this_service' %}#section-coverage">if we cover that court and date</a>.
+  </p>
+  <p>In particular, we have:</p>
+  <ul>
+    <li>
+      <strong>no</strong> court judgments before 2003
+    </li>
+    <li>
+      <strong>no</strong> Scottish, Northern Irish or Irish court judgments or tribunal decisions
+    </li>
+    <li>
+      <strong>no</strong> Crown Court, County Court or Magistrates' Court judgments
+    </li>
+    <li>only a limited selection of tribunal decisions</li>
+  </ul>
+  <p>
+    Ex tempore (verbal) judgments that are not routinely transcribed may not be sent to the archive, please contact the court or tribunal directly.
+  </p>
+  <p>
+    If you are looking for a judgment that has been recently handed down and it has been longer than two working days, it is likely that we have not received it, please contact the court of tribunal directly.
+  </p>
+</div>

--- a/ds_judgements_public_ui/templates/includes/results_list.html
+++ b/ds_judgements_public_ui/templates/includes/results_list.html
@@ -1,6 +1,6 @@
 {% load static i18n %}
 <h2>Results listing</h2>
-<ul class="judgment-listing__list">
+<ul class="judgment-listing__list {% if not context.paginator.has_next_page %}judgment-listing__list--last-page{% endif %}">
   {% for item in context.search_results %}
     <li>
       <span class="judgment-listing__judgment">

--- a/ds_judgements_public_ui/templates/judgment/results.html
+++ b/ds_judgements_public_ui/templates/judgment/results.html
@@ -13,35 +13,13 @@
           <div class="results__result-controls-container">{% include "includes/result_controls.html" %}</div>
           <div class="results__result-list-container">
             {% include "includes/results_list.html" %}
+            {% if not context.paginator.has_next_page %}
+              {% include "includes/no_results_message.html" with title="End of results" %}
+            {% endif %}
             {% include "includes/pagination.html" %}
           </div>
-          {% if not context.paginator.has_next_page %}
-            <h2>End of results</h2>
-            <p>
-              If you can't find the judgment you're looking for, please review the search filters
-              you have applied to increase the number of search results.
-            </p>
-            <p>
-              Please bear in mind that as an alpha service, we don't yet have all historical judgments available --
-              you can check the <a href="{% url 'what_to_expect' %}">availability list</a> or
-              <a href="mailto:{{ caselaw.email }}">contact us</a> if you believe there is a problem.
-            </p>
-          {% endif %}
         {% else %}
-          <h2>We found no results</h2>
-          <p>
-            If you're unable to find a particular judgment, you may wish to check
-            <a href="{% url 'about_this_service' %}#section-coverage">whether we cover that court and date</a>.
-          </p>
-          <p>
-            In particular, we do not have:
-            <ul>
-              <li>any court judgments before 2003</li>
-              <li>any Crown Court, County Court or Magistrates' Court judgments,</li>
-            </ul>
-            and only have a limited selection of tribunal decisions.
-          </p>
-          <p>We are working to add more historical judgments.</p>
+          {% include "includes/no_results_message.html" %}
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
## Changes in this PR:
 - Harmonised content in both places, added lack of scottish and northern irish courts
 - Reworded 'no results' title so as not to bury the lede
 - Refactored a bit to move message into its own include
 - A quick design/styles pass to make sure the message has appropriate prominence, appears in a natural place in the page flow, and is clearly differentiated from the results themselves.


## Trello card / Rollbar error (etc)

Part of https://trello.com/c/e8N4LhfQ/902-pui-recovering-from-0-results-simple-changes-first, 
All of https://trello.com/c/X0VvkKzC/933-add-we-havent-got-scottish-irish-court-stuff-to-no-results-and-stuff
## Screenshots of UI changes:

### After
<img width="1379" alt="Screenshot 2023-05-25 at 18 23 27" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/f473a368-4ec3-454c-862b-dfe17c966f87">
<img width="617" alt="Screenshot 2023-05-25 at 18 23 13" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/fd40d905-9861-4969-b12a-0ccc8fd1a427">
<img width="1265" alt="Screenshot 2023-05-25 at 18 20 05" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/8306c6a6-8829-41d1-b538-b216e96ebc74">

