### PR TITLE
Speedup fab run

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -65,12 +65,19 @@ def start(c, container_name=None):
         cmd += f" {container_name}"
     local(cmd)
 
+
 @task
-def run(c):
+def pip(c):
     start(c, "django")
     django_exec("pip install -r requirements/local.txt -U")
     django_exec("DJANGO_SETTINGS_MODULE= django-admin compilemessages")
     django_exec("python manage.py migrate")
+    stop(c, "django")
+
+
+@task
+def runquick(c):
+    start(c, "django")
     django_exec("rm -rf /app/staticfiles")
     django_exec("python manage.py collectstatic")
     try:
@@ -78,6 +85,11 @@ def run(c):
     except KeyboardInterrupt:
         pass
     stop(c, "django")
+
+
+@task(pip, runquick)
+def run(c):
+    ...
 
 
 @task
@@ -115,7 +127,8 @@ def translate(c):
     """
     subprocess.run(
         [
-            "docker", "compose",
+            "docker",
+            "compose",
             "exec",
             "django",
             "bash",
@@ -134,7 +147,8 @@ def test(c):
     # Static analysis
     subprocess.run(
         [
-            "docker", "compose",
+            "docker",
+            "compose",
             "exec",
             "django",
             "mypy",
@@ -145,7 +159,8 @@ def test(c):
     # Pytest
     subprocess.run(
         [
-            "docker", "compose",
+            "docker",
+            "compose",
             "exec",
             "django",
             "pytest",
@@ -158,7 +173,8 @@ def coverage(c):
     # Run pytest with coverage
     subprocess.run(
         [
-            "docker", "compose",
+            "docker",
+            "compose",
             "exec",
             "django",
             "coverage",
@@ -170,7 +186,8 @@ def coverage(c):
     # Generate html report
     subprocess.run(
         [
-            "docker", "compose",
+            "docker",
+            "compose",
             "exec",
             "django",
             "coverage",
@@ -190,7 +207,8 @@ def psql(c, command=None):
     Connect to the local postgres DB using psql
     """
     cmd_list = [
-        "docker", "compose",
+        "docker",
+        "compose",
         "exec",
         "postgres",
         "psql",

--- a/fabfile.py
+++ b/fabfile.py
@@ -25,7 +25,7 @@ LOCAL_DB_DUMP_DIR = "database_dumps"
 
 def container_exec(cmd, container_name="django", check_returncode=False):
     result = subprocess.run(
-        ["docker-compose", "exec", "-T", container_name, "bash", "-c", cmd]
+        ["docker", "compose", "exec", "-T", container_name, "bash", "-c", cmd]
     )
     if check_returncode:
         result.check_returncode()
@@ -52,7 +52,7 @@ def build(c):
     """
     Build (or rebuild) local development containers.
     """
-    local("docker-compose build")
+    local("docker compose build")
 
 
 @task
@@ -60,11 +60,10 @@ def start(c, container_name=None):
     """
     Start the local development environment.
     """
-    cmd = "docker-compose up -d"
+    cmd = "docker compose up -d"
     if container_name:
         cmd += f" {container_name}"
     local(cmd)
-
 
 @task
 def run(c):
@@ -86,7 +85,7 @@ def stop(c, container_name=None):
     """
     Stop the local development environment.
     """
-    cmd = "docker-compose stop"
+    cmd = "docker compose stop"
     if container_name:
         cmd += f" {container_name}"
     local(cmd)
@@ -106,7 +105,7 @@ def sh(c):
     """
     Run bash in a local container (with access to dependencies)
     """
-    subprocess.run(["docker-compose", "exec", "django", "bash"])
+    subprocess.run(["docker", "compose", "exec", "django", "bash"])
 
 
 @task
@@ -116,7 +115,7 @@ def translate(c):
     """
     subprocess.run(
         [
-            "docker-compose",
+            "docker", "compose",
             "exec",
             "django",
             "bash",
@@ -135,7 +134,7 @@ def test(c):
     # Static analysis
     subprocess.run(
         [
-            "docker-compose",
+            "docker", "compose",
             "exec",
             "django",
             "mypy",
@@ -146,7 +145,7 @@ def test(c):
     # Pytest
     subprocess.run(
         [
-            "docker-compose",
+            "docker", "compose",
             "exec",
             "django",
             "pytest",
@@ -159,7 +158,7 @@ def coverage(c):
     # Run pytest with coverage
     subprocess.run(
         [
-            "docker-compose",
+            "docker", "compose",
             "exec",
             "django",
             "coverage",
@@ -171,7 +170,7 @@ def coverage(c):
     # Generate html report
     subprocess.run(
         [
-            "docker-compose",
+            "docker", "compose",
             "exec",
             "django",
             "coverage",
@@ -191,7 +190,7 @@ def psql(c, command=None):
     Connect to the local postgres DB using psql
     """
     cmd_list = [
-        "docker-compose",
+        "docker", "compose",
         "exec",
         "postgres",
         "psql",


### PR DESCRIPTION
Add a fab runquick command for when you've not played with any of the static files, pip installs, migrations etc.