### PR TITLE
Add visual marker date errors

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -173,7 +173,6 @@
     color: #d4351c;
     font-weight: 700;
     font-size: 0.8rem;
-    #display: none;
   }
 
   &__to-date-error-message {
@@ -182,7 +181,6 @@
     color: #d4351c;
     font-weight: 700;
     font-size: 0.8rem;
-    #display: none;
   }
 
   input:invalid {
@@ -307,6 +305,18 @@
     border: none;
     padding: 0;
     margin: 0;
+  }
+
+  &__multi-fields-panel {
+    fieldset.set-1 {
+      padding-left: 20px;
+      border-left: 4px solid #d4351c;
+    }
+
+    fieldset.set-2 {
+      padding-left: 20px;
+      border-left: 4px solid #d4351c;
+    }
   }
 
   &__update-filters-button {

--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -308,13 +308,13 @@
   }
 
   &__multi-fields-panel {
-    fieldset.set-1 {
-      padding-left: 20px;
+    fieldset.with-errors {
+      padding-left: calc($spacer__unit * 1.5);
       border-left: 4px solid #d4351c;
     }
 
-    fieldset.set-2 {
-      padding-left: 20px;
+    fieldset.with-errors {
+      padding-left: calc($spacer__unit * 1.5);
       border-left: 4px solid #d4351c;
     }
   }

--- a/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
@@ -11,7 +11,7 @@
 <div class="structured-search__multi-fields-panel">
   <div class="structured-search__limit-to-container">
     {% if context.errors|has_errors_for_field:"from_date" %}
-      <fieldset class="set-1">
+      <fieldset class="{% if context.errors %}with-errors{% endif %}">
       {% endif %}
       <legend>
         <span class="structured-search__limit-to-label" id="from_date_label">From date</span>
@@ -65,7 +65,7 @@
   </div>
   <div class="structured-search__limit-to-container">
     {% if context.errors|has_errors_for_field:"to_date" %}
-      <fieldset class="set-2">
+      <fieldset class="{% if context.errors %}with-errors{% endif %}">
       {% endif %}
       <legend>
         <span class="structured-search__limit-to-label"

--- a/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
@@ -10,7 +10,7 @@
 </div>
 <div class="structured-search__multi-fields-panel">
   <div class="structured-search__limit-to-container">
-    <fieldset>
+    {% if context.errors %}<fieldset class="set-1">{% endif %}
       <legend>
         <span class="structured-search__limit-to-label" id="from_date_label">From date</span>
       </legend>
@@ -62,7 +62,7 @@
     </fieldset>
   </div>
   <div class="structured-search__limit-to-container">
-    <fieldset>
+    {% if context.errors %}<fieldset class="set-2">{% endif %}
       <legend>
         <span class="structured-search__limit-to-label"
               name="to_date"

--- a/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
@@ -10,7 +10,9 @@
 </div>
 <div class="structured-search__multi-fields-panel">
   <div class="structured-search__limit-to-container">
-    {% if context.errors %}<fieldset class="set-1">{% endif %}
+    {% if context.errors|has_errors_for_field:"from_date" %}
+      <fieldset class="set-1">
+      {% endif %}
       <legend>
         <span class="structured-search__limit-to-label" id="from_date_label">From date</span>
       </legend>
@@ -62,7 +64,9 @@
     </fieldset>
   </div>
   <div class="structured-search__limit-to-container">
-    {% if context.errors %}<fieldset class="set-2">{% endif %}
+    {% if context.errors|has_errors_for_field:"to_date" %}
+      <fieldset class="set-2">
+      {% endif %}
       <legend>
         <span class="structured-search__limit-to-label"
               name="to_date"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Added to validation visual marker for error states -using the red GDS side border marker
## Trello card / Rollbar error (etc)
https://trello.com/c/MRQqUFei/935-pui-form-validation-visual-marker-for-error-states
## Screenshots of UI changes:

### Before
![before-update-error](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/57b8db79-fa6f-49fe-8d04-6ad6ed8ae9a9)

### After
![update-error-after](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/7bb703a4-39e3-4352-b468-1169d5274d03)


- [ ] Requires env variable(s) to be updated
