### PR TITLE
Accesibility tidyup

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_cookie_banner_overrides.scss
+++ b/ds_judgements_public_ui/sass/includes/_cookie_banner_overrides.scss
@@ -1,0 +1,9 @@
+#ds-cookie-consent-banner a {
+  color: $color__white;
+}
+
+#ds-cookie-consent-banner .container #btn_preferences:hover,
+#ds-cookie-consent-banner .container #btn_preferences:focus {
+  background: none;
+  border: 2px solid transparent;
+}

--- a/ds_judgements_public_ui/sass/main.scss
+++ b/ds_judgements_public_ui/sass/main.scss
@@ -15,6 +15,7 @@
 @import "includes/buttons";
 @import "includes/cookie_consent/cookie-consent";
 @import "includes/cookie_consent/ds-cookie-consent";
+@import "includes/cookie_banner_overrides";
 @import "includes/document_navigation_links";
 @import "includes/forms";
 @import "includes/help_end_document_marker";

--- a/ds_judgements_public_ui/templates/includes/structured_search_additional_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/structured_search_additional_inputs.html
@@ -2,8 +2,7 @@
   <div class="structured-search__multi-fields-panel">
     <div class="structured-search__specific-field-container">
       <label for="neutral_citation" class="structured-search__limit-to-label">Neutral citation</label>
-      <p class="structured-search__help-text"
-         id="neutral_citation-help-text-ncn">For example [2021] EWCA Crim 1785</p>
+      <p class="structured-search__help-text" id="neutral_citation-help-text">For example [2021] EWCA Crim 1785</p>
       <input class="structured-search__limit-to-input"
              id="neutral_citation"
              name="neutral_citation"
@@ -13,8 +12,7 @@
     </div>
     <div class="structured-search__limit-to-container">
       <label for="specific_keywords" class="structured-search__limit-to-label">Containing specific keywords</label>
-      <p class="structured-search__help-text"
-         id="neutral_citation-help-text-keywords">For example, London Borough of...</p>
+      <p class="structured-search__help-text" id="keywords-help-text">For example, London Borough of...</p>
       <input class="structured-search__limit-to-input"
              id="specific_keywords"
              name="specific_keyword"

--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -15,7 +15,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="{% static 'images/favicons/favicon.png' %}" />
     {% block css %}
-      <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&amp;family=Roboto:wght@400;600;700&amp;display=swap"
+      <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&amp;family=Roboto:wght@400;600;700&amp;family=Roboto+Mono:wght@400;600;700&amp;display=swap"
             rel="stylesheet" />
       <link href="{% static 'css/main.css' %}" rel="stylesheet" />
     {% endblock css %}

--- a/ds_judgements_public_ui/templates/layouts/judgment.html
+++ b/ds_judgements_public_ui/templates/layouts/judgment.html
@@ -13,7 +13,7 @@
     {% translate "common.findcaselaw" %}</title>
     <link rel="icon" href="{% static 'images/favicons/favicon.png' %}" />
     {% block css %}
-      <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&amp;family=Roboto:wght@400;600;700&amp;display=swap"
+      <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&amp;family=Roboto:wght@400;600;700&amp;family=Roboto+Mono:wght@400;600;700&amp;display=swap"
             rel="stylesheet" />
       <link href="{% static 'css/main.css' %}" rel="stylesheet" />
     {% endblock css %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Couple of tiny improvements for accessibility:

 - rename ids to make them more meaningful
 - include fonts needed by NI global cookie banner
 - tame an unruly CSS rule that was making the 'cookie settings' link hard to read

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

https://trello.com/c/Igy4Oa4T/974-%E2%9C%94%EF%B8%8F-aa-pui-eui-cookie-banners-update-font-colour-contrast-fails-on-preferences-links

### Before
<img width="1156" alt="Screenshot 2023-06-12 at 16 04 17" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/d443be70-1710-4695-848c-50befbff5da4">


### After
<img width="1156" alt="Screenshot 2023-06-12 at 16 04 04" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/f2e997e0-ddcf-4021-a682-ccb959e61bca">


