### PR TITLE
Bug/fix css around download toolbar/1044

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -33,33 +33,13 @@
 
     &.btn {
       @include call-to-action-button;
-      margin-right: 1rem;
       margin-bottom: calc($spacer__unit / 3) !important;
     }
 
     &.btn-related-document {
-      background-color: transparent;
-      text-decoration: none;
-      font-weight: 700;
-      border: 0;
-      outline: 2px solid $color__cta-background !important;
-      color: $color__cta-background !important;
-      padding: 0.7rem 1.3rem;
-      display: inline-block;
-      margin-top: 1em;
-      font-size: 1rem;
+      @include call-to-action-button-secondary;
       margin-bottom: calc($spacer__unit / 3) !important;
-      margin-right: calc($spacer__unit / 1) !important;
-    }
-    &:focus,
-    &:hover {
-      @include focus-default;
-      color: $color__white !important;
-      background-color: $color__cta-background-hover;
-      outline-color: $color__cta-background-hover;
-      border-color: $color__cta-background-hover;
-      text-decoration: underline;
-      outline-offset: 0.2rem;
+      margin-right: 1rem;
     }
 
     @media (min-width: $grid__breakpoint-small) {

--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -86,7 +86,7 @@
     text-align: center;
   }
 
-  &__options {
+  &__option--download-options {
     color: $color__dark-grey;
     font-size: 0.75rem;
     text-align: center;

--- a/ds_judgements_public_ui/sass/includes/_mixins.scss
+++ b/ds_judgements_public_ui/sass/includes/_mixins.scss
@@ -61,6 +61,7 @@
 @mixin call-to-action-button-secondary {
   @include call-to-action-button;
   background-color: transparent;
+  padding: 0.875rem 1.175rem;
   color: $color__cta-background !important;
   border: 2px solid $color__cta-background;
 }

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -24,7 +24,8 @@
          role="button"
          draggable="false"
          href="{{ context.pdf_uri }}">{% translate "judgment.downloadaspdf" %}<span style="font-weight:normal;font-size:0.9rem">{{ context.pdf_size }}</span></a>
-      <p class="judgment-toolbar-buttons__download-options" role="note">
+      <p class="judgment-toolbar-buttons__option--download-options"
+         role="note">
         <a href="#download-options">{% translate "judgment.downloadoptions.shortcutlink" %}</a>
       </p>
     </div>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

In original PR for https://trello.com/c/Q2lNPibf/1044-pui-add-to-judgment-view-press-summary-button-and-box-in-download-options, we messed up the css a bit. this fixes the issues there.

- Fix button alignment and remove hover functionality from the download
- Fix download options css

## Trello card / Rollbar error (etc)
https://trello.com/c/Q2lNPibf/1044-pui-add-to-judgment-view-press-summary-button-and-box-in-download-options
## Screenshots of UI changes:

### Before
<img width="669" alt="Screenshot 2023-07-05 at 11 32 45" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/d8a63337-3ca5-4050-b28d-15f843dbc0ec">


### After
<img width="711" alt="Screenshot 2023-07-05 at 11 32 22" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/48f4244c-bc08-447a-84db-acb6187216f9">
