### PR TITLE
Use bookworm to fix version woes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.11-slim-bullseye
+ARG PYTHON_VERSION=3.11-slim-bookworm
 
 
 
@@ -41,7 +41,7 @@ ENV BUILD_ENV ${BUILD_ENVIRONMENT}
 WORKDIR ${APP_HOME}
 
 RUN addgroup --system django \
-    && adduser --system --ingroup django django
+    && adduser --system --ingroup django --home /home/django django
 
 
 # Install required system dependencies


### PR DESCRIPTION
Comparable to https://github.com/nationalarchives/ds-caselaw-editor-ui/pull/1107 -- upgrade Debian to upgrade Node to support upgrades of packages.