### PR TITLE
Generalise judgment variables with document

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -73,6 +73,8 @@ class FeedbackLinkMiddleware:
             params["type"] = response.context_data["feedback_survey_type"]
 
         if "feedback_survey_document_uri" in response.context_data:
+            # TODO: update the survey to allow for generalisation to `document`
+            # https://trello.com/c/l0iBFM1e/1151-update-survey-to-account-for-judgment-the-fact-that-we-have-press-summaries-as-well-as-judgments-now
             params["judgment_uri"] = response.context_data[
                 "feedback_survey_document_uri"
             ]

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -72,9 +72,9 @@ class FeedbackLinkMiddleware:
         if "feedback_survey_type" in response.context_data:
             params["type"] = response.context_data["feedback_survey_type"]
 
-        if "feedback_survey_judgment_uri" in response.context_data:
+        if "feedback_survey_document_uri" in response.context_data:
             params["judgment_uri"] = response.context_data[
-                "feedback_survey_judgment_uri"
+                "feedback_survey_document_uri"
             ]
 
         if "feedback_survey_court" in response.context_data:

--- a/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
@@ -23,7 +23,7 @@
     </div>
     <div class="judgment-download-options__download-option">
       <h3>
-        <a href="{% url 'detail_xml' context.judgment_uri %}">
+        <a href="{% url 'detail_xml' context.document_uri %}">
           {% if context.document_type == 'press_summary' %}
             {% translate "press_summary.downloadoptions.xml.cta" %}
           {% else %}

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -11,7 +11,7 @@
         <a class="judgment-toolbar-buttons__option--related-document btn-related-document"
            role="button"
            draggable="false"
-           href="{% url 'detail' judgment_uri=context.linked_document_uri %}">
+           href="{% url 'detail' document_uri=context.linked_document_uri %}">
           {% if context.document_type == "judgment" %}
             {% translate "judgment.view_press_summary" %}
           {% else %}

--- a/ds_judgements_public_ui/templates/judgment/detail.html
+++ b/ds_judgements_public_ui/templates/judgment/detail.html
@@ -1,8 +1,8 @@
 {% extends "layouts/judgment.html" %}
 {% block content %}
-  {% if context.judgment %}
+  {% if context.document %}
     {% autoescape off %}
-      {{ context.judgment }}
+      {{ context.document }}
     {% endautoescape %}
   {% else %}
     {{ content }}

--- a/ds_judgements_public_ui/templates/pdf/judgment.html
+++ b/ds_judgements_public_ui/templates/pdf/judgment.html
@@ -12,7 +12,7 @@
   <body>
     <main id="main-content">
       {% autoescape off %}
-        {{ judgment }}
+        {{ document }}
       {% endautoescape %}
     </main>
   </body>

--- a/ds_judgements_public_ui/templates/pdf/judgment.html
+++ b/ds_judgements_public_ui/templates/pdf/judgment.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="robots" content="noindex,nofollow" />
-    <title>{{ judgment_uri }}</title>
+    <title>{{ document_uri }}</title>
     {% block css %}
       <link href="{% static 'css/judgmentpdf.css' %}" rel="stylesheet" />
     {% endblock css %}

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -123,7 +123,7 @@ class LatestJudgmentsFeed(Feed):
         return item.name
 
     def item_link(self, item) -> str:
-        return reverse("detail", kwargs={"judgment_uri": item.uri})
+        return reverse("detail", kwargs={"document_uri": item.uri})
 
     def item_author_name(self, item) -> Optional[str]:
         return item.metadata.author

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -14,55 +14,57 @@ from judgments.tests.utils.assertions import (
 from judgments.views.detail import (
     PdfDetailView,
     get_pdf_size,
-    get_published_judgment_by_uri,
+    get_published_document_by_uri,
 )
 
 
 class TestWeasyWithoutCSS(TestCase):
     @patch.object(PdfDetailView, "pdf_stylesheets", [])
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_weasy_without_css_runs_in_ci(self, mock_judgment):
+    @patch("judgments.views.detail.get_document_by_uri")
+    def test_weasy_without_css_runs_in_ci(self, mock_get_document_by_uri):
         judgment = JudgmentFactory.build(is_published=True)
-        mock_judgment.return_value = judgment
+        mock_get_document_by_uri.return_value = judgment
         response = self.client.get("/eat/2023/1/generated.pdf")
         assert response.status_code == 200
         assert b"%PDF-1.7" in response.content
 
 
-class TestGetPublishedJudgment:
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_judgment_is_published(self, mock_judgment):
+class TestGetPublishedDocument:
+    @patch("judgments.views.detail.get_document_by_uri")
+    def test_judgment_is_published(self, mock_get_document_by_uri):
         judgment = JudgmentFactory.build(is_published=True)
-        mock_judgment.return_value = judgment
-        assert get_published_judgment_by_uri("2022/eat/1") == judgment
+        mock_get_document_by_uri.return_value = judgment
+        assert get_published_document_by_uri("2022/eat/1") == judgment
 
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_judgment_is_unpublished(self, mock_judgment):
-        mock_judgment.return_value = JudgmentFactory.build(is_published=False)
+    @patch("judgments.views.detail.get_document_by_uri")
+    def test_judgment_is_unpublished(self, mock_get_document_by_uri):
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
+            is_published=False
+        )
         with pytest.raises(Http404):
-            get_published_judgment_by_uri("2099/eat/1")
+            get_published_document_by_uri("2099/eat/1")
 
     @patch(
-        "judgments.views.detail.get_judgment_by_uri", side_effect=JudgmentNotFoundError
+        "judgments.views.detail.get_document_by_uri", side_effect=JudgmentNotFoundError
     )
-    def test_judgment_missing(self, mock_judgment):
+    def test_judgment_missing(self, mock_get_document_by_uri):
         with pytest.raises(Http404):
-            get_published_judgment_by_uri("not-a-judgment")
+            get_published_document_by_uri("not-a-judgment")
 
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_press_summary_is_published(self, mock_judgment):
+    @patch("judgments.views.detail.get_document_by_uri")
+    def test_press_summary_is_published(self, mock_get_document_by_uri):
         judgment = JudgmentFactory.build(
             is_published=True, uri="2022/eat/1/press-summary/1"
         )
-        mock_judgment.return_value = judgment
-        assert get_published_judgment_by_uri("2022/eat/1/press-summary/1") == judgment
+        mock_get_document_by_uri.return_value = judgment
+        assert get_published_document_by_uri("2022/eat/1/press-summary/1") == judgment
 
 
 class TestJudgment(TestCase):
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_published_judgment_by_uri")
-    def test_published_judgment_response(self, mock_judgment, mock_pdf_size):
-        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
+    @patch("judgments.views.detail.get_published_document_by_uri")
+    def test_published_judgment_response(self, mock_get_document_by_uri, mock_pdf_size):
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(is_published=True)
         mock_pdf_size.return_value = "1234KB"
 
         response = self.client.get("/test/2023/123")
@@ -80,9 +82,9 @@ class TestJudgment(TestCase):
 
 class TestJudgmentBackToSearchLink(TestCase):
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_published_judgment_by_uri")
-    def test_no_link_if_no_context(self, mock_judgment, mock_pdf_size):
-        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
+    @patch("judgments.views.detail.get_published_document_by_uri")
+    def test_no_link_if_no_context(self, mock_get_document_by_uri, mock_pdf_size):
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(is_published=True)
         mock_pdf_size.return_value = "1234KB"
 
         response = self.client.get("/test/2023/123")
@@ -93,9 +95,9 @@ class TestJudgmentBackToSearchLink(TestCase):
 
 class TestJudgmentPdfLinkText(TestCase):
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_published_judgment_by_uri")
+    @patch("judgments.views.detail.get_published_document_by_uri")
     @patch.dict(environ, {"ASSETS_CDN_BASE_URL": "https://example.com"})
-    def test_pdf_link_with_size(self, mock_judgment, mock_pdf_size):
+    def test_pdf_link_with_size(self, mock_get_document_by_uri, mock_pdf_size):
         """
         `get_pdf_size` serves several purposes; it can _either_ return a string with the size of a PDF if one exists
         in S3, _or_ return a string saying "unknown size" if the file exists but S3 doesn't tell us the size, _or_
@@ -103,7 +105,7 @@ class TestJudgmentPdfLinkText(TestCase):
         "unknown"), in which case we should link to the file in S3 via our assets URL and display the size string.
         """
 
-        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(is_published=True)
         mock_pdf_size.return_value = " (1234KB)"
 
         response = self.client.get("/test/2023/123")
@@ -116,16 +118,16 @@ class TestJudgmentPdfLinkText(TestCase):
         self.assertIn("(1234KB)", decoded_response)
 
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_published_judgment_by_uri")
+    @patch("judgments.views.detail.get_published_document_by_uri")
     @patch.dict(environ, {"ASSETS_CDN_BASE_URL": "https://example.com"})
-    def test_pdf_link_with_no_size(self, mock_judgment, mock_pdf_size):
+    def test_pdf_link_with_no_size(self, mock_get_document_by_uri, mock_pdf_size):
         """
         `get_pdf_size` serves several purposes; it can _either_ return a string with the size of a PDF if one exists
         in S3, _or_ return a string saying "unknown size" if the file exists but S3 doesn't tell us the size, _or_
         return an empty string. This tests the case where it returns an empty string (implying that the file doesn't
         exist in S3), so we should link to our generated PDF instead and not S3."""
 
-        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(is_published=True)
         mock_pdf_size.return_value = ""
 
         response = self.client.get("/test/2023/123")
@@ -139,13 +141,18 @@ class TestJudgmentPdfLinkText(TestCase):
 class TestDocumentDownloadOptions:
     @patch("judgments.views.detail.get_pdf_uri")
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
+    @patch("judgments.views.detail.get_document_by_uri")
     @pytest.mark.parametrize(
         "uri,document_type",
         [("eat/2023/1/press-summary/1", "press summary"), ("eat/2023/1", "judgment")],
     )
     def test_download_options(
-        self, mock_judgment, mock_get_pdf_size, mock_get_pdf_uri, uri, document_type
+        self,
+        mock_get_document_by_uri,
+        mock_get_pdf_size,
+        mock_get_pdf_uri,
+        uri,
+        document_type,
     ):
         """
         GIVEN a document
@@ -155,7 +162,9 @@ class TestDocumentDownloadOptions:
         AND this contains the Download XML button
         AND the descriptions refer to the document's type
         """
-        mock_judgment.return_value = JudgmentFactory.build(uri=uri, is_published=True)
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
+            uri=uri, is_published=True
+        )
         mock_get_pdf_size.return_value = "(112KB)"
         mock_get_pdf_uri.return_value = "http://example.com/test.pdf"
         client = Client()
@@ -219,9 +228,9 @@ class TestGetPdfSize(TestCase):
 
 
 class TestDocumentURIRedirects(TestCase):
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_non_canonical_uri_redirects(self, mock_judgment):
-        mock_judgment.return_value = JudgmentFactory.build(
+    @patch("judgments.views.detail.get_document_by_uri")
+    def test_non_canonical_uri_redirects(self, mock_get_document_by_uri):
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
             uri="test/1234/567", is_published=True
         )
         response = self.client.get("/test/1234/567/")
@@ -232,15 +241,17 @@ class TestDocumentURIRedirects(TestCase):
 
 class TestPressSummaryLabel(TestCase):
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_label_when_press_summary(self, mock_judgment, mock_get_pdf_size):
+    @patch("judgments.views.detail.get_document_by_uri")
+    def test_label_when_press_summary(
+        self, mock_get_document_by_uri, mock_get_pdf_size
+    ):
         """
         GIVEN press summary
         WHEN request is made with press summary uri
         THEN response should contain the press summary label
         """
 
-        mock_judgment.return_value = JudgmentFactory.build(
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
             uri="eat/2023/1/press-summary/1", is_published=True
         )
         response = self.client.get("/eat/2023/1/press-summary/1")
@@ -250,16 +261,16 @@ class TestPressSummaryLabel(TestCase):
         )
 
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
+    @patch("judgments.views.detail.get_document_by_uri")
     def test_no_press_summary_label_when_on_judgment(
-        self, mock_judgment, mock_get_pdf_size
+        self, mock_get_document_by_uri, mock_get_pdf_size
     ):
         """
         GIVEN judgment
         WHEN request is made with judgment uri
         THEN response should NOT contain the press summary label
         """
-        mock_judgment.return_value = JudgmentFactory.build(
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
             uri="eat/2023/1", is_published=True
         )
         response = self.client.get("/eat/2023/1")
@@ -272,7 +283,7 @@ class TestPressSummaryLabel(TestCase):
 @pytest.mark.django_db
 class TestViewRelatedDocumentButton:
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
+    @patch("judgments.views.detail.get_document_by_uri")
     @pytest.mark.parametrize(
         "uri,expected_text,expected_href",
         [
@@ -282,7 +293,7 @@ class TestViewRelatedDocumentButton:
     )
     def test_view_related_document_button_when_document_with_related_document(
         self,
-        mock_get_judgment_by_uri,
+        mock_get_document_by_uri,
         mock_get_pdf_size,
         uri,
         expected_text,
@@ -294,7 +305,7 @@ class TestViewRelatedDocumentButton:
         THEN the response should contain a button linking to the related document
         """
 
-        def get_judgment_by_uri_side_effect(document_uri):
+        def get_document_by_uri_side_effect(document_uri):
             if document_uri == uri:
                 return JudgmentFactory.build(uri=uri, is_published=True)
             elif document_uri == expected_href:
@@ -302,7 +313,7 @@ class TestViewRelatedDocumentButton:
             else:
                 raise JudgmentNotFoundError()
 
-        mock_get_judgment_by_uri.side_effect = get_judgment_by_uri_side_effect
+        mock_get_document_by_uri.side_effect = get_document_by_uri_side_effect
 
         expected_html_button = f"""
         <a class="judgment-toolbar-buttons__option--related-document btn-related-document"
@@ -318,7 +329,7 @@ class TestViewRelatedDocumentButton:
         assert_contains_html(response, expected_html_button)
 
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
+    @patch("judgments.views.detail.get_document_by_uri")
     @pytest.mark.parametrize(
         "uri,unexpected_text,unexpected_href",
         [
@@ -328,7 +339,7 @@ class TestViewRelatedDocumentButton:
     )
     def test_no_view_related_document_button_when_document_without_related_document(
         self,
-        mock_get_judgment_by_uri,
+        mock_get_document_by_uri,
         mock_get_pdf_size,
         uri,
         unexpected_text,
@@ -340,13 +351,13 @@ class TestViewRelatedDocumentButton:
         THEN the response should not contain a button linking to the related judgment
         """
 
-        def get_judgment_by_uri_side_effect(document_uri):
+        def get_document_by_uri_side_effect(document_uri):
             if document_uri == uri:
                 return JudgmentFactory.build(uri=document_uri, is_published=True)
             else:
                 raise JudgmentNotFoundError()
 
-        mock_get_judgment_by_uri.side_effect = get_judgment_by_uri_side_effect
+        mock_get_document_by_uri.side_effect = get_document_by_uri_side_effect
 
         unexpected_html_button = f"""
         <a class="judgment-toolbar-buttons__option--related-document btn-related-document"
@@ -368,15 +379,17 @@ class TestBreadcrumbs:
     client = Client(raise_request_exception=False)
 
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_breadcrumb_when_press_summary(self, mock_judgment, mock_get_pdf_size):
+    @patch("judgments.views.detail.get_document_by_uri")
+    def test_breadcrumb_when_press_summary(
+        self, mock_get_document_by_uri, mock_get_pdf_size
+    ):
         """
         GIVEN a press summary
         WHEN a request is made with the press summary URI
         THEN the response should contain breadcrumbs including the press summary name
         AND an additional `Press Summary` breadcrumb
         """
-        mock_judgment.return_value = JudgmentFactory.build(
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
             uri="eat/2023/1/press-summary/1",
             is_published=True,
             name="Press Summary of Judgment A",
@@ -399,15 +412,17 @@ class TestBreadcrumbs:
         assert_contains_html(response, breadcrumb_html)
 
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_breadcrumb_when_judgment(self, mock_judgment, mock_get_pdf_size):
+    @patch("judgments.views.detail.get_document_by_uri")
+    def test_breadcrumb_when_judgment(
+        self, mock_get_document_by_uri, mock_get_pdf_size
+    ):
         """
         GIVEN a judgment
         WHEN a request is made with the judgment URI
         THEN the response should contain breadcrumbs including the judgment name
         AND NOT contain an additional `Press Summary` breadcrumb
         """
-        mock_judgment.return_value = JudgmentFactory.build(
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
             uri="eat/2023/1",
             is_published=True,
             name="Judgment A",
@@ -428,7 +443,7 @@ class TestBreadcrumbs:
         assert_contains_html(response, breadcrumb_html)
 
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
+    @patch("judgments.views.detail.get_document_by_uri")
     @pytest.mark.parametrize(
         "http_error,expected_breadcrumb",
         [
@@ -437,7 +452,11 @@ class TestBreadcrumbs:
         ],
     )
     def test_breadcrumb_when_errors(
-        self, mock_judgment, mock_get_pdf_size, http_error, expected_breadcrumb
+        self,
+        mock_get_document_by_uri,
+        mock_get_pdf_size,
+        http_error,
+        expected_breadcrumb,
     ):
         """
         GIVEN an URI matching the detail URI structure but does not match a valid document
@@ -445,10 +464,10 @@ class TestBreadcrumbs:
         THEN the response should contain breadcrumbs including the appropriate error reference
         """
 
-        def get_judgment_by_uri_side_effect(document_uri):
+        def get_document_by_uri_side_effect(document_uri):
             raise http_error()
 
-        mock_judgment.side_effect = get_judgment_by_uri_side_effect
+        mock_get_document_by_uri.side_effect = get_document_by_uri_side_effect
 
         response = self.client.get("/eat/2023/1")
         breadcrumb_html = f"""
@@ -468,9 +487,9 @@ class TestBreadcrumbs:
 
 class TestDocumentHeadings(TestCase):
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
+    @patch("judgments.views.detail.get_document_by_uri")
     def test_document_headings_when_press_summary(
-        self, mock_judgment, mock_get_pdf_size
+        self, mock_get_document_by_uri, mock_get_pdf_size
     ):
         """
         GIVEN a press summary and related judgment
@@ -480,7 +499,7 @@ class TestDocumentHeadings(TestCase):
         AND a p tag subheading with the related judgment's NCN
         """
 
-        def get_judgment_by_uri_side_effect(document_uri):
+        def get_document_by_uri_side_effect(document_uri):
             if document_uri == "eat/2023/1/press-summary/1":
                 return JudgmentFactory.build(
                     uri="eat/2023/1/press-summary/1",
@@ -498,7 +517,7 @@ class TestDocumentHeadings(TestCase):
             else:
                 raise JudgmentNotFoundError()
 
-        mock_judgment.side_effect = get_judgment_by_uri_side_effect
+        mock_get_document_by_uri.side_effect = get_document_by_uri_side_effect
         response = self.client.get("/eat/2023/1/press-summary/1")
         headings_html = """
         <h1 class="judgment-toolbar__title">Judgment A (with some slightly different wording)</h1>
@@ -507,15 +526,17 @@ class TestDocumentHeadings(TestCase):
         assert_contains_html(response, headings_html)
 
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_document_headings_when_judgment(self, mock_judgment, mock_get_pdf_size):
+    @patch("judgments.views.detail.get_document_by_uri")
+    def test_document_headings_when_judgment(
+        self, mock_get_document_by_uri, mock_get_pdf_size
+    ):
         """
         GIVEN a judgment exists with URI "eat/2023/1"
         WHEN a request is made with the judgment URI "/eat/2023/1"
         THEN the response should contain the heading HTML with the judgment name
         AND a p tag subheading with the judgment's NCN
         """
-        mock_judgment.return_value = JudgmentFactory.build(
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
             uri="eat/2023/1",
             is_published=True,
             name="Judgment A",
@@ -531,15 +552,17 @@ class TestDocumentHeadings(TestCase):
 
 class TestHTMLTitle(TestCase):
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_html_title_when_press_summary(self, mock_judgment, mock_get_pdf_size):
+    @patch("judgments.views.detail.get_document_by_uri")
+    def test_html_title_when_press_summary(
+        self, mock_get_document_by_uri, mock_get_pdf_size
+    ):
         """
         GIVEN a press summary
         WHEN a request is made with the press summary URI
         THEN the response should have an HTML title containing the press summary name and "- Find case law"
         """
 
-        def get_judgment_by_uri_side_effect(document_uri):
+        def get_document_by_uri_side_effect(document_uri):
             if document_uri == "eat/2023/1/press-summary/1":
                 return JudgmentFactory.build(
                     uri="eat/2023/1/press-summary/1",
@@ -555,20 +578,22 @@ class TestHTMLTitle(TestCase):
             else:
                 raise JudgmentNotFoundError()
 
-        mock_judgment.side_effect = get_judgment_by_uri_side_effect
+        mock_get_document_by_uri.side_effect = get_document_by_uri_side_effect
         response = self.client.get("/eat/2023/1/press-summary/1")
         html_title = "<title>Press Summary of Judgment A (with some slightly different wording) - Find case law</title>"
         assert_contains_html(response, html_title)
 
     @patch("judgments.views.detail.get_pdf_size")
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_html_title_when_judgment(self, mock_judgment, mock_get_pdf_size):
+    @patch("judgments.views.detail.get_document_by_uri")
+    def test_html_title_when_judgment(
+        self, mock_get_document_by_uri, mock_get_pdf_size
+    ):
         """
         GIVEN a judgment
         WHEN a request is made with the judgment URI
         THEN the response should have an HTML title containing the judgment name and  "- Find case law"
         """
-        mock_judgment.return_value = JudgmentFactory.build(
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
             uri="eat/2023/1",
             is_published=True,
             name="Judgment A",

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -166,19 +166,19 @@ class TestRobotsDirectives(TestCase):
         self.assertContains(response, "CAT")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_xml(self, mock_judgment):
-        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
+    @patch("judgments.views.detail.get_document_by_uri")
+    def test_xml(self, mock_get_document_by_uri):
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(is_published=True)
         response = self.client.get("/eat/2023/1/data.xml")
-        mock_judgment.assert_called_with("eat/2023/1")
+        mock_get_document_by_uri.assert_called_with("eat/2023/1")
         self.assertContains(response, "This is a judgment in XML.")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
-    @patch("judgments.views.detail.get_judgment_by_uri")
-    def test_xml_press_summary(self, mock_judgment):
-        mock_judgment.return_value = JudgmentFactory.build(is_published=True)
+    @patch("judgments.views.detail.get_document_by_uri")
+    def test_xml_press_summary(self, mock_get_document_by_uri):
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(is_published=True)
         response = self.client.get("/eat/2023/1/press-summary/1/data.xml")
-        mock_judgment.assert_called_with("eat/2023/1/press-summary/1")
+        mock_get_document_by_uri.assert_called_with("eat/2023/1/press-summary/1")
         self.assertContains(response, "This is a judgment in XML.")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -187,7 +187,7 @@ class TestRobotsDirectives(TestCase):
     def test_weasy_pdf(self, mock_context):
         mock_context.return_value = {"judgment": "<cat>KITTEN</cat>"}
         response = self.client.get("/eat/2023/1/generated.pdf")
-        mock_context.assert_called_with(judgment_uri="eat/2023/1")
+        mock_context.assert_called_with(document_uri="eat/2023/1")
         self.assertContains(response, b"%PDF-1.7")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
@@ -196,7 +196,7 @@ class TestRobotsDirectives(TestCase):
     def test_weasy_pdf_press_summary(self, mock_context):
         mock_context.return_value = {"judgment": "<cat>KITTEN</cat>"}
         response = self.client.get("/eat/2023/1/press-summary/1/generated.pdf")
-        mock_context.assert_called_with(judgment_uri="eat/2023/1/press-summary/1")
+        mock_context.assert_called_with(document_uri="eat/2023/1/press-summary/1")
         self.assertContains(response, b"%PDF-1.7")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -39,22 +39,22 @@ urlpatterns = [
         name="feed",
     ),
     re_path(
-        r"^(?P<judgment_uri>.*/\d{4}/\d+.*)/data.pdf$",
+        r"^(?P<document_uri>.*/\d{4}/\d+.*)/data.pdf$",
         get_best_pdf,
         name="detail_pdf",
     ),
     re_path(
-        r"^(?P<judgment_uri>.*/\d{4}/\d+.*)/generated.pdf$",
+        r"^(?P<document_uri>.*/\d{4}/\d+.*)/generated.pdf$",
         PdfDetailView.as_view(),
         name="weasy_pdf",
     ),
     re_path(
-        r"^(?P<judgment_uri>.*/\d{4}/\d+.*)/data.xml$", detail_xml, name="detail_xml"
+        r"^(?P<document_uri>.*/\d{4}/\d+.*)/data.xml$", detail_xml, name="detail_xml"
     ),
     re_path(
-        r"^(?P<judgment_uri>.*/\d{4}/\d+.*)/data.html$", detail, name="detail_html"
+        r"^(?P<document_uri>.*/\d{4}/\d+.*)/data.html$", detail, name="detail_html"
     ),
-    re_path(r"^(?P<judgment_uri>.*/\d{4}/\d+.*)/?$", detail, name="detail"),
+    re_path(r"^(?P<document_uri>.*/\d{4}/\d+.*)/?$", detail, name="detail"),
     path("judgments/results", results, name="results"),
     path("judgments/advanced_search", advanced_search, name="advanced_search"),
     path("", index, name="home"),

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -203,7 +203,7 @@ def parse_date_parameter(params, param_name, default_to_last=False):
         raise ValueError(gettext("search.errors.missing_year_detail"))
 
 
-def get_judgment_by_uri(document_uri: str) -> Judgment:
+def get_document_by_uri(document_uri: str) -> Judgment:
     api_client = MarklogicApiClient(
         host=settings.MARKLOGIC_HOST,
         username=settings.MARKLOGIC_USER,

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -121,10 +121,10 @@ def paginator(current_page, total, size_per_page=RESULTS_PER_PAGE):
     }
 
 
-def get_pdf_uri(judgment_uri: str) -> str:
+def get_pdf_uri(document_uri: str) -> str:
     env = environ.Env()
     """Create a string saying where the S3 PDF will be for a judgment uri"""
-    pdf_path = f'{judgment_uri}/{judgment_uri.replace("/", "_")}.pdf'
+    pdf_path = f'{document_uri}/{document_uri.replace("/", "_")}.pdf'
     assets = env("ASSETS_CDN_BASE_URL", default=None)
     if assets:
         return f"{assets}/{pdf_path}"
@@ -203,7 +203,7 @@ def parse_date_parameter(params, param_name, default_to_last=False):
         raise ValueError(gettext("search.errors.missing_year_detail"))
 
 
-def get_judgment_by_uri(judgment_uri: str) -> Judgment:
+def get_judgment_by_uri(document_uri: str) -> Judgment:
     api_client = MarklogicApiClient(
         host=settings.MARKLOGIC_HOST,
         username=settings.MARKLOGIC_USER,
@@ -212,4 +212,4 @@ def get_judgment_by_uri(judgment_uri: str) -> Judgment:
     )
 
     # raises a JudgmentNotFoundError if it doesn't exist
-    return Judgment(judgment_uri, api_client)
+    return Judgment(document_uri, api_client)

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -112,7 +112,8 @@ def detail(request, document_uri):
         "judgment/detail.html",
         context={
             "context": context,
-            "feedback_survey_type": "judgment",
+            "feedback_survey_type": "judgment",  # TODO: update the survey to allow for generalisation to `document`
+            # https://trello.com/c/l0iBFM1e/1151-update-survey-to-account-for-judgment-the-fact-that-we-have-press-summaries-as-well-as-judgments-now
             "feedback_survey_document_uri": document.uri,
             "search_context": search_context_from_url(request.META.get("HTTP_REFERER")),
         },

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -20,14 +20,14 @@ if os.environ.get("SHOW_WEASYPRINT_LOGS") != "True":
     logging.getLogger("weasyprint").handlers = []
 
 
-def get_published_judgment_by_uri(judgment_uri: str) -> Judgment:
+def get_published_judgment_by_uri(document_uri: str) -> Judgment:
     try:
-        document = get_judgment_by_uri(judgment_uri)
+        document = get_judgment_by_uri(document_uri)
     except JudgmentNotFoundError:
-        raise Http404(f"Judgment {judgment_uri} was not found")
+        raise Http404(f"Judgment {document_uri} was not found")
 
     if not document.is_published:
-        raise Http404(f"This Judgment {judgment_uri} is not available")
+        raise Http404(f"This Judgment {document_uri} is not available")
     return document
 
 
@@ -36,10 +36,10 @@ class PdfDetailView(WeasyTemplateResponseMixin, TemplateView):
     pdf_stylesheets = [os.path.join(settings.STATIC_ROOT, "css", "judgmentpdf.css")]
     pdf_attachment = True
 
-    def get_context_data(self, judgment_uri, **kwargs):
+    def get_context_data(self, document_uri, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        document = get_published_judgment_by_uri(judgment_uri)
+        document = get_published_judgment_by_uri(document_uri)
 
         self.pdf_filename = f"{document.uri}.pdf"
 
@@ -48,44 +48,44 @@ class PdfDetailView(WeasyTemplateResponseMixin, TemplateView):
         return context
 
 
-def get_best_pdf(request, judgment_uri):
+def get_best_pdf(request, document_uri):
     """
     Response for the legacy data.pdf endpoint, used by data reusers
 
     If there's a DOCX-derived PDF in the S3 bucket, return that.
     Otherwise fall back and redirect to the weasyprint version."""
-    pdf_uri = get_pdf_uri(judgment_uri)
+    pdf_uri = get_pdf_uri(document_uri)
     response = requests.get(pdf_uri)
     if response.status_code == 200:
         return HttpResponse(response.content, content_type="application/pdf")
 
     if response.status_code != 404:
         logging.warn(
-            f"Unexpected {response.status_code} error on {judgment_uri} whilst trying to get_best_pdf"
+            f"Unexpected {response.status_code} error on {document_uri} whilst trying to get_best_pdf"
         )
     # fall back to weasy_pdf
-    return redirect(reverse("weasy_pdf", kwargs={"judgment_uri": judgment_uri}))
+    return redirect(reverse("weasy_pdf", kwargs={"document_uri": document_uri}))
 
 
-def detail(request, judgment_uri):
-    document = get_published_judgment_by_uri(judgment_uri)
+def detail(request, document_uri):
+    document = get_published_judgment_by_uri(document_uri)
 
-    # If the judgment_uri which was requested isn't the canonical URI of the document, redirect the user
-    if judgment_uri != document.uri:
+    # If the document_uri which was requested isn't the canonical URI of the document, redirect the user
+    if document_uri != document.uri:
         return HttpResponseRedirect(
-            reverse("detail", kwargs={"judgment_uri": document.uri})
+            reverse("detail", kwargs={"document_uri": document.uri})
         )
 
     context = {}
 
     press_summary_suffix = "/press-summary/1"
-    if judgment_uri.endswith(press_summary_suffix):
+    if document_uri.endswith(press_summary_suffix):
         context["document_type"] = "press_summary"
-        context["linked_document_uri"] = judgment_uri.removesuffix(press_summary_suffix)
+        context["linked_document_uri"] = document_uri.removesuffix(press_summary_suffix)
         context["judgment_ncn"] = ""
     else:
         context["document_type"] = "judgment"
-        context["linked_document_uri"] = judgment_uri + press_summary_suffix
+        context["linked_document_uri"] = document_uri + press_summary_suffix
         context["judgment_ncn"] = document.neutral_citation
 
     linked_document = None
@@ -99,7 +99,7 @@ def detail(request, judgment_uri):
 
     # TODO: All references to `document` here need to be updated to the more general `document`
     context["judgment"] = document.content_as_html("")  # "" is most recent version
-    context["judgment_uri"] = document.uri
+    context["document_uri"] = document.uri
     context["page_title"] = document.name
     context["pdf_size"] = get_pdf_size(document.uri)
     context["pdf_uri"] = (
@@ -114,14 +114,14 @@ def detail(request, judgment_uri):
         context={
             "context": context,
             "feedback_survey_type": "judgment",
-            "feedback_survey_judgment_uri": document.uri,
+            "feedback_survey_document_uri": document.uri,
             "search_context": search_context_from_url(request.META.get("HTTP_REFERER")),
         },
     )
 
 
-def detail_xml(_request, judgment_uri):
-    document = get_published_judgment_by_uri(judgment_uri)
+def detail_xml(_request, document_uri):
+    document = get_published_judgment_by_uri(document_uri)
 
     judgment_xml = document.content_as_xml()
 
@@ -130,11 +130,11 @@ def detail_xml(_request, judgment_uri):
     return response
 
 
-def get_pdf_size(judgment_uri):
+def get_pdf_size(document_uri):
     """Return the size of the S3 PDF for a document as a string in brackets, or an empty string if unavailable"""
     response = requests.head(
         # it is possible that "" is a better value than None, but that is untested
-        get_pdf_uri(judgment_uri),
+        get_pdf_uri(document_uri),
         headers={"Accept-Encoding": None},  # type: ignore
     )
     content_length = response.headers.get("Content-Length", None)
@@ -143,5 +143,5 @@ def get_pdf_size(judgment_uri):
     if content_length:
         filesize = filesizeformat(int(content_length))
         return f" ({filesize})"
-    logging.warning(f"Unable to determine PDF size for {judgment_uri}")
+    logging.warning(f"Unable to determine PDF size for {document_uri}")
     return " (unknown size)"

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -123,9 +123,9 @@ def detail(request, document_uri):
 def detail_xml(_request, document_uri):
     document = get_published_document_by_uri(document_uri)
 
-    judgment_xml = document.content_as_xml()
+    document_xml = document.content_as_xml()
 
-    response = HttpResponse(judgment_xml, content_type="application/xml")
+    response = HttpResponse(document_xml, content_type="application/xml")
     response["Content-Disposition"] = f"attachment; filename={document.uri}.xml"
     return response
 

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -43,7 +43,7 @@ class PdfDetailView(WeasyTemplateResponseMixin, TemplateView):
 
         self.pdf_filename = f"{document.uri}.pdf"
 
-        context["judgment"] = document.content_as_html("")  # "" is most recent version
+        context["document"] = document.content_as_html("")  # "" is most recent version
 
         return context
 
@@ -97,8 +97,7 @@ def detail(request, document_uri):
     if context["document_type"] == "press_summary" and linked_document:
         context["judgment_ncn"] = linked_document.neutral_citation
 
-    # TODO: All references to `document` here need to be updated to the more general `document`
-    context["judgment"] = document.content_as_html("")  # "" is most recent version
+    context["document"] = document.content_as_html("")  # "" is most recent version
     context["document_uri"] = document.uri
     context["page_title"] = document.name
     context["pdf_size"] = get_pdf_size(document.uri)

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -13,21 +13,21 @@ from django.urls import reverse
 from django.views.generic import TemplateView
 from django_weasyprint import WeasyTemplateResponseMixin
 
-from judgments.utils import get_judgment_by_uri, get_pdf_uri, search_context_from_url
+from judgments.utils import get_document_by_uri, get_pdf_uri, search_context_from_url
 
 # suppress weasyprint log spam
 if os.environ.get("SHOW_WEASYPRINT_LOGS") != "True":
     logging.getLogger("weasyprint").handlers = []
 
 
-def get_published_judgment_by_uri(document_uri: str) -> Judgment:
+def get_published_document_by_uri(document_uri: str) -> Judgment:
     try:
-        document = get_judgment_by_uri(document_uri)
+        document = get_document_by_uri(document_uri)
     except JudgmentNotFoundError:
-        raise Http404(f"Judgment {document_uri} was not found")
+        raise Http404(f"Document {document_uri} was not found")
 
     if not document.is_published:
-        raise Http404(f"This Judgment {document_uri} is not available")
+        raise Http404(f"Document {document_uri} is not available")
     return document
 
 
@@ -39,7 +39,7 @@ class PdfDetailView(WeasyTemplateResponseMixin, TemplateView):
     def get_context_data(self, document_uri, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        document = get_published_judgment_by_uri(document_uri)
+        document = get_published_document_by_uri(document_uri)
 
         self.pdf_filename = f"{document.uri}.pdf"
 
@@ -68,7 +68,7 @@ def get_best_pdf(request, document_uri):
 
 
 def detail(request, document_uri):
-    document = get_published_judgment_by_uri(document_uri)
+    document = get_published_document_by_uri(document_uri)
 
     # If the document_uri which was requested isn't the canonical URI of the document, redirect the user
     if document_uri != document.uri:
@@ -90,7 +90,7 @@ def detail(request, document_uri):
 
     linked_document = None
     try:
-        linked_document = get_published_judgment_by_uri(context["linked_document_uri"])
+        linked_document = get_published_document_by_uri(context["linked_document_uri"])
     except Http404:
         context["linked_document_uri"] = ""
 
@@ -121,7 +121,7 @@ def detail(request, document_uri):
 
 
 def detail_xml(_request, document_uri):
-    document = get_published_judgment_by_uri(document_uri)
+    document = get_published_document_by_uri(document_uri)
 
     judgment_xml = document.content_as_xml()
 


### PR DESCRIPTION
## Changes in this PR:

- Generalise judgment variables with document

No end user changes - just internal renaming. The view args changed from judgement_uri to document_uri but that is only exposed in our url routing - we don't have external apis, so that is fine.

## Trello card / Rollbar error (etc)
https://trello.com/c/s6nPDKx6/1152-chore-generalise-pui-references-to-judgment-to-document
