### PR TITLE
Refer to press summary when viewing press summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: docker-compose run --rm django python manage.py migrate --settings=config.settings.test
 
       - name: Run Django Tests with coverage
-        run: docker-compose run django coverage run -m pytest -m "not local"
+        run: docker-compose run django coverage run -m pytest -vvvv -rsa -m "not local"
 
       - name: Generate coverage XML
         run: docker-compose run django coverage xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Run DB Migrations
         run: docker-compose run --rm django python manage.py migrate --settings=config.settings.test
 
+      - name: Run Django Translation Compiling
+        run: docker-compose run --rm django python manage.py compilemessages
+
       - name: Run Django Tests with coverage
         run: docker-compose run django coverage run -m pytest -vvvv -rsa -m "not local"
 

--- a/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
@@ -4,15 +4,40 @@
   <div class="judgment-download-options__options-list">
     <div class="judgment-download-options__download-option">
       <h3>
-        <a href="{{ context.pdf_uri }}">{% translate "judgment.downloadoptions.pdf.cta" %}{{ context.pdf_size }}</a>
+        <a href="{{ context.pdf_uri }}">
+          {% if context.document_type == 'press_summary' %}
+            {% translate "press_summary.downloadoptions.pdf.cta" %}
+          {% else %}
+            {% translate "judgment.downloadoptions.pdf.cta" %}
+          {% endif %}
+          {{ context.pdf_size }}
+        </a>
       </h3>
-      <p>{% translate "judgment.downloadoptions.pdf.description" %}</p>
+      <p>
+        {% if context.document_type == 'press_summary' %}
+          {% translate "press_summary.downloadoptions.pdf.description" %}
+        {% else %}
+          {% translate "judgment.downloadoptions.pdf.description" %}
+        {% endif %}
+      </p>
     </div>
     <div class="judgment-download-options__download-option">
       <h3>
-        <a href="{% url 'detail_xml' context.judgment_uri %}">{% translate "judgment.downloadoptions.xml.cta" %}</a>
+        <a href="{% url 'detail_xml' context.judgment_uri %}">
+          {% if context.document_type == 'press_summary' %}
+            {% translate "press_summary.downloadoptions.xml.cta" %}
+          {% else %}
+            {% translate "judgment.downloadoptions.xml.cta" %}
+          {% endif %}
+        </a>
       </h3>
-      <p>{% translate "judgment.downloadoptions.xml.description" %}</p>
+      <p>
+        {% if context.document_type == 'press_summary' %}
+          {% translate "press_summary.downloadoptions.xml.description" %}
+        {% else %}
+          {% translate "judgment.downloadoptions.xml.description" %}
+        {% endif %}
+      </p>
     </div>
   </div>
 </div>

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -78,12 +78,16 @@ def detail(request, judgment_uri):
 
     context = {}
 
+    if "press-summary" in judgment_uri:
+        context["document_type"] = "press_summary"
+    else:
+        context["document_type"] = "judgment"
+
     context["judgment"] = judgment.content_as_html("")  # "" is most recent version
     context["page_title"] = judgment.name
     context["judgment_uri"] = judgment.uri
     context["judgment_title"] = judgment.name
     context["judgment_ncn"] = judgment.neutral_citation
-
     context["pdf_size"] = get_pdf_size(judgment.uri)
     context["pdf_uri"] = (
         get_pdf_uri(judgment.uri)

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -138,9 +138,19 @@ msgid "judgment.downloadoptions.pdf.cta"
 msgstr "Download this judgment as a PDF"
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+msgid "press_summary.downloadoptions.pdf.cta"
+msgstr "Download this press summary as a PDF"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
 msgid "judgment.downloadoptions.pdf.description"
 msgstr ""
 "The original format of the judgment as handed down by the court, for "
+"printing and downloading."
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+msgid "press_summary.downloadoptions.pdf.description"
+msgstr ""
+"The original format of the press summary as handed down by the court, for "
 "printing and downloading."
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
@@ -148,9 +158,19 @@ msgid "judgment.downloadoptions.xml.cta"
 msgstr "Download this judgment as XML"
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+msgid "press_summary.downloadoptions.xml.cta"
+msgstr "Download this press summary as XML"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
 msgid "judgment.downloadoptions.xml.description"
 msgstr ""
 "The judgment in machine-readable LegalDocML format for developers, data "
+"scientists and researchers."
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+msgid "press_summary.downloadoptions.xml.description"
+msgstr ""
+"The press summary in machine-readable LegalDocML format for developers, data "
 "scientists and researchers."
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_source.html


### PR DESCRIPTION
Note: new version of https://github.com/nationalarchives/ds-caselaw-public-ui/pull/789, since it wouldnt update with my force pushed changes.

## Changes in this PR:
Since we were adding the buttons to go back and forth between judgment and press summary, I thought it was only right that we fix up the press summary html pages to show the correct static text.

Adds conditional logic to the detail view we now share between judgment and press summary to display "press summary" in text when its a press summary!

## Trello card / Rollbar error (etc)
https://trello.com/c/Q2lNPibf/1044-pui-add-to-judgment-view-press-summary-button-and-box-in-download-options

## Screenshots of UI changes:

### Before
<img width="1023" alt="Screenshot 2023-06-28 at 17 02 21" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/606420f5-bdba-45d5-8158-190cb735f5de">


### After
<img width="1077" alt="Screenshot 2023-06-28 at 17 05 08" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/934cd9e5-41c2-4fbf-899f-45e5c5114420">


