### PR TITLE
❓ Coerce rollbar config path to a string

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -127,7 +127,7 @@ LOGGING = {
 ROLLBAR = {
     "access_token": env("ROLLBAR_ACCESS_TOKEN"),
     "environment": env("ROLLBAR_ENV"),
-    "root": ROOT_DIR,
+    "root": str(ROOT_DIR),
 }
 
 rollbar.init(**ROLLBAR)


### PR DESCRIPTION
We have regular issues with errors ending in:

```
During handling of the above exception, another exception occurred: Traceback (most recent call last):
File "/usr/local/lib/python3.11/site-packages/rollbar/__init__.py", line 1026, in _add_locals_data if arginfo.locals and _check_add_locals(cur_frame, frame_num, num_frames):
File "/usr/local/lib/python3.11/site-packages/rollbar/__init__.py", line 1129, in _check_add_locals ('root' in SETTINGS and (frame.get('filename') or '').lower().startswith((SETTINGS['root'] or '').lower()))))
AttributeError: 'PosixPath' object has no attribute 'lower'
```

https://github.com/rollbar/pyrollbar/issues/345 suggests this is caused by rollbar reciving a PosixPath not a string, so we coerce it before passing it to the config.