### PR TITLE
Use balanced line lengths in judgment titles

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -42,7 +42,18 @@
   }
 
   &__title {
-    margin: 1rem 0;
+    text-wrap: balance;
+    margin-top: $spacer__unit;
+    margin-bottom: 0;
+    color: $color__almost-black;
+    text-align: center;
+  }
+
+  &__reference {
+    text-wrap: balance;
+    margin-top: 0.5 * $spacer__unit;
+    margin-bottom: $spacer__unit;
+    font-size: 2rem;
     color: $color__almost-black;
     text-align: center;
   }

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -1,11 +1,8 @@
 {% load i18n %}
 <div class="judgment-toolbar">
   <div class="judgment-toolbar__container">
-    <h1 class="judgment-toolbar__title">
-      {{ context.judgment_title }}
-      <br>
-      <small>{{ context.judgment_ncn }}</small>
-    </h1>
+    <h1 class="judgment-toolbar__title">{{ context.judgment_title }}</h1>
+    <p class="judgment-toolbar__reference">{{ context.judgment_ncn }}</p>
     <div class="judgment-toolbar__download judgment-toolbar-download">
       <a class="judgment-toolbar-download__option--pdf btn"
          role="button"


### PR DESCRIPTION
## Changes in this PR:

Use `text-wrap: balance` in judgment headers [where supported](https://github.com/nationalarchives/ds-caselaw-public-ui/pull/new/feature/balance-judgment-titles) to produce visually balanced headings.

In browsers where `balance` isn't supported, behaviour is the same as previously.

## Screenshots of UI changes:

### Before

![localhost_3000_ewca_civ_2023_701 (1)](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/ecc65adb-bd7b-48c9-84d7-dc5bdc9c94ee)

### After

![localhost_3000_ewca_civ_2023_701](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/619082/3513aa03-e830-4b22-83ff-c8e8d6f7a0ed)