### PR TITLE
added a metadescription for the homepage

### DIFF
--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -4,6 +4,8 @@
 <html lang="{{ LANGUAGE_CODE }}">
   <head>
     <meta charset="utf-8" />
+    {% block meta_description %}
+    {% endblock meta_description %}
     {% block robots %}
       <meta name="robots" content="noindex,nofollow" />
     {% endblock robots %}

--- a/ds_judgements_public_ui/templates/pages/home.html
+++ b/ds_judgements_public_ui/templates/pages/home.html
@@ -1,5 +1,9 @@
 {% extends "layouts/base.html" %}
 {% load i18n %}
+{% block meta_description %}
+  <meta name="description"
+        content="Judgments and decisions from 2003 onwards." />
+{% endblock meta_description %}
 {% block robots %}
 {% endblock robots %}
 {% block title %}


### PR DESCRIPTION
<!-- Amend as appropriate -->
Added a meta description to the homepage "Judgments and decisions from 2003 onwards."
## Changes in this PR:

## Trello card / Rollbar error (etc)
https://trello.com/c/Q3j9pb8Z/1055-%E2%9C%94%EF%B8%8F-aa-no-meta-descriptions-present-in-google-search-result-pui
## Screenshots of UI changes:

### Before
![Screenshot 2023-08-14 at 15 40 08](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/401677f2-717f-4cb4-82e8-560615febcf4)

### After
![Screenshot 2023-08-14 at 15 39 18](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/102584881/e74550d5-63cd-4fd9-9b7b-d1cd9c52556e)

- [ ] Requires env variable(s) to be updated
