### PR TITLE
Search date parser now returns a real `date` instead of a yyyy-mm-dd string

### DIFF
--- a/judgments/test_date_parsing.py
+++ b/judgments/test_date_parsing.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import Dict
 
 from django.test import TestCase
@@ -41,7 +42,7 @@ class TestDateParsing(TestCase):
         """
         params = {"date": "", "date_day": "3", "date_month": "1", "date_year": "2020"}
         parsed = parse_date_parameter(params, "date")
-        self.assertEqual(parsed, "2020-01-03")
+        self.assertEqual(parsed, date(2020, 1, 3))
 
     def test_constructs_a_date_from_date_parts(self):
         """
@@ -49,7 +50,7 @@ class TestDateParsing(TestCase):
         """
         params = {"date_day": "3", "date_month": "1", "date_year": "2020"}
         parsed = parse_date_parameter(params, "date")
-        self.assertEqual(parsed, "2020-01-03")
+        self.assertEqual(parsed, date(2020, 1, 3))
 
     def test_returns_none_if_no_date_provided(self):
         """
@@ -65,7 +66,7 @@ class TestDateParsing(TestCase):
         """
         params = {"date_month": "5", "date_year": "2020"}
         parsed = parse_date_parameter(params, "date")
-        self.assertEqual(parsed, "2020-05-01")
+        self.assertEqual(parsed, date(2020, 5, 1))
 
     def test_returns_january_when_no_month(self):
         """
@@ -73,7 +74,7 @@ class TestDateParsing(TestCase):
         """
         params = {"date_year": "2020"}
         parsed = parse_date_parameter(params, "date")
-        self.assertEqual(parsed, "2020-01-01")
+        self.assertEqual(parsed, date(2020, 1, 1))
 
     def test_returns_none_if_year_is_blank(self):
         """When a year parameter is provided but empty, it returns none"""
@@ -85,7 +86,7 @@ class TestDateParsing(TestCase):
         """Blank months and days are treated as undefined, and default to the first month / day."""
         params = {"date_year": "2009", "date_month": "", "date_day": ""}
         parsed = parse_date_parameter(params, "date")
-        self.assertEqual(parsed, "2009-01-01")
+        self.assertEqual(parsed, date(2009, 1, 1))
 
     def test_returns_december_when_no_month_and_default_to_last_selected(self):
         """
@@ -94,7 +95,7 @@ class TestDateParsing(TestCase):
         """
         params = {"date_year": "2020"}
         parsed = parse_date_parameter(params, "date", default_to_last=True)
-        self.assertEqual(parsed, "2020-12-31")
+        self.assertEqual(parsed, date(2020, 12, 31))
 
     def test_returns_lastday_long_month_when_year_and_month_given(self):
         """
@@ -103,7 +104,7 @@ class TestDateParsing(TestCase):
         """
         params = {"date_month": "5", "date_year": "2020"}
         parsed = parse_date_parameter(params, "date", default_to_last=True)
-        self.assertEqual(parsed, "2020-05-31")
+        self.assertEqual(parsed, date(2020, 5, 31))
 
     def test_returns_lastday_short_month_when_year_and_month_given(self):
         """
@@ -112,7 +113,7 @@ class TestDateParsing(TestCase):
         """
         params = {"date_month": "2", "date_year": "2021"}
         parsed = parse_date_parameter(params, "date", default_to_last=True)
-        self.assertEqual(parsed, "2021-02-28")
+        self.assertEqual(parsed, date(2021, 2, 28))
 
     def test_returns_lastday_month_when_leap_year_and_month_given(self):
         """
@@ -121,7 +122,7 @@ class TestDateParsing(TestCase):
         """
         params = {"date_month": "2", "date_year": "2020"}
         parsed = parse_date_parameter(params, "date", default_to_last=True)
-        self.assertEqual(parsed, "2020-02-29")
+        self.assertEqual(parsed, date(2020, 2, 29))
 
     def test_raises_error_when_a_silly_month_is_given(self):
         """
@@ -136,3 +137,11 @@ class TestDateParsing(TestCase):
         """
         params = {"date_month": "04", "date_day": "31", "date_year": "2020"}
         self.assertRaises(ValueError, parse_date_parameter, params, "date")
+
+    def test_checks_return_date_format_as_day_month_year(self):
+        """
+        Checks date is provided in day, month, year format.
+        """
+        params = {"date_day": "3", "date_month": "1", "date_year": "2020"}
+        parsed = parse_date_parameter(params, "date")
+        self.assertEqual(parsed, date(2020, 1, 3))

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -1,7 +1,7 @@
 import math
 import re
 from calendar import monthrange
-from datetime import datetime
+from datetime import date, datetime
 from typing import Optional, TypedDict
 from urllib.parse import parse_qs, urlparse
 
@@ -190,7 +190,7 @@ def parse_parameter_as_int(params, parameter_name, default=None):
         return default
 
 
-def parse_date_parameter(params, param_name, default_to_last=False):
+def parse_date_parameter(params, param_name, default_to_last=False) -> Optional[date]:
     year_param_name = f"{param_name}_year"
     month_param_name = f"{param_name}_month"
     day_param_name = f"{param_name}_day"
@@ -204,12 +204,12 @@ def parse_date_parameter(params, param_name, default_to_last=False):
         default_day = monthrange(year, month)[1] if default_to_last else 1
         day = parse_parameter_as_int(params, day_param_name, default=default_day)
 
-        dt = datetime(year, month, day)
-        return dt.strftime("%Y-%m-%d")
+        return date(year, month, day)
     elif parameter_provided(params, month_param_name) or parameter_provided(
         params, day_param_name
     ):
         raise ValueError(gettext("search.errors.missing_year_detail"))
+    return None
 
 
 def get_document_by_uri(document_uri: str) -> Document:


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Bug fix : update date filters  from yyyy-mm-dd to dd-mm-yyyy
## Trello card / Rollbar error (etc)
https://trello.com/c/eSE97UiL/1094-pui-date-filters-read-yyyy-mm-dd-should-read-dd-mm-yyyy
## Screenshots of UI changes:

### Before
![before](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/e486883d-61f9-4c7d-8151-6d431150daad)

### After
![after](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/32126a92-0cb6-4833-9f80-4809eeea7aa1)

- [ ] Requires env variable(s) to be updated
