### PR TITLE
Add orange press summary label

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -41,6 +41,16 @@
     }
   }
 
+  &__press-summary-title {
+    text-wrap: balance;
+    margin-top: -1 * $spacer__unit;
+    margin-bottom: 0;
+    background-color: $color__yellow;
+    color: $color__almost-black;
+    padding: calc($spacer__unit / 3) calc($spacer__unit / 2);
+    text-align: center;
+  }
+
   &__title {
     text-wrap: balance;
     margin-top: $spacer__unit;

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -1,6 +1,9 @@
 {% load i18n %}
 <div class="judgment-toolbar">
   <div class="judgment-toolbar__container">
+    {% if context.document_type == "press_summary" %}
+      <p class="judgment-toolbar__press-summary-title">Press Summary</p>
+    {% endif %}
     <h1 class="judgment-toolbar__title">{{ context.judgment_title }}</h1>
     <p class="judgment-toolbar__reference">{{ context.judgment_ncn }}</p>
     <div class="judgment-toolbar__download judgment-toolbar-download">

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -226,3 +226,42 @@ class TestDocumentURIRedirects(TestCase):
         assert isinstance(response, HttpResponseRedirect)
         assert response.status_code == 302
         assert response.url == "/test/1234/567"
+
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_label_when_press_summary(self, mock_judgment, mock_get_pdf_size):
+        """
+        GIVEN press summary
+        WHEN request is made with press summary uri
+        THEN response should contain the press summary label
+        """
+
+        mock_judgment.return_value = JudgmentFactory.build(
+            uri="eat/2023/1/press-summary/1", is_published=True
+        )
+        response = self.client.get("/eat/2023/1/press-summary/1")
+        mock_judgment.assert_called_with("eat/2023/1/press-summary/1")
+        self.assertContains(
+            response,
+            '<p class="judgment-toolbar__press-summary-title">Press Summary</p>',
+        )
+
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_no_press_summary_label_when_on_judgment(
+        self, mock_judgment, mock_get_pdf_size
+    ):
+        """
+        GIVEN judgment
+        WHEN request is made with judgment uri
+        THEN response should NOT contain the press summary label
+        """
+        mock_judgment.return_value = JudgmentFactory.build(
+            uri="eat/2023/1", is_published=True
+        )
+        response = self.client.get("/eat/2023/1")
+        mock_judgment.assert_called_with("eat/2023/1")
+        self.assertNotContains(
+            response,
+            '<p class="judgment-toolbar__press-summary-title">Press Summary</p>',
+        )

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -227,6 +227,8 @@ class TestDocumentURIRedirects(TestCase):
         assert response.status_code == 302
         assert response.url == "/test/1234/567"
 
+
+class TestPressSummaryLabel(TestCase):
     @patch("judgments.views.detail.get_pdf_size")
     @patch("judgments.views.detail.get_judgment_by_uri")
     def test_label_when_press_summary(self, mock_judgment, mock_get_pdf_size):


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Orange label for press summary added ONLY For the press summary view 
## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before
![before-label](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/942fa853-cfc5-4ae4-aae0-b863e6da5cd2)


### After
![after-label](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/e812720b-4ee2-4f49-98d0-e0b01f75ed1b)

- [ ] Requires env variable(s) to be updated
