### PR TITLE
Reinstate breadcrumbs on search results

### DIFF
--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -173,3 +173,25 @@ class TestSearchResults(TestCase):
         self.assertContains(
             response, f'<div class="page-notification--failure">{message}</div>'
         )
+
+
+class TestSearchBreadcrumbs(TestCase):
+    @patch("judgments.views.advanced_search.api_client")
+    @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
+    def test_search_breadcrumbs_without_query_string(
+        self, mock_search_judgments_and_parse_response, mock_api_client
+    ):
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
+        response = self.client.get("/judgments/search")
+        assert response.context["breadcrumbs"] == [{"text": "Search results"}]
+
+    @patch("judgments.views.advanced_search.api_client")
+    @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
+    def test_search_breadcrumbs_with_query_string(
+        self, mock_search_judgments_and_parse_response, mock_api_client
+    ):
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
+        response = self.client.get("/judgments/search?query=waltham+forest")
+        assert response.context["breadcrumbs"] == [
+            {"text": 'Search results for "waltham forest"'}
+        ]

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -132,11 +132,18 @@ def advanced_search(request):
 
         except MarklogicResourceNotFoundError:
             raise Http404("Search failed")  # TODO: This should be something else!
+
+        # If we have a search query, stick it in the breadcrumbs. Otherwise, don't bother.
+        if query_params["query"]:
+            breadcrumbs = [{"text": f'Search results for "{query_params["query"]}"'}]
+        else:
+            breadcrumbs = [{"text": "Search results"}]
         return TemplateResponse(
             request,
             "judgment/results.html",
             context={
                 "context": context,
+                "breadcrumbs": breadcrumbs,
                 "feedback_survey_type": "structured_search",
             },
         )


### PR DESCRIPTION
These had gone missing at some point in the past; search results now have breadcrumbs to help users orient themselves.

This does _not_ reinstate the 'back to search' behaviour or breadcrumb trail for viewing a judgment via search. This should be some future work.