### PR TITLE
fixed ordered list padding bottom issue and added more space between …

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_typography.scss
+++ b/ds_judgements_public_ui/sass/includes/_typography.scss
@@ -59,3 +59,8 @@ h4 {
   margin: 0;
   padding: calc($spacer__unit * 1.25) 0 0;
 }
+
+.standard-text-template ol li {
+  padding-bottom: calc($spacer__unit / 1.5);
+  padding-left: calc($spacer__unit / 2);
+}

--- a/ds_judgements_public_ui/templates/pages/publishing_policy.html
+++ b/ds_judgements_public_ui/templates/pages/publishing_policy.html
@@ -97,7 +97,6 @@
       <li>
         The Court that decided the case is the Data Controller for the publication of
         judgments on the Find Case Law service. The National Archives is a Data Processor.
-        <br>
         The National Archives cannot and will not takedown a published judgment without
         explicit instruction from the court. Revisions to judgments already published must also
         come directly from the court. To contact a specific court or tribunal please see:


### PR DESCRIPTION
…mark and text

<!-- Amend as appropriate -->

- Fixing the styling of ordered lists on the content pages that were failing as there were `<br>` used to create space. Took those out and...
- improved the `<ol> `legibility by adding padding on the `<li>` and adding more space between the ::mark and the text so it was more legible when the number goes to two digits.

## Changes in this PR:

## Trello card / Rollbar error (etc)
https://trello.com/c/6jeR5Qge/1012-%E2%9C%94%EF%B8%8F-aa-about-and-publishing-policy-pages-lists-should-only-contain-lis-take-out-brs
## Screenshots of UI changes:

### Before
![Screenshot 2023-06-16 at 11 25 21](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/6924cc1b-8ea7-42da-8983-fc228e09071f)


### After
![Screenshot 2023-06-16 at 11 25 11](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/55002c99-83f4-4fe3-80a8-11639f9e0f3b)


- [ ] Requires env variable(s) to be updated
