### PR TITLE
Tweak width of new date inputs on mobile

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -286,12 +286,21 @@
     gap: calc(0.5 * $spacer__unit);
     & :nth-of-type(1) {
       width: 10%;
+      @media (max-width: $grid__breakpoint-small) {
+        width: 20%;
+      }
     }
     & :nth-of-type(2) {
       width: 10%;
+      @media (max-width: $grid__breakpoint-small) {
+        width: 20%;
+      }
     }
     & :nth-of-type(3) {
       width: 20%;
+      @media (max-width: $grid__breakpoint-small) {
+        width: 40%;
+      }
     }
   }
 


### PR DESCRIPTION

## Changes in this PR:

They were a bit squashed. Now they're not.


## Screenshots of UI changes:

### Before
<img width="420" alt="Screenshot 2023-06-20 at 14 43 51" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/0683c91c-0ba5-4004-b08d-4d24bbae4b1b">

### After
<img width="420" alt="Screenshot 2023-06-20 at 14 43 28" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/0c6b45e5-a506-480a-86ec-8ccfb4dba8dc">
