### PR TITLE
Ensure that courts are listed column-wise

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_browse_by_court.scss
+++ b/ds_judgements_public_ui/sass/includes/_browse_by_court.scss
@@ -17,19 +17,13 @@
     margin: 0 0 calc($spacer__unit * 3);
 
     @media (min-width: $grid__breakpoint-medium) {
-      display: grid;
-      grid-auto-columns: 1fr;
-      grid-template-columns: 1fr 1fr;
-      gap: 1rem;
+      column-count: 2;
+      column-gap: $spacer__unit;
     }
+  }
 
-    @media (min-width: $grid__breakpoint-large) {
-      grid-template-columns: 1fr 1fr;
-    }
-
-    @media (min-width: $grid__breakpoint-extra-large) {
-      grid-template-columns: 1fr 1fr;
-    }
+  &__list-item {
+    break-inside: avoid;
   }
 
   &__court {

--- a/ds_judgements_public_ui/sass/includes/_homepage_browse.scss
+++ b/ds_judgements_public_ui/sass/includes/_homepage_browse.scss
@@ -23,8 +23,7 @@
     padding: 0;
 
     @media (min-width: $grid__breakpoint-medium) {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
+      column-count: 2;
       column-gap: $spacer__unit;
     }
   }
@@ -33,6 +32,7 @@
     padding: calc($spacer__unit / 2) 0;
     font-family: $font__roboto;
     font-size: 1.1rem;
+    break-inside: avoid;
   }
 
   &__year-range {

--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -203,6 +203,11 @@
   &__court-options {
     display: block;
     width: 100%;
+
+    @media (min-width: $grid__breakpoint-medium) {
+      column-count: 2;
+      column-gap: calc(2 * $spacer__unit);
+    }
   }
 
   &__court-option {
@@ -249,21 +254,6 @@
 
         &:checked::before {
           transform: scale(1);
-        }
-      }
-    }
-
-    @media (min-width: $grid__breakpoint-medium) {
-      width: 50%;
-      float: left;
-
-      &:nth-of-type(odd) {
-        clear: left;
-      }
-
-      &:nth-of-type(2n) {
-        label {
-          margin-left: $spacer__unit;
         }
       }
     }


### PR DESCRIPTION
On both the homepage and the search form, for consistency.

## Changes in this PR:

This is the first part of https://trello.com/c/buVaFvjM/1001-ensure-courts-on-search-form-are-ordered-column-wise-and-consistent-was-part-of-969 - harmonising the court names (and tweaking the actual order if needed) to follow.

Tab focus follows the column layout!

## Trello card / Rollbar error (etc)
https://trello.com/c/buVaFvjM/1001-ensure-courts-on-search-form-are-ordered-column-wise-and-consistent-was-part-of-969


## Screenshots of UI changes:

### Before
<img width="1208" alt="Screenshot 2023-06-14 at 18 25 33" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/4c6ebd38-2166-4928-bb33-3bee91750dfb">
<img width="1208" alt="Screenshot 2023-06-14 at 18 25 24" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/33cf5e20-f534-43d7-8823-2187a8585a57">

### After
<img width="1208" alt="Screenshot 2023-06-14 at 18 22 34" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/4e48d065-3a4f-419b-9067-dbf8b74ce1b4">

<img width="1223" alt="Screenshot 2023-06-14 at 18 00 30" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/b5c87783-53a3-43d0-b196-637ab72a7a75">
