### PR TITLE
Suppress warnings about docker network format being out of date

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,5 +58,5 @@ services:
 
 networks:
   default:
-    external:
-      name: caselaw
+    name: caselaw
+    external: true


### PR DESCRIPTION
network.external.name is deprecated in favour of network.name and network.external=True. There were warnings.