### PR TITLE
PUI update Aria labels so they are unique

### DIFF
--- a/ds_judgements_public_ui/templates/includes/structured_search_additional_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/structured_search_additional_inputs.html
@@ -2,7 +2,8 @@
   <div class="structured-search__multi-fields-panel">
     <div class="structured-search__specific-field-container">
       <label for="neutral_citation" class="structured-search__limit-to-label">Neutral citation</label>
-      <p class="structured-search__help-text" id="neutral_citation-help-text">For example [2021] EWCA Crim 1785</p>
+      <p class="structured-search__help-text"
+         id="neutral_citation-help-text-ncn">For example [2021] EWCA Crim 1785</p>
       <input class="structured-search__limit-to-input"
              id="neutral_citation"
              name="neutral_citation"
@@ -12,7 +13,8 @@
     </div>
     <div class="structured-search__limit-to-container">
       <label for="specific_keywords" class="structured-search__limit-to-label">Containing specific keywords</label>
-      <p class="structured-search__help-text" id="neutral_citation-help-text">For example, London Borough of...</p>
+      <p class="structured-search__help-text"
+         id="neutral_citation-help-text-keywords">For example, London Borough of...</p>
       <input class="structured-search__limit-to-input"
              id="specific_keywords"
              name="specific_keyword"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
PUI update Aria labels so they are unique
## Trello card / Rollbar error (etc)
https://trello.com/c/uAmWJZiR/973-%E2%9C%94%EF%B8%8F-aa-structured-search-page-aria-ids-are-not-unique
## Screenshots of UI changes:

### Before
![before-ncn](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/d45b33e1-d616-4fc8-8cd7-7831ffa53e92)
![before](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/9ca9da37-13be-49b9-9133-4e31c8c425a5)


### After
![after-ncn](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/d3c6b79b-7f86-4493-a62a-a60ca127e474)

![after-keywords](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/72177c0e-7f2d-490e-94fb-82ca17ccc289)



- [ ] Requires env variable(s) to be updated
