### PR TITLE
Make npm ci fail on EBADENGINE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN pip install --no-cache-dir --no-index --find-links=/wheels/ /wheels/* \
   && rm -rf /wheels/
 COPY --chown=django:django package-lock.json package-lock.json
 COPY --chown=django:django package.json package.json
-RUN npm ci
+RUN npm ci --engine-strict=true
 COPY --chown=django:django ./compose/production/django/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint
 RUN chmod +x /entrypoint


### PR DESCRIPTION
By default npm does not exit with an error code when the node version is not
the one that a package requires it merely warns that the engine is unsupported
and carries on without installing the package.

This means that Docker builds can succeed and we end up shipping broken images.

```
```

Adding `--engine-strict=true` to `npm ci` makes it fail if it encounters
EBADENGINE

```
```

Which then casues the docker build to fail and we wont ship bad images.


<!-- Amend as appropriate -->

## Changes in this PR:

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated