### PR TITLE
added an alt text tag to the FCL home logo

### DIFF
--- a/ds_judgements_public_ui/templates/includes/header_nav.html
+++ b/ds_judgements_public_ui/templates/includes/header_nav.html
@@ -1,7 +1,7 @@
 {% load i18n document_utils %}
 <div class="page-header__nav">
   <div class="page-header__site-logo">
-    <a href="{% url "home" %}" id="home-link">{% translate "home" %}</a>
+    <a href="{% url "home" %}" id="home-link" alt="Home of Find case law">{% translate "home" %}</a>
   </div>
   <div class="page-header__breadcrumb">
     <nav class="page-header__breadcrumb-flex-container"


### PR DESCRIPTION
<!-- Amend as appropriate -->
added an alt text tag to the FCL home link
## Changes in this PR:

## Trello card / Rollbar error (etc)
https://trello.com/c/IBBzaGQo/1235-%E2%9C%94%EF%B8%8F-aa-no-alt-tag-on-fcl-home-logo-pui
## Screenshots of UI changes:

### Before
![Screenshot 2023-08-08 at 10 19 59](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/526e0464-e603-4ba1-ad52-7bc94ab1f933)

### After
![Screenshot 2023-08-08 at 10 19 32](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/21494b47-4327-4b33-b06c-136e054be0cc)

- [ ] Requires env variable(s) to be updated
