### PR TITLE
Move 'back to search results' link into breadcrumbs and expose context

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -41,32 +41,6 @@
     }
   }
 
-  &__return-link {
-    @include container;
-
-    a {
-      background: transparent url($fa_chevron_left_aqua_blue) 1.5rem 0.65rem
-        no-repeat;
-      background-size: 0.75rem;
-      color: $color__aqua-blue;
-      padding: calc($spacer__unit / 2) calc($spacer__unit * 3);
-      margin: 0;
-      display: inline-block;
-      text-decoration: underline;
-
-      &:hover {
-        text-decoration: none;
-      }
-
-      @media (min-width: $grid__breakpoint-small) {
-        background: transparent url($fa_chevron_left_aqua_blue) 0rem 0.65rem
-          no-repeat;
-        padding: calc($spacer__unit / 2) calc($spacer__unit * 1.2);
-        background-size: 0.75rem;
-      }
-    }
-  }
-
   &__title {
     margin: 1rem 0;
     color: $color__almost-black;

--- a/ds_judgements_public_ui/templates/includes/breadcrumbs.html
+++ b/ds_judgements_public_ui/templates/includes/breadcrumbs.html
@@ -11,12 +11,13 @@
           <a href="{% url 'home' %}">{% translate "common.findcaselaw" %}</a>
         {% endif %}
       </li>
-      {% if context.back_link %}
+      {% if search_context %}
         <li>
-          <a href="{{ context.back_link }}">{% translate "breadcrumbs.search" %}</a>
-        </li>
-      {% endif %}
-      {% if title and link %}<li>{{ title }}</li>{% endif %}
-    </ol>
-  </nav>
-</div>
+          <a href="{{ search_context.search_url }}">{% translate "breadcrumbs.search" %}
+            {% if search_context.query %}for "{{ search_context.query }}"{% endif %}</a>
+          </li>
+        {% endif %}
+        {% if title and link %}<li>{{ title }}</li>{% endif %}
+      </ol>
+    </nav>
+  </div>

--- a/ds_judgements_public_ui/templates/includes/breadcrumbs.html
+++ b/ds_judgements_public_ui/templates/includes/breadcrumbs.html
@@ -11,6 +11,11 @@
           <a href="{% url 'home' %}">{% translate "common.findcaselaw" %}</a>
         {% endif %}
       </li>
+      {% if context.back_link %}
+        <li>
+          <a href="{{ context.back_link }}">{% translate "breadcrumbs.search" %}</a>
+        </li>
+      {% endif %}
       {% if title and link %}<li>{{ title }}</li>{% endif %}
     </ol>
   </nav>

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -1,10 +1,5 @@
 {% load i18n %}
 <div class="judgment-toolbar">
-  {% if context.back_link %}
-    <div class="judgment-toolbar__return-link">
-      <a href="{{ context.back_link }}">{% translate "judgment.back" %}</a>
-    </div>
-  {% endif %}
   <div class="judgment-toolbar__container">
     <h1 class="judgment-toolbar__title">
       {{ context.judgment_title }}

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -13,7 +13,7 @@ from django.urls import reverse
 from django.views.generic import TemplateView
 from django_weasyprint import WeasyTemplateResponseMixin
 
-from judgments.utils import display_back_link, get_judgment_by_uri, get_pdf_uri
+from judgments.utils import get_judgment_by_uri, get_pdf_uri, search_context_from_url
 
 # suppress weasyprint log spam
 if os.environ.get("SHOW_WEASYPRINT_LOGS") != "True":
@@ -84,8 +84,6 @@ def detail(request, judgment_uri):
         else reverse("detail_pdf", args=[judgment.uri])
     )
 
-    context["back_link"] = get_back_link(request)
-
     return TemplateResponse(
         request,
         "judgment/detail.html",
@@ -93,6 +91,7 @@ def detail(request, judgment_uri):
             "context": context,
             "feedback_survey_type": "judgment",
             "feedback_survey_judgment_uri": judgment.uri,
+            "search_context": search_context_from_url(request.META.get("HTTP_REFERER")),
         },
     )
 
@@ -122,11 +121,3 @@ def get_pdf_size(judgment_uri):
         return f" ({filesize})"
     logging.warning(f"Unable to determine PDF size for {judgment_uri}")
     return " (unknown size)"
-
-
-def get_back_link(request):
-    back_link = request.META.get("HTTP_REFERER")
-    if display_back_link(back_link):
-        return back_link
-    else:
-        return None

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-07 16:21+0000\n"
+"POT-Creation-Date: 2023-06-12 14:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,6 +35,10 @@ msgstr "Filter by court, date or person"
 #: ds_judgements_public_ui/templates/pages/structured_search.html
 msgid "common.findcaselaw"
 msgstr "Find case law"
+
+#: ds_judgements_public_ui/templates/includes/breadcrumbs.html
+msgid "breadcrumbs.search"
+msgstr "Search"
 
 #: ds_judgements_public_ui/templates/includes/footer.html
 msgid "footer.websites"
@@ -153,10 +157,6 @@ msgstr "This judgment has been provided to The National Archives by "
 #: ds_judgements_public_ui/templates/includes/judgment_text_source.html
 msgid "judgment.bailii"
 msgstr "The British and Irish Legal Information Institute"
-
-#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
-msgid "judgment.back"
-msgstr "Back to search results"
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.downloadaspdf"


### PR DESCRIPTION
Where the `HTTP_REFERER` is a search link, extract the search context from it and display it in the breadcrumbs bar for a judgment.

This replaces the existing behaviour where a straightforward "back to search results" link is displayed in the judgment header.

## Screenshots

### Before

![localhost_3000_ewca_civ_2004_575 (1)](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/02b9bf35-59f5-47eb-9136-7da29f1c4193)

### After

![localhost_3000_ewca_civ_2004_575](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/ce495336-34b9-4f6a-8f4d-ca0cbf073437)
