### PR TITLE
Make npm ci fail on EBADENGINE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN pip install --no-cache-dir --no-index --find-links=/wheels/ /wheels/* \
   && rm -rf /wheels/
 COPY --chown=django:django package-lock.json package-lock.json
 COPY --chown=django:django package.json package.json
-RUN npm ci
+RUN npm ci --engine-strict=true
 COPY --chown=django:django ./compose/production/django/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint
 RUN chmod +x /entrypoint


### PR DESCRIPTION
By default npm does not exit with an error code when the node version is not
the one that a package requires it merely warns that the engine is unsupported
and carries on without installing the package.

This means that Docker builds can succeed and we end up shipping broken images.

```
0.359 npm WARN EBADENGINE Unsupported engine {
0.359 npm WARN EBADENGINE   package: '@webpack-cli/configtest@2.1.1',          0.359 npm WARN EBADENGINE   required: { node: '>=14.15.0' },
0.359 npm WARN EBADENGINE   current: { node: 'v12.22.12', npm: '7.5.2' }       0.359 npm WARN EBADENGINE }
```

Adding `--engine-strict=true` to `npm ci` makes it fail if it encounters
EBADENGINE

```
[python-run-stage  9/17] RUN npm ci --engine-strict=true
0.390 npm ERR! code EBADENGINE                                                 0.392 npm ERR! engine Unsupported engine
0.392 npm ERR! engine Not compatible with your version of node/npm: sass@1.64.2
0.392 npm ERR! notsup Not compatible with your version of node/npm: sass@1.64.20.392 npm ERR! notsup Required: {"node":">=14.0.0"}
0.392 npm ERR! notsup Actual:   {"npm":"7.5.2","node":"v12.22.12"}
0.399
0.399 npm ERR! A complete log of this run can be found in:                     0.399 npm ERR!     /root/.npm/_logs/2023-08-08T10_21_53_906Z-debug.log
```

Which then casues the docker build to fail and we wont ship bad images.