### PR TITLE
make document nav link copy consistent

### DIFF
--- a/ds_judgements_public_ui/templates/includes/help_end_document_marker.html
+++ b/ds_judgements_public_ui/templates/includes/help_end_document_marker.html
@@ -1,5 +1,5 @@
 <div class="help-end-document-marker" id="end-of-document">
   <div class="help-end-document-marker__top-link">
-    <a href="#start-of-document">Back to top</a>
+    <a href="#start-of-document">Back to start</a>
   </div>
 </div>

--- a/ds_judgements_public_ui/templates/includes/judgment_end_document_marker.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_end_document_marker.html
@@ -2,6 +2,6 @@
   <div class="judgment-end-document-marker__top-link">
     <span>End of document</span>
     <br />
-    <a href="#start-of-document">Back to top</a>
+    <a href="#start-of-document">Back to start</a>
   </div>
 </div>

--- a/ds_judgements_public_ui/templates/judgment/detail.html
+++ b/ds_judgements_public_ui/templates/judgment/detail.html
@@ -26,7 +26,7 @@
   {% include "includes/judgment_end_document_marker.html" %}
   <div id="js-document-navigation-links-end"
        class="document-navigation-links">
-    <a class="up" href="#start-of-document">Back to top</a>
+    <a class="up" href="#start-of-document">Back to start</a>
   </div>
 {% endblock content %}
 {% block postcontent %}


### PR DESCRIPTION

## Changes in this PR:
Tiny copy change in the document skip to bottom /top links requested by Gaz