### PR TITLE
Remove redundant global sass install in dockerfile and instruction in readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
-RUN npm i -g sass
 
 # All absolute dir copies ignore workdir instruction. All relative dir copies are wrt to the workdir instruction
 # copy python dependency wheels from python-build-stage

--- a/README.md
+++ b/README.md
@@ -245,7 +245,6 @@ If you have already made some unsigned commits on a branch before setting up sig
 ### Pre-requisites
 
 - Ensure you have NodeJS & NPM installed.
-- Install SASS globally by running `npm install -g sass`.
 
 ### Dependencies in this repository
 


### PR DESCRIPTION
## Changes in this PR:
- Removed redundant global sass install in dockerfile and instruction in readme

Since https://github.com/nationalarchives/ds-caselaw-public-ui/pull/861 was merged in, we no longer need to manually install sass, we install it through our package.json!

## Trello card / Rollbar error (etc)
https://trello.com/c/WkhvV1VO/1223-eui-pui-set-up-shared-front-end-code-repo-and-add-documenttext-css-to-it