### PR TITLE
Show 'order by' field even when no query string is present

### DIFF
--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -15,21 +15,23 @@
         {% endif %}
       {% endif %}
     {% endfor %}
-    {% if context.query %}
-      <div>
-        <label for="order_by" class="result-controls__label">Order results by</label>
-        <select class="result-controls__select" id="order_by" name="order">
+    <div>
+      <label for="order_by" class="result-controls__label">Order results by</label>
+      <select class="result-controls__select" id="order_by" name="order">
+        {% if context.query %}
           <option value="relevance"
                   {% if context.order == "relevance" or context.order is None %}selected='selected'{% endif %}>
             Most relevant
           </option>
-          <option value="-date"
-                  {% if context.order == "-date" %}selected='selected'{% endif %}>Newest</option>
-          <option value="date"
-                  {% if context.order == "date" %}selected='selected'{% endif %}>Oldest</option>
-        </select>
-      </div>
-    {% endif %}
+        {% endif %}
+        <option value="-date"
+                {% if context.order == "-date" or context.order is None and not context.query %}selected='selected'{% endif %}>
+          Newest
+        </option>
+        <option value="date"
+                {% if context.order == "date" %}selected='selected'{% endif %}>Oldest</option>
+      </select>
+    </div>
     <div>
       <label for="per_page" class="result-controls__label">Results per page</label>
       <select class="result-controls__select" id="per_page" name="per_page">


### PR DESCRIPTION
## Changes in this PR:

Previously, we only showed the 'order by' dropdown when a query is present, as we only have a 'relevance' score when the query has performed a text match. However, this leads to two UX downsides when the query does not include a text string:

- No indication is given of how the results are ordered
- No option is available to switch between 'newest first' and 'oldest first' ordering

This corrects this - the 'relevance' option is only shown when a query string is provided, but the dropdown itself (with 'newest' and 'oldest' options) is always displayed.

## Trello card / Rollbar error (etc)
https://trello.com/c/grl2IS41/996-order-results-missing-on-some-search-pages