### PR TITLE
Build scss in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,21 @@ on:
   merge_group:
 
 jobs:
+  build-scss:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v4
+
+      - name: Set up node
+        uses: actions/setup-node@v3.8.1
+
+      - name: Install node dependencies
+        run: npm ci
+
+      - name: Build scss
+        run: npm run build
+
   linter:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Changes in this PR:
- Build scss in CI

so that we catch our scss issues in CI, rather than at deployment like we have experienced a few times.

I considered having this in the GH action job where we build the django docker container but I thought we'd rather have this run in parallel.

Once https://github.com/nationalarchives/ds-caselaw-public-ui/pull/885  is merged in, i will rebase off main and the build will then hopefully pass.

## Trello card / Rollbar error (etc)

https://trello.com/c/VebppEVb/1342-build-scss-in-ci

example of the step working: ![Screenshot 2023-09-11 at 12 36 53](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/42998618/93edfb57-e847-459e-b162-805dc677afd7)