### PR TITLE
Enforce updated translations file in pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Build the Stack
         run: docker-compose build postgres django
 
+      - name: Verify translations
+        run: |
+          docker-compose run --rm django script/makemessages
+          script/verify-translations
+
       - name: Run DB Migrations
         run: docker-compose run --rm django python manage.py migrate --settings=config.settings.test
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ We're using [the built-in django translation module](https://docs.djangoproject.
 3. Update the locale file by running the following command in a `fab sh` shell:
 
    ```
-   python manage.py makemessages --no-obsolete --add-location file -l en_GB
+   script/makemessages
    ```
 
 4. In the generated `.po` file, find the generated translation section, it will be a block like this, with the `msgid` corresponding to the key you added in the template:

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-27 12:34+0000\n"
+"POT-Creation-Date: 2023-08-04 12:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -105,11 +105,13 @@ msgid "accessibilitystatement.title"
 msgstr "Accessibility statement"
 
 #: ds_judgements_public_ui/templates/includes/header_nav.html
+#: ds_judgements_public_ui/templates/layouts/base.html
 msgid "home"
 msgstr "Find case law"
 
 #: ds_judgements_public_ui/templates/includes/header_nav.html
 #: ds_judgements_public_ui/templates/judgment/results.html
+#: ds_judgements_public_ui/templates/layouts/base.html
 #: ds_judgements_public_ui/templates/layouts/judgment.html
 #: ds_judgements_public_ui/templates/layouts/static_content.html
 #: ds_judgements_public_ui/templates/pages/home.html
@@ -134,18 +136,12 @@ msgid "judgment.downloadoptions.title"
 msgstr "Download options"
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
-msgid "judgment.downloadoptions.pdf.cta"
-msgstr "Download this judgment as a PDF"
-
-#: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
 msgid "press_summary.downloadoptions.pdf.cta"
 msgstr "Download this press summary as a PDF"
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
-msgid "judgment.downloadoptions.pdf.description"
-msgstr ""
-"The original format of the judgment as handed down by the court, for "
-"printing and downloading."
+msgid "judgment.downloadoptions.pdf.cta"
+msgstr "Download this judgment as a PDF"
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
 msgid "press_summary.downloadoptions.pdf.description"
@@ -154,12 +150,24 @@ msgstr ""
 "printing and downloading."
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
-msgid "judgment.downloadoptions.xml.cta"
-msgstr "Download this judgment as XML"
+msgid "judgment.downloadoptions.pdf.description"
+msgstr ""
+"The original format of the judgment as handed down by the court, for "
+"printing and downloading."
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
 msgid "press_summary.downloadoptions.xml.cta"
 msgstr "Download this press summary as XML"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+msgid "judgment.downloadoptions.xml.cta"
+msgstr "Download this judgment as XML"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+msgid "press_summary.downloadoptions.xml.description"
+msgstr ""
+"The press summary in machine-readable LegalDocML format for developers, data "
+"scientists and researchers."
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
 msgid "judgment.downloadoptions.xml.description"
@@ -167,11 +175,13 @@ msgstr ""
 "The judgment in machine-readable LegalDocML format for developers, data "
 "scientists and researchers."
 
-#: ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
-msgid "press_summary.downloadoptions.xml.description"
-msgstr ""
-"The press summary in machine-readable LegalDocML format for developers, data "
-"scientists and researchers."
+#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+msgid "judgment.view_press_summary"
+msgstr "View Press Summary"
+
+#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+msgid "judgment.view_judgment"
+msgstr "View Judgment"
 
 #: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
 msgid "judgment.downloadaspdf"
@@ -317,14 +327,6 @@ msgstr "The 'to' date entered is before the 'from' date"
 #: judgments/utils.py
 msgid "search.errors.missing_year_detail"
 msgstr "You must specify a year"
-
-#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
-msgid "judgment.view_press_summary"
-msgstr "View Press Summary"
-
-#: ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
-msgid "judgment.view_judgment"
-msgstr "View Judgment"
 
 #: judgments/views/advanced_search.py
 msgid "search.errors.to_before_from_detail"

--- a/script/makemessages
+++ b/script/makemessages
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+python manage.py makemessages --no-obsolete --add-location file -l en_GB

--- a/script/verify-translations
+++ b/script/verify-translations
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+if git diff -I POT-Creation-Date --exit-code; then
+  echo Translations check passed: all messages are up to date.
+else
+  echo Translations check failed: you may need to run script/makemessages and commit the changes to django.po
+  exit 1
+fi


### PR DESCRIPTION
CI now checks that translations have actually been updated, and will fail a build if not.

This works by running script/makemessage (a new helper script for building translations, so we don't need to keep checking the README for the right invocation), and then script/verify-translations which uses git diff with an ignore pattern for the line which includes the date of last update.

An example of a failed workflow is at https://github.com/nationalarchives/ds-caselaw-editor-ui/actions/runs/5749924858/job/15585691509?pr=1093