### PR TITLE
Sort out press summary title and headings

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -1,10 +1,10 @@
-{% load i18n %}
+{% load i18n document_utils %}
 <div class="judgment-toolbar">
   <div class="judgment-toolbar__container">
     {% if context.document_type == "press_summary" %}
       <p class="judgment-toolbar__press-summary-title">Press Summary</p>
     {% endif %}
-    <h1 class="judgment-toolbar__title">{{ context.judgment_title }}</h1>
+    <h1 class="judgment-toolbar__title">{{ context.page_title|get_title_to_display_in_html:context.document_type }}</h1>
     <p class="judgment-toolbar__reference">{{ context.judgment_ncn }}</p>
     <div class="judgment-toolbar__buttons judgment-toolbar-buttons">
       {% if context.linked_document_uri %}

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -423,3 +423,59 @@ class TestBreadcrumbs(TestCase):
             </nav>
         </div>"""
         assert_contains_html(response, breadcrumb_html)
+
+
+class TestDocumentHeadings(TestCase):
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_document_headings_when_press_summary(
+        self, mock_judgment, mock_get_pdf_size
+    ):
+        """
+        GIVEN a press summary
+        WHEN a request is made with the press summary URI
+        THEN the response should contain the heading HTML with the press summary
+            name without the "Press Summary of " prefix"
+        """
+
+        def get_judgment_by_uri_side_effect(document_uri):
+            if document_uri == "eat/2023/1/press-summary/1":
+                return JudgmentFactory.build(
+                    uri="eat/2023/1/press-summary/1",
+                    is_published=True,
+                    name="Press Summary of Judgment A (with some slightly different wording)",
+                )
+            elif document_uri == "eat/2023/1":
+                return JudgmentFactory.build(
+                    uri="eat/2023/1",
+                    is_published=True,
+                    name="Judgment A",
+                )
+            else:
+                raise JudgmentNotFoundError()
+
+        mock_judgment.side_effect = get_judgment_by_uri_side_effect
+        response = self.client.get("/eat/2023/1/press-summary/1")
+        headings_html = """
+        <h1 class="judgment-toolbar__title">Judgment A (with some slightly different wording)</h1>
+        """
+        assert_contains_html(response, headings_html)
+
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_document_headings_when_judgment(self, mock_judgment, mock_get_pdf_size):
+        """
+        GIVEN a judgment exists with URI "eat/2023/1"
+        WHEN a request is made with the judgment URI "/eat/2023/1"
+        THEN the response should contain the heading HTML with the judgment name
+        """
+        mock_judgment.return_value = JudgmentFactory.build(
+            uri="eat/2023/1",
+            is_published=True,
+            name="Judgment A",
+        )
+        response = self.client.get("/eat/2023/1")
+        headings_html = """
+        <h1 class="judgment-toolbar__title">Judgment A</h1>
+        """
+        assert_contains_html(response, headings_html)

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -479,3 +479,52 @@ class TestDocumentHeadings(TestCase):
         <h1 class="judgment-toolbar__title">Judgment A</h1>
         """
         assert_contains_html(response, headings_html)
+
+
+class TestHTMLTitle(TestCase):
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_html_title_when_press_summary(self, mock_judgment, mock_get_pdf_size):
+        """
+        GIVEN a press summary
+        WHEN a request is made with the press summary URI
+        THEN the response should have an HTML title containing the press summary name and "- Find case law"
+        """
+
+        def get_judgment_by_uri_side_effect(document_uri):
+            if document_uri == "eat/2023/1/press-summary/1":
+                return JudgmentFactory.build(
+                    uri="eat/2023/1/press-summary/1",
+                    is_published=True,
+                    name="Press Summary of Judgment A (with some slightly different wording)",
+                )
+            elif document_uri == "eat/2023/1":
+                return JudgmentFactory.build(
+                    uri="eat/2023/1",
+                    is_published=True,
+                    name="Judgment A",
+                )
+            else:
+                raise JudgmentNotFoundError()
+
+        mock_judgment.side_effect = get_judgment_by_uri_side_effect
+        response = self.client.get("/eat/2023/1/press-summary/1")
+        html_title = "<title>Press Summary of Judgment A (with some slightly different wording) - Find case law</title>"
+        assert_contains_html(response, html_title)
+
+    @patch("judgments.views.detail.get_pdf_size")
+    @patch("judgments.views.detail.get_judgment_by_uri")
+    def test_html_title_when_judgment(self, mock_judgment, mock_get_pdf_size):
+        """
+        GIVEN a judgment
+        WHEN a request is made with the judgment URI
+        THEN the response should have an HTML title containing the judgment name and  "- Find case law"
+        """
+        mock_judgment.return_value = JudgmentFactory.build(
+            uri="eat/2023/1",
+            is_published=True,
+            name="Judgment A",
+        )
+        response = self.client.get("/eat/2023/1")
+        html_title = "<title>Judgment A - Find case law</title>"
+        assert_contains_html(response, html_title)

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -94,7 +94,6 @@ def detail(request, judgment_uri):
     # TODO: All references to `judgment` here need to be updated to the more general `document`
     context["judgment"] = judgment.content_as_html("")  # "" is most recent version
     context["judgment_uri"] = judgment.uri
-    context["judgment_title"] = judgment.name
     context["page_title"] = judgment.name
     context["pdf_size"] = get_pdf_size(judgment.uri)
     context["pdf_uri"] = (


### PR DESCRIPTION
## Changes in this PR:
- Don't display press summaery prefix in heading oh html.
-  However continue to show "Press Summary of " prefix in the html title/ browser tabs.
<img width="323" alt="Screenshot 2023-07-05 at 17 51 28" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/cf443439-5634-470c-9c30-0f75c3f7b0a0">


## Trello card / Rollbar error (etc)
https://trello.com/c/WNIrNHhy/1126-dont-display-press-summary-of-prefix-in-heading-of-html

## Screenshots of UI changes:

### Before
<img width="1238" alt="Screenshot 2023-07-05 at 17 50 47" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/a791b7e6-0fce-4c4d-b73b-1ed1477db424">


### After
<img width="1220" alt="Screenshot 2023-07-05 at 17 50 14" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/a7058846-32dc-4253-8165-c74e9a135855">
