### PR TITLE
Fix open redirect in resolving URIs with trailing slashes

### DIFF
--- a/config/tests.py
+++ b/config/tests.py
@@ -1,19 +1,6 @@
 from django.test import TestCase
 
 
-class TestRedirect(TestCase):
-    def test_slash_redirection_works(self):
-        url = "/arbitrary/url/with/slash/at/end/"
-        response = self.client.get(url)
-        assert response.status_code == 302
-        assert response.url == url.rstrip("/")
-
-    def test_no_infinite_loop(self):
-        url = "/2022/202"
-        response = self.client.get(url)
-        assert response.status_code == 404
-
-
 class TestCacheHeaders(TestCase):
     def test_static_headers(self):
         url = "/static/images/tna_logo.svg"

--- a/config/urls.py
+++ b/config/urls.py
@@ -2,22 +2,16 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.http import HttpResponseRedirect
-from django.urls import include, path, re_path
+from django.urls import include, path
 from django.views import defaults as default_views
 from django.views.generic.base import TemplateView
 
 from . import views
 
-
-def redirect(request, uri):
-    return HttpResponseRedirect(f"/{uri}")
-
-
 urlpatterns = [
     # Django Admin, use {% url 'admin:index' %}
     path(settings.ADMIN_URL, admin.site.urls),
     # Your stuff: custom urls includes go here
-    re_path("^(?P<uri>.*)/$", redirect),
     path(
         "transactional-licence-form",
         views.TransactionalLicenceFormView.as_view(),

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -51,7 +51,9 @@ urlpatterns = [
     re_path(
         r"^(?P<judgment_uri>.*/\d{4}/\d+.*)/data.xml$", detail_xml, name="detail_xml"
     ),
-    re_path(r"^(?P<judgment_uri>.*/\d{4}/\d+.*)/data.html$", detail, name="detail"),
+    re_path(
+        r"^(?P<judgment_uri>.*/\d{4}/\d+.*)/data.html$", detail, name="detail_html"
+    ),
     re_path(r"^(?P<judgment_uri>.*/\d{4}/\d+.*)/?$", detail, name="detail"),
     path("judgments/results", results, name="results"),
     path("judgments/advanced_search", advanced_search, name="advanced_search"),

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -5,7 +5,7 @@ import requests
 from caselawclient.errors import JudgmentNotFoundError
 from caselawclient.models.judgments import Judgment
 from django.conf import settings
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.template.defaultfilters import filesizeformat
 from django.template.response import TemplateResponse
@@ -69,6 +69,13 @@ def get_best_pdf(request, judgment_uri):
 
 def detail(request, judgment_uri):
     judgment = get_published_judgment_by_uri(judgment_uri)
+
+    # If the judgment_uri which was requested isn't the canonical URI of the judgment, redirect the user
+    if judgment_uri != judgment.uri:
+        return HttpResponseRedirect(
+            reverse("detail", kwargs={"judgment_uri": judgment.uri})
+        )
+
     context = {}
 
     context["judgment"] = judgment.content_as_html("")  # "" is most recent version


### PR DESCRIPTION
An open redirect was present on the site where you could use a URL starting with `nationalarchives.gov.uk` to redirect to arbitrary locations on the internet. This was due to a badly implemented redirect function which wasn't sense-checking the URL.

The fix was to remove this behaviour and instead rely on the presence of an optional trailing slash in the resolver for judgment URIs. This fixes the vulnerability, but has two side effects:

- Other URLs on the site which could previously be accessed with a trailing slash become inaccessible. This was judged to be low impact, as it affects a very small portion of resources on the site which wouldn't usually be linked to with a trailing slash.
- Two distinct resources are now presented for each judgment, one with a trailing slash and one without.

A resolution for the second one now checks the requested judgment URI (which may still resolve due to support for historical cases where URIs were presented with a trailing slash) against the canonical one, and redirects the user if they accessed the judgment with a non-canonical URI.