### PR TITLE
Fix the use of the shared module in PUI

### DIFF
--- a/ds_judgements_public_ui/sass/judgmentpdf.scss
+++ b/ds_judgements_public_ui/sass/judgmentpdf.scss
@@ -1,6 +1,6 @@
 @import "includes/variables";
 @import "includes/mixins";
-@import "includes/judgment_text";
+@import "../../node_modules/@nationalarchives/ds-caselaw-frontend/src/main";
 
 html {
   font-size: 12px;

--- a/ds_judgements_public_ui/sass/main.scss
+++ b/ds_judgements_public_ui/sass/main.scss
@@ -10,7 +10,7 @@
 @import "includes/footer";
 
 // Shared
-@import "../../node_modules/@nationalarchives/ds-caselaw-frontend/src/main.scss";
+@import "../../node_modules/@nationalarchives/ds-caselaw-frontend/src/main";
 
 // Components
 @import "includes/animations";


### PR DESCRIPTION
## Changes in this PR:

- Fix the usage of the shared scss.
In particular we had forgotten to update the scss import in `ds_judgements_public_ui/sass/judgmentpdf.scss`

I have also just dropped `.scss` from the import as that is the convention we use in this repo.

I hadn't verified this properly before as I just ran `npm run start-sass` but not `npm run build`

`npm run build` did give a complaint about `@import "includes/judgment_text";` since it was still referenced in `ds_judgements_public_ui/sass/judgmentpdf.scss`

## Trello card / Rollbar error (etc)
https://trello.com/c/WkhvV1VO/1223-eui-pui-set-up-shared-front-end-code-repo-and-add-documenttext-css-to-it