### PR TITLE
Fix breadcrumbs on error pages

### DIFF
--- a/ds_judgements_public_ui/templates/403.html
+++ b/ds_judgements_public_ui/templates/403.html
@@ -2,20 +2,10 @@
 {% block title %}
   Forbidden - Find Case Law
 {% endblock title %}
+{% block breadcrumbs %}
+  <li>Forbidden</li>
+{% endblock breadcrumbs %}
 {% block content %}
-  <header class="page-header">
-    <div class="page-header__breadcrumb">
-      <nav class="page-header__breadcrumb-container" aria-label="Breadcrumb">
-        <span class="page-header__breadcrumb-you-are-in">You are in:</span>
-        <ol>
-          <li>
-            <a href="{% url 'home' %}">Find case law</a>
-          </li>
-          <li>Forbidden</li>
-        </ol>
-      </nav>
-    </div>
-  </header>
   <div class="standard-text-template container py-3">
     <h1>Forbidden</h1>
     <p>

--- a/ds_judgements_public_ui/templates/404.html
+++ b/ds_judgements_public_ui/templates/404.html
@@ -2,20 +2,10 @@
 {% block title %}
   Page not found - Find case law
 {% endblock title %}
+{% block breadcrumbs %}
+  <li>Page not found</li>
+{% endblock breadcrumbs %}
 {% block content %}
-  <header class="page-header">
-    <div class="page-header__breadcrumb">
-      <nav class="page-header__breadcrumb-container" aria-label="Breadcrumb">
-        <span class="page-header__breadcrumb-you-are-in">You are in:</span>
-        <ol>
-          <li>
-            <a href="{% url 'home' %}">Find case law</a>
-          </li>
-          <li>Page not found</li>
-        </ol>
-      </nav>
-    </div>
-  </header>
   <div class="standard-text-template container py-3">
     <h1>Page not found</h1>
     <p>If you typed the web address, check it is correct.</p>

--- a/ds_judgements_public_ui/templates/500.html
+++ b/ds_judgements_public_ui/templates/500.html
@@ -2,20 +2,10 @@
 {% block title %}
   Server Error - Find Case Law
 {% endblock title %}
+{% block breadcrumbs %}
+  <li>Server Error</li>
+{% endblock breadcrumbs %}
 {% block content %}
-  <header class="page-header">
-    <div class="page-header__breadcrumb">
-      <nav class="page-header__breadcrumb-container" aria-label="Breadcrumb">
-        <span class="page-header__breadcrumb-you-are-in">You are in:</span>
-        <ol>
-          <li>
-            <a href="{% url 'home' %}">Find case law</a>
-          </li>
-          <li>Server error</li>
-        </ol>
-      </nav>
-    </div>
-  </header>
   <div class="standard-text-template container py-3">
     <h1>Server Error</h1>
     <p>Sorry, there seems to be an error. Please try again soon.</p>

--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -36,7 +36,28 @@
     <header class="page-header">
       {% block header %}
         <div class="page-header__flex-container container py-1">
-          {% include "includes/header_nav.html" with title=context.page_title link=request.path %}
+          <div class="page-header__nav">
+            <div class="page-header__site-logo">
+              <a href="{% url "home" %}" id="home-link">{% translate "home" %}</a>
+            </div>
+            <div class="page-header__breadcrumb">
+              <nav class="page-header__breadcrumb-flex-container"
+                   aria-label="Breadcrumb">
+                <ol>
+                  <li>
+                    <span class="page-header__breadcrumb-you-are-in">You are in:</span>
+                    {% if title == "home" %}
+                      {% translate "common.findcaselaw" %}
+                    {% else %}
+                      <a href="{% url 'home' %}">{% translate "common.findcaselaw" %}</a>
+                    {% endif %}
+                  </li>
+                  {% block breadcrumbs %}
+                  {% endblock breadcrumbs %}
+                </ol>
+              </nav>
+            </div>
+          </div>
           {% include "includes/logo.html" %}
         </div>
       {% endblock header %}


### PR DESCRIPTION
## Changes in this PR:
- Remove extra breadcrumb in error pages and fix the main shared breadcrumb in error pages

## Trello card / Rollbar error (etc)
https://trello.com/c/rnT5T9iE/1105-page-not-found-double-breadcrumbs

## Screenshots of UI changes:

### Before
<img width="469" alt="Screenshot 2023-07-06 at 12 29 06" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/35438664-1d85-4b81-9748-9783c15afd98">

### After
<img width="660" alt="Screenshot 2023-07-06 at 17 20 04" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/49240037-22f4-43be-a9d6-9c79d760a8d7">
