### PR TITLE
Remove TEXT_DATE_INPUT feature flag

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -51,7 +51,7 @@ DATABASES["default"]["ATOMIC_REQUESTS"] = True
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Feature flags for django-flags
-FLAGS: Dict[str, Any] = {"TEXT_DATE_INPUT": []}
+FLAGS: Dict[str, Any] = {}
 
 # URLS
 # ------------------------------------------------------------------------------

--- a/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
@@ -1,5 +1,4 @@
 {% load court_utils feature_flags errors %}
-{% flag_enabled 'TEXT_DATE_INPUT' as text_date_input %}
 <div class="structured-search__single-field-panel">
   <div class="structured-search__limit-to-container">
     <fieldset>
@@ -17,43 +16,32 @@
         <p class="structured-search__from-date-error-message"
            id="from-date-error">{{ context.errors|errors_for_field:"from_date" }}</p>
       {% endif %}
-      {% if text_date_input %}
-        <input type="hidden" name="text_date_input" value="True" />
-        <div class="structured-search__date-input-group js-date-input">
-          <div>
-            <label for="from_day" class="structured-search__help-text">Day</label>
-            <input class="structured-search__date-input date-input--error"
-                   id="from_day"
-                   name="from_day"
-                   type="number"
-                   value="{{ context.from_day }}" />
-          </div>
-          <div>
-            <label for="from_month" class="structured-search__help-text">Month</label>
-            <input class="structured-search__date-input date-input--error"
-                   id="from_month"
-                   name="from_month"
-                   type="number"
-                   value="{{ context.from_month }}" />
-          </div>
-          <div>
-            <label for="from_year" class="structured-search__help-text">Year</label>
-            <input class="structured-search__date-input date-input--error"
-                   id="from_year"
-                   name="from_year"
-                   type="number"
-                   value="{{ context.from_year }}" />
-          </div>
+      <div class="structured-search__date-input-group js-date-input">
+        <div>
+          <label for="from_day" class="structured-search__help-text">Day</label>
+          <input class="structured-search__date-input date-input--error"
+                 id="from_day"
+                 name="from_day"
+                 type="number"
+                 value="{{ context.from_day }}" />
         </div>
-      {% else %}
-        <input class="structured-search__date-input "
-               id="from_date"
-               name="from"
-               placeholder="DD-MM-YYYY"
-               type="date"
-               value="{{ context.from }}"
-               aria-labelledby="from_date_label" />
-      {% endif %}
+        <div>
+          <label for="from_month" class="structured-search__help-text">Month</label>
+          <input class="structured-search__date-input date-input--error"
+                 id="from_month"
+                 name="from_month"
+                 type="number"
+                 value="{{ context.from_month }}" />
+        </div>
+        <div>
+          <label for="from_year" class="structured-search__help-text">Year</label>
+          <input class="structured-search__date-input date-input--error"
+                 id="from_year"
+                 name="from_year"
+                 type="number"
+                 value="{{ context.from_year }}" />
+        </div>
+      </div>
     </fieldset>
   </div>
   <div class="structured-search__limit-to-container">
@@ -65,42 +53,32 @@
           {{ context.errors|errors_for_field:"to_date" }}
         </p>
       {% endif %}
-      {% if text_date_input %}
-        <div class="structured-search__date-input-group js-date-input">
-          <div>
-            <label for="to_day" class="structured-search__help-text">Day</label>
-            <input class="structured-search__date-input date-input--error"
-                   id="to_day"
-                   name="to_day"
-                   type="number"
-                   value="{{ context.to_day }}" />
-          </div>
-          <div>
-            <label for="to_month" class="structured-search__help-text">Month</label>
-            <input class="structured-search__date-input date-input--error"
-                   id="to_month"
-                   name="to_month"
-                   type="number"
-                   value="{{ context.to_month }}" />
-          </div>
-          <div>
-            <label for="to_year" class="structured-search__help-text">Year</label>
-            <input class="structured-search__date-input date-input--error"
-                   id="to_year"
-                   name="to_year"
-                   type="number"
-                   value="{{ context.to_year }}" />
-          </div>
+      <div class="structured-search__date-input-group js-date-input">
+        <div>
+          <label for="to_day" class="structured-search__help-text">Day</label>
+          <input class="structured-search__date-input date-input--error"
+                 id="to_day"
+                 name="to_day"
+                 type="number"
+                 value="{{ context.to_day }}" />
         </div>
-      {% else %}
-        <input class="structured-search__date-input"
-               id="to_date"
-               name="to"
-               placeholder="DD-MM-YYYY"
-               type="date"
-               value="{{ context.to }}"
-               aria-labelledby="to_date_label" />
-      {% endif %}
+        <div>
+          <label for="to_month" class="structured-search__help-text">Month</label>
+          <input class="structured-search__date-input date-input--error"
+                 id="to_month"
+                 name="to_month"
+                 type="number"
+                 value="{{ context.to_month }}" />
+        </div>
+        <div>
+          <label for="to_year" class="structured-search__help-text">Year</label>
+          <input class="structured-search__date-input date-input--error"
+                 id="to_year"
+                 name="to_year"
+                 type="number"
+                 value="{{ context.to_year }}" />
+        </div>
+      </div>
     </fieldset>
   </div>
 </div>

--- a/judgments/templatetags/query_filters.py
+++ b/judgments/templatetags/query_filters.py
@@ -32,7 +32,6 @@ def removable_filter_param(key):
         "to_day",
         "to_month",
         "to_year",
-        "text_date_input",
     ]
     return key not in excluded
 

--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -134,7 +134,7 @@ class TestSearchResults(TestCase):
                  tabindex="0"
                  draggable="false"
                  class="results-search-component__removable-options-link"
-                 href="/judgments/advanced_search?query=&amp;court=ewhc/ipec&amp;judge=&amp;party=&amp;neutral_citation=&amp;specific_keyword=&amp;order=&amp;from=&amp;from_day=&amp;from_month=&amp;from_year=&amp;to=&amp;to_day=&amp;to_month=&amp;to_year=&amp;per_page=&amp;text_date_input=&amp;page="
+                 href="/judgments/advanced_search?query=&amp;court=ewhc/ipec&amp;judge=&amp;party=&amp;neutral_citation=&amp;specific_keyword=&amp;order=&amp;from=&amp;from_day=&amp;from_month=&amp;from_year=&amp;to=&amp;to_day=&amp;to_month=&amp;to_year=&amp;per_page=&amp;page="
                  title="Chancery Division of the High Court">
                 <span class="results-search-component__removable-options-value">
                   <span class="results-search-component__removable-options-value-text">
@@ -149,7 +149,7 @@ class TestSearchResults(TestCase):
                  tabindex="0"
                  draggable="false"
                  class="results-search-component__removable-options-link"
-                 href="/judgments/advanced_search?query=&amp;court=ewhc/ch&amp;judge=&amp;party=&amp;neutral_citation=&amp;specific_keyword=&amp;order=&amp;from=&amp;from_day=&amp;from_month=&amp;from_year=&amp;to=&amp;to_day=&amp;to_month=&amp;to_year=&amp;per_page=&amp;text_date_input=&amp;page="
+                 href="/judgments/advanced_search?query=&amp;court=ewhc/ch&amp;judge=&amp;party=&amp;neutral_citation=&amp;specific_keyword=&amp;order=&amp;from=&amp;from_day=&amp;from_month=&amp;from_year=&amp;to=&amp;to_day=&amp;to_month=&amp;to_year=&amp;per_page=&amp;page="
                  title="Intellectual Property Enterprise Court">
                 <span class="results-search-component__removable-options-value">
                   <span class="results-search-component__removable-options-value-text">

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -63,7 +63,6 @@ def advanced_search(request):
         "to_month": params.get("to_month"),
         "to_year": params.get("to_year"),
         "per_page": params.get("per_page"),
-        "text_date_input": params.get("text_date_input"),
     }
     page = str(as_integer(params.get("page"), minimum=1))
     per_page = str(


### PR DESCRIPTION
## Changes in this PR:
- Removed `TEXT_DATE_INPUT` Feature Flag and all code blocks which were entered when `TEXT_DATE_INPUT` was False.

## Trello card / Rollbar error (etc)
https://trello.com/c/0BhK4DLa/1009-pui-remove-date-picker-feature-flag-staging-and-prod-tim-has-done-mobile-tweaks

## Screenshots of UI changes:

### Before
![Screenshot 2023-06-26 at 09 35 13](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/9f3bb193-bd2c-411f-9fcf-16f1fdec0a3f)


### After
![Screenshot 2023-06-26 at 09 34 43](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/f2176246-62be-402a-961f-931abcccb076)