### PR TITLE
Breadcrumbs now render from structured data

### DIFF
--- a/ds_judgements_public_ui/templates/judgment/detail.html
+++ b/ds_judgements_public_ui/templates/judgment/detail.html
@@ -7,20 +7,6 @@
   {% if context.page_title %}{{ context.page_title }} -{% endif %}
   {% translate "common.findcaselaw" %}
 {% endblock title %}
-{% block breadcrumbs %}
-  {% if context.document_noun == "press summary" %}
-    <li>
-      {% if context.linked_document_uri %}
-        <a href="{% url 'detail' context.linked_document_uri %}">{{ context.page_title|get_title_to_display_in_html:context.document_noun }}</a>
-      {% else %}
-        <a>{{ context.page_title|get_title_to_display_in_html:context.document_noun }}</a>
-      {% endif %}
-    </li>
-    <li>Press Summary</li>
-  {% else %}
-    <li>{{ context.page_title }}</li>
-  {% endif %}
-{% endblock breadcrumbs %}
 {% block precontent %}
   {% include "includes/judgment_text_toolbar.html" %}
 {% endblock precontent %}

--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -49,13 +49,18 @@
                 <ol>
                   <li>
                     <span class="page-header__breadcrumb-you-are-in">You are in:</span>
-                    {% if title == "home" %}
-                      {% translate "common.findcaselaw" %}
-                    {% else %}
-                      <a href="{% url 'home' %}">{% translate "common.findcaselaw" %}</a>
-                    {% endif %}
+                    <a href="{% url 'home' %}">{% translate "common.findcaselaw" %}</a>
                   </li>
                   {% block breadcrumbs %}
+                    {% for breadcrumb in breadcrumbs %}
+                      {% if breadcrumb.url %}
+                        <li>
+                          <a href="{{ breadcrumb.url }}">{{ breadcrumb.text }}</a>
+                        </li>
+                      {% else %}
+                        <li>{{ breadcrumb.text }}</li>
+                      {% endif %}
+                    {% endfor %}
                   {% endblock breadcrumbs %}
                 </ol>
               </nav>

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -110,11 +110,27 @@ def detail(request, document_uri):
         else reverse("detail_pdf", args=[document.uri])
     )
 
+    if document.document_noun == "press summary":
+        breadcrumbs = [
+            {
+                "url": "/" + context["linked_document_uri"],
+                "text": document.name.removeprefix("Press Summary of "),
+            },
+            {
+                "text": "Press Summary",
+            },
+        ]
+    else:
+        breadcrumbs = [
+            {"text": document.name},
+        ]
+
     return TemplateResponse(
         request,
         "judgment/detail.html",
         context={
             "context": context,
+            "breadcrumbs": breadcrumbs,
             "feedback_survey_type": "judgment",  # TODO: update the survey to allow for generalisation to `document`
             # https://trello.com/c/l0iBFM1e/1151-update-survey-to-account-for-judgment-the-fact-that-we-have-press-summaries-as-well-as-judgments-now
             "feedback_survey_document_uri": document.uri,


### PR DESCRIPTION
The breadcrumbs now use the `breadcrumbs` array in the context to build and render a list from structured data.

For templates with hardcoded breadcrumbs, these can be overridden with the `breadcrumbs` block as previously.