### PR TITLE
Move source of SASS colour variables to shared repository

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_variables.scss
+++ b/ds_judgements_public_ui/sass/includes/_variables.scss
@@ -1,30 +1,8 @@
+@import "../../../node_modules/@nationalarchives/ds-caselaw-frontend/src/includes/variables/colours";
+
 $spacer__unit: 1rem;
 
-$color__almost-black: #121212;
-$color__light-pink: #fbe2bc;
-$color__white: #fff;
-$color__light-grey: #efefef;
-$color__dark-blue: #134571;
-$color__grey: #ddd;
-$color__dark-grey: #555;
-$color__black: #000;
-$color__highlight-blue: #0066cc;
-$color__yellow: #ffb952;
-$color__aqua-blue: #037091;
-
-$color__link-blue: $color__aqua-blue;
-$color__link-blue-hover: $color__dark-blue;
-$color__link-blue-focus: $color__dark-blue;
-$color__link-blue-visited: #4c2c92;
-$color__link-blue-active: #1e1e2a;
-
-$color__focus-blue-outline: $color__dark-blue;
-$color__cta-background: $color__aqua-blue;
-$color__cta-background-hover: $color__dark-blue;
-
 $gutter_unit: 25px;
-$color__success: #336600;
-$color__failure: #cc3300;
 
 $grid__breakpoint-small: 576px;
 $grid__breakpoint-medium: 768px;


### PR DESCRIPTION
**Watch out:** Merge [the frontend PR](https://github.com/nationalarchives/ds-caselaw-frontend/pull/11) before this one!

We ran into a SASS compilation bug because a colour was available in EUI but not PUI.

Fix this by [moving all of the colours into the frontend shared SASS](https://github.com/nationalarchives/ds-caselaw-frontend/pull/11), and updating frontends to use the shared colours instead of maintaining their own.