### PR TITLE
Improve pre commit setup instructions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 exclude: "^docs/|/migrations/"
-default_stages: [commit]
+default_install_hook_types: [pre-commit, pre-push]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -216,9 +216,15 @@ cannot load library 'gobject-2.0-0'
 
 Then it means the dependencies for WeasyPrint have not been installed correctly. Try rebuilding the docker image using the command `docker-compose build django` and then running `fab run`.
 
-## Using the pre-push hook (optional)
+## Setting up the pre-commit hooks (strongly advised)
 
-Copy `pre-push.sample` to `.git/hooks/pre-push` to set up the pre-push hook. This will run Python linting and style checks when you push to the repo and alert you to any linting issues that will cause CI to fail. To use this, you will need to install [pre-commit](https://pre-commit.com/) on your development machine, typically using `pip install pre-commit`.
+To use this, you will need to install [pre-commit](https://pre-commit.com/) on your development machine, typically using `pip install pre-commit`.
+
+Install the git hooks configured in `.pre-commit-config.yaml` with:
+
+`pre-commit install`
+
+This will set up various checks including Python linting and style checks when you commit and push to the repo and alert you to any linting issues that will cause CI to fail.
 
 ## Setting up commit signing
 

--- a/pre-push.sample
+++ b/pre-push.sample
@@ -1,1 +1,0 @@
-pre-commit run --all-files


### PR DESCRIPTION
## Changes in this PR:
- Remove 'stages' part of configuration file since we dont define any stages in our hooks at the moment. ref: https://pre-commit.com/#top_level-default_stages
- Added `default_install_hook_types` to the config so that when you run `pre-commit install`, it installs the hooks for precommit and prepush https://pre-commit.com/#top_level-default_install_hook_types
- Removed the pre-push.sample file now that we dont need to copy this file into the git hooks and instead just use `pre-commit install`
- Updated the README appropriately

## Screenshots of UI changes:

### Before
<img width="752" alt="Screenshot 2023-07-04 at 10 03 58" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/5d4b07da-7fbe-435c-a8a5-5edb64367fd3">

### After
<img width="904" alt="Screenshot 2023-07-04 at 10 03 51" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/5cf42887-ec6c-4199-9a6a-1d30a662e569">
<img width="752" alt="Screenshot 2023-07-04 at 10 03 58" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/5d4b07da-7fbe-435c-a8a5-5edb64367fd3">