### PR TITLE
Add press summary button in judgment view and vice versa

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -37,7 +37,7 @@
       margin-bottom: calc($spacer__unit / 3) !important;
     }
 
-    &.btn-ps {
+    &.btn-related-document {
       background-color: transparent;
       text-decoration: none;
       font-weight: 700;
@@ -95,10 +95,10 @@
   }
 }
 
-.judgment-toolbar-download {
+.judgment-toolbar-buttons {
   margin: 0 auto;
 
-  &__option--ps {
+  &__option--related-document {
     text-align: center;
   }
 
@@ -106,7 +106,7 @@
     text-align: center;
   }
 
-  &__download-options {
+  &__options {
     color: $color__dark-grey;
     font-size: 0.75rem;
     text-align: center;

--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -33,7 +33,33 @@
 
     &.btn {
       @include call-to-action-button;
+      margin-right: 1rem;
       margin-bottom: calc($spacer__unit / 3) !important;
+    }
+
+    &.btn-ps {
+      background-color: transparent;
+      text-decoration: none;
+      font-weight: 700;
+      border: 0;
+      outline: 2px solid $color__cta-background !important;
+      color: $color__cta-background !important;
+      padding: 0.7rem 1.3rem;
+      display: inline-block;
+      margin-top: 1em;
+      font-size: 1rem;
+      margin-bottom: calc($spacer__unit / 3) !important;
+      margin-right: calc($spacer__unit / 1) !important;
+    }
+    &:focus,
+    &:hover {
+      @include focus-default;
+      color: $color__white !important;
+      background-color: $color__cta-background-hover;
+      outline-color: $color__cta-background-hover;
+      border-color: $color__cta-background-hover;
+      text-decoration: underline;
+      outline-offset: 0.2rem;
     }
 
     @media (min-width: $grid__breakpoint-small) {
@@ -71,6 +97,10 @@
 
 .judgment-toolbar-download {
   margin: 0 auto;
+
+  &__option--ps {
+    text-align: center;
+  }
 
   &__option--pdf {
     text-align: center;

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -7,6 +7,19 @@
     <h1 class="judgment-toolbar__title">{{ context.judgment_title }}</h1>
     <p class="judgment-toolbar__reference">{{ context.judgment_ncn }}</p>
     <div class="judgment-toolbar__download judgment-toolbar-download">
+      {% if context.linked_document_uri %}
+        <a class="judgment-toolbar-download__option--ps btn-ps"
+           role="button"
+           draggable="false"
+           href="{% url 'detail' judgment_uri=context.linked_document_uri %}">
+          {% if context.document_type == "judgment" %}
+            {% translate "judgment.view_press_summary" %}
+          {% else %}
+            {% translate "judgment.view_judgment" %}
+          {% endif %}
+          <span style="font-weight:normal;font-size:0.9rem"></span>
+        </a>
+      {% endif %}
       <a class="judgment-toolbar-download__option--pdf btn"
          role="button"
          draggable="false"

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -6,9 +6,9 @@
     {% endif %}
     <h1 class="judgment-toolbar__title">{{ context.judgment_title }}</h1>
     <p class="judgment-toolbar__reference">{{ context.judgment_ncn }}</p>
-    <div class="judgment-toolbar__download judgment-toolbar-download">
+    <div class="judgment-toolbar__buttons judgment-toolbar-buttons">
       {% if context.linked_document_uri %}
-        <a class="judgment-toolbar-download__option--ps btn-ps"
+        <a class="judgment-toolbar-buttons__option--related-document btn-related-document"
            role="button"
            draggable="false"
            href="{% url 'detail' judgment_uri=context.linked_document_uri %}">
@@ -20,11 +20,11 @@
           <span style="font-weight:normal;font-size:0.9rem"></span>
         </a>
       {% endif %}
-      <a class="judgment-toolbar-download__option--pdf btn"
+      <a class="judgment-toolbar-buttons__option--pdf btn"
          role="button"
          draggable="false"
          href="{{ context.pdf_uri }}">{% translate "judgment.downloadaspdf" %}<span style="font-weight:normal;font-size:0.9rem">{{ context.pdf_size }}</span></a>
-      <p class="judgment-toolbar-download__download-options" role="note">
+      <p class="judgment-toolbar-buttons__download-options" role="note">
         <a href="#download-options">{% translate "judgment.downloadoptions.shortcutlink" %}</a>
       </p>
     </div>

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -292,7 +292,10 @@ class TestViewRelatedDocumentButton(TestCase):
         mock_get_judgment_by_uri.side_effect = get_judgment_by_uri_side_effect
 
         expected_html_button = """
-        <a class="judgment-toolbar-download__option--ps btn-ps" role="button" draggable="false" href="/eat/2023/1">
+        <a class="judgment-toolbar-buttons__option--related-document btn-related-document"
+            role="button" draggable="false"
+            href="/eat/2023/1"
+        >
             View Judgment
             <span style="font-weight:normal;font-size:0.9rem"></span>
         </a>
@@ -324,7 +327,10 @@ class TestViewRelatedDocumentButton(TestCase):
         mock_get_judgment_by_uri.side_effect = get_judgment_by_uri_side_effect
 
         expected_html_button = """
-        <a class="judgment-toolbar-download__option--ps btn-ps" role="button" draggable="false" href="/eat/2023/1/press-summary/1">
+        <a class="judgment-toolbar-buttons__option--related-document btn-related-document"
+            role="button" draggable="false"
+            href="/eat/2023/1/press-summary/1"
+        >
             View Press Summary
             <span style="font-weight:normal;font-size:0.9rem"></span>
         </a>
@@ -354,7 +360,10 @@ class TestViewRelatedDocumentButton(TestCase):
         mock_get_judgment_by_uri.side_effect = get_judgment_by_uri_side_effect
 
         expected_html_button = """
-        <a class="judgment-toolbar-download__option--ps btn-ps" role="button" draggable="false" href="/eat/2023/1">
+        <a class="judgment-toolbar-buttons__option--related-document btn-related-document"
+            role="button" draggable="false"
+            href="/eat/2023/1"
+        >
             View Judgment
             <span style="font-weight:normal;font-size:0.9rem"></span>
         </a>
@@ -384,7 +393,10 @@ class TestViewRelatedDocumentButton(TestCase):
         mock_get_judgment_by_uri.side_effect = get_judgment_by_uri_side_effect
 
         expected_html_button = """
-        <a class="judgment-toolbar-download__option--ps btn-ps" role="button" draggable="false" href="/eat/2023/1/press-summary/1">
+        <a class="judgment-toolbar-buttons__option--related-document btn-related-document"
+            role="button" draggable="false"
+            href="/eat/2023/1/press-summary/1"
+        >
             View Press Summary
             <span style="font-weight:normal;font-size:0.9rem"></span>
         </a>

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -7,6 +7,10 @@ from django.http import Http404, HttpResponseRedirect
 from django.test import Client, TestCase
 from factories import JudgmentFactory
 
+from judgments.tests.utils.assertions import (
+    assert_contains_html,
+    assert_not_contains_html,
+)
 from judgments.views.detail import (
     PdfDetailView,
     get_pdf_size,
@@ -173,9 +177,7 @@ class TestDocumentDownloadOptions:
         </div>
         </div>
         """
-        assert download_options_html.replace(" ", "").replace(
-            "\n", ""
-        ) in response.content.decode().replace(" ", "").replace("\n", "")
+        assert_contains_html(response, download_options_html)
 
 
 class TestGetPdfSize(TestCase):
@@ -359,15 +361,3 @@ class TestViewRelatedDocumentButton:
         client = Client()
         response = client.get(f"/{uri}")
         assert_not_contains_html(response, unexpected_html_button)
-
-
-def assert_contains_html(response, html):
-    assert html.replace(" ", "").replace("\n", "") in response.content.decode().replace(
-        " ", ""
-    ).replace("\n", "")
-
-
-def assert_not_contains_html(response, html):
-    assert html.replace(" ", "").replace(
-        "\n", ""
-    ) not in response.content.decode().replace(" ", "").replace("\n", "")

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -242,7 +242,6 @@ class TestPressSummaryLabel(TestCase):
             uri="eat/2023/1/press-summary/1", is_published=True
         )
         response = self.client.get("/eat/2023/1/press-summary/1")
-        mock_judgment.assert_called_with("eat/2023/1/press-summary/1")
         self.assertContains(
             response,
             '<p class="judgment-toolbar__press-summary-title">Press Summary</p>',
@@ -262,7 +261,6 @@ class TestPressSummaryLabel(TestCase):
             uri="eat/2023/1", is_published=True
         )
         response = self.client.get("/eat/2023/1")
-        mock_judgment.assert_called_with("eat/2023/1")
         self.assertNotContains(
             response,
             '<p class="judgment-toolbar__press-summary-title">Press Summary</p>',

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -267,3 +267,129 @@ class TestPressSummaryLabel(TestCase):
             response,
             '<p class="judgment-toolbar__press-summary-title">Press Summary</p>',
         )
+
+
+class TestViewRelatedDocumentButton(TestCase):
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_view_judgment_button_when_press_summary_with_judgment(
+        self, mock_get_judgment_by_uri, mock_get_pdf_size
+    ):
+        """
+        GIVEN a press summary with an associated judgment
+        WHEN a request is made to the press summary URI
+        THEN the response should contain a button linking to the related judgment
+        """
+
+        def get_judgment_by_uri_side_effect(uri):
+            if uri == "eat/2023/1/press-summary/1":
+                return JudgmentFactory.build(uri=uri, is_published=True)
+            elif uri == "eat/2023/1":
+                return JudgmentFactory.build(uri=uri, is_published=True)
+            else:
+                raise JudgmentNotFoundError()
+
+        mock_get_judgment_by_uri.side_effect = get_judgment_by_uri_side_effect
+
+        expected_html_button = """
+        <a class="judgment-toolbar-download__option--ps btn-ps" role="button" draggable="false" href="/eat/2023/1">
+            View Judgment
+            <span style="font-weight:normal;font-size:0.9rem"></span>
+        </a>
+        """
+        response = self.client.get("/eat/2023/1/press-summary/1")
+        assert expected_html_button.replace(" ", "").replace(
+            "\n", ""
+        ) in response.content.decode().replace(" ", "").replace("\n", "")
+
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_view_press_summary_button_when_judgment_with_press_summary(
+        self, mock_get_judgment_by_uri, mock_get_pdf_size
+    ):
+        """
+        GIVEN a judgment with an associated press summary
+        WHEN a request is made to the judgment URI
+        THEN the response should contain a button linking to the related press summary
+        """
+
+        def get_judgment_by_uri_side_effect(uri):
+            if uri == "eat/2023/1/press-summary/1":
+                return JudgmentFactory.build(uri=uri, is_published=True)
+            elif uri == "eat/2023/1":
+                return JudgmentFactory.build(uri=uri, is_published=True)
+            else:
+                raise JudgmentNotFoundError()
+
+        mock_get_judgment_by_uri.side_effect = get_judgment_by_uri_side_effect
+
+        expected_html_button = """
+        <a class="judgment-toolbar-download__option--ps btn-ps" role="button" draggable="false" href="/eat/2023/1/press-summary/1">
+            View Press Summary
+            <span style="font-weight:normal;font-size:0.9rem"></span>
+        </a>
+        """
+        response = self.client.get("/eat/2023/1")
+        assert expected_html_button.replace(" ", "").replace(
+            "\n", ""
+        ) in response.content.decode().replace(" ", "").replace("\n", "")
+
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_no_view_judgment_button_when_press_summary_without_judgment(
+        self, mock_get_judgment_by_uri, mock_get_pdf_size
+    ):
+        """
+        GIVEN a press summary without an associated judgment
+        WHEN a request is made to the press summary URI
+        THEN the response should not contain a button linking to the related judgment
+        """
+
+        def get_judgment_by_uri_side_effect(uri):
+            if uri == "eat/2023/1/press-summary/1":
+                return JudgmentFactory.build(uri=uri, is_published=True)
+            else:
+                raise JudgmentNotFoundError()
+
+        mock_get_judgment_by_uri.side_effect = get_judgment_by_uri_side_effect
+
+        expected_html_button = """
+        <a class="judgment-toolbar-download__option--ps btn-ps" role="button" draggable="false" href="/eat/2023/1">
+            View Judgment
+            <span style="font-weight:normal;font-size:0.9rem"></span>
+        </a>
+        """
+        response = self.client.get("/eat/2023/1/press-summary/1")
+        assert expected_html_button.replace(" ", "").replace(
+            "\n", ""
+        ) not in response.content.decode().replace(" ", "").replace("\n", "")
+
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_no_view_press_summary_button_when_judgment_without_press_summary(
+        self, mock_get_judgment_by_uri, mock_get_pdf_size
+    ):
+        """
+        GIVEN a judgment without an associated press summary
+        WHEN a request is made to the judgment URI
+        THEN the response should not contain a button linking to the related press summary
+        """
+
+        def get_judgment_by_uri_side_effect(uri):
+            if uri == "eat/2023/1":
+                return JudgmentFactory.build(uri=uri, is_published=True)
+            else:
+                raise JudgmentNotFoundError()
+
+        mock_get_judgment_by_uri.side_effect = get_judgment_by_uri_side_effect
+
+        expected_html_button = """
+        <a class="judgment-toolbar-download__option--ps btn-ps" role="button" draggable="false" href="/eat/2023/1/press-summary/1">
+            View Press Summary
+            <span style="font-weight:normal;font-size:0.9rem"></span>
+        </a>
+        """
+        response = self.client.get("/eat/2023/1")
+        assert expected_html_button.replace(" ", "").replace(
+            "\n", ""
+        ) not in response.content.decode().replace(" ", "").replace("\n", "")

--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from django.utils.translation import gettext
 
 from judgments.tests.fixtures import FakeSearchResponse
+from judgments.tests.utils.assertions import assert_contains_html
 
 
 class TestBrowseResults(TestCase):
@@ -164,9 +165,7 @@ class TestSearchResults(TestCase):
             mock_api_client,
             SearchParameters(query="", court="ewhc/ch,ewhc/ipec", order="-date"),
         )
-        assert expected_applied_filters_html.replace(" ", "").replace(
-            "\n", ""
-        ) in response.content.decode().replace(" ", "").replace("\n", "")
+        assert_contains_html(response, expected_applied_filters_html)
 
     @patch("judgments.views.results.api_client")
     @patch("judgments.views.results.search_judgments_and_parse_response")

--- a/judgments/tests/utils/assertions.py
+++ b/judgments/tests/utils/assertions.py
@@ -1,0 +1,27 @@
+"""
+Custom assertion helpers for tests.
+"""
+
+
+def assert_contains_html(response, html):
+    """
+    Asserts that the given HTML is contained within the response content.
+
+    Raises:
+        AssertionError: If the HTML is not found in the response content.
+    """
+    assert html.replace(" ", "").replace("\n", "") in response.content.decode().replace(
+        " ", ""
+    ).replace("\n", "")
+
+
+def assert_not_contains_html(response, html):
+    """
+    Asserts that the given HTML is not contained within the response content.
+
+    Raises:
+        AssertionError: If the HTML is found in the response content.
+    """
+    assert html.replace(" ", "").replace(
+        "\n", ""
+    ) not in response.content.decode().replace(" ", "").replace("\n", "")

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -78,10 +78,18 @@ def detail(request, judgment_uri):
 
     context = {}
 
-    if "press-summary" in judgment_uri:
+    press_summary_suffix = "/press-summary/1"
+    if judgment_uri.endswith(press_summary_suffix):
         context["document_type"] = "press_summary"
+        context["linked_document_uri"] = judgment_uri.removesuffix(press_summary_suffix)
     else:
         context["document_type"] = "judgment"
+        context["linked_document_uri"] = judgment_uri + press_summary_suffix
+
+    try:
+        get_published_judgment_by_uri(context["linked_document_uri"])
+    except Http404:
+        context["linked_document_uri"] = ""
 
     context["judgment"] = judgment.content_as_html("")  # "" is most recent version
     context["page_title"] = judgment.name

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -326,6 +326,14 @@ msgstr "The 'to' date entered is before the 'from' date"
 msgid "search.errors.missing_year_detail"
 msgstr "You must specify a year"
 
+#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+msgid "judgment.view_press_summary"
+msgstr "View Press Summary"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+msgid "judgment.view_judgment"
+msgstr "View Judgment"
+
 #: judgments/views/advanced_search.py
 msgid "search.errors.to_before_from_detail"
 msgstr "Please enter a date after the 'from' date"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Added "View Press Summary" and "View Judgment" Buttons as designed here:
https://14z0gp.axshare.com/?id=qizmwu&p=judgment&g=1

Also generalised some css class names to make sense now that they contain / are utilised for more than before.

## Trello card / Rollbar error (etc)
https://trello.com/c/Q2lNPibf/1044-pui-add-to-judgment-view-press-summary-button-and-box-in-download-options
## Screenshots of UI changes:

### Before
![before-add-ps](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/a4bcf477-7869-4149-8d90-055d4a162eb7)

### After
[add-press-summary-to-judgment-toolbar.webm](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/3f937f8b-d427-44f8-8031-49e81cd55ec9)

