### PR TITLE
increased space between footer links to improve accessibility

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_footer.scss
+++ b/ds_judgements_public_ui/sass/includes/_footer.scss
@@ -52,10 +52,10 @@
 
   li {
     list-style: none;
-    margin-bottom: calc($spacer__unit / 4);
+    margin-bottom: calc($spacer__unit * 1.6);
 
     @media (min-width: $grid__breakpoint-medium) {
-      margin-bottom: calc($spacer__unit / 2);
+      margin-bottom: calc($spacer__unit * 1.4);
     }
   }
 

--- a/ds_judgements_public_ui/templates/includes/footer.html
+++ b/ds_judgements_public_ui/templates/includes/footer.html
@@ -50,10 +50,9 @@
       </div>
     </div>
     <p class="judgments-footer__base-paragraph">
-      All content is available under the
-      <a class="judgments-footer__link"
-         href="{% url "open_justice_licence" %}">Open Justice Licence</a>. For re-use that is not covered by the Open Justice Licence, please
-      <a href="{% url "transactional_licence_form" %}">apply for a transactional licence</a>.
+      All content is available under the <a class="judgments-footer__link"
+    href="{% url "open_justice_licence" %}">Open Justice Licence</a>.
+      For re-use that is not covered by the Open Justice Licence, please <a href="{% url "transactional_licence_form" %}">apply for a transactional licence</a>.
     </p>
   </div>
 </footer>


### PR DESCRIPTION
<!-- Amend as appropriate -->
## Changes in this PR:

- Desktop: Increased the vertical spacing of the footer links to make the target area for each one easier to select with those with motor health related conditions.
- Mobile: was also increased by a slightly bigger percentage.

## Trello card / Rollbar error (etc)
https://trello.com/c/XH2MpASl/1003-%E2%9C%94%EF%B8%8F-aa-footer-target-area-of-footer-links-is-too-small

## Screenshots of UI changes:

### Before
![Screenshot 2023-06-15 at 11 35 51](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/d28faf5c-07b6-4e0c-9e6a-baf5ec597ae2)
![Screenshot 2023-06-15 at 11 35 35](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/4efa5f84-e193-4f5c-9951-8152df5d7308)

### After
![Screenshot 2023-06-15 at 10 50 26](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/06e6bc3e-f970-4df9-a659-feb308de20bb)
![Screenshot 2023-06-15 at 11 35 26](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/b1c26a5d-929d-40ee-bede-da9d3cd333ab)

- [ ] Requires env variable(s) to be updated
