### PR TITLE
Validate that inputted search years are within court date range

### DIFF
--- a/judgments/test_date_parsing.py
+++ b/judgments/test_date_parsing.py
@@ -145,3 +145,15 @@ class TestDateParsing(TestCase):
         params = {"date_day": "3", "date_month": "1", "date_year": "2020"}
         parsed = parse_date_parameter(params, "date")
         self.assertEqual(parsed, date(2020, 1, 3))
+
+    def test_raises_error_when_a_year_before_first_judgment_given(self):
+        params = {"date_year": "1999"}
+        self.assertRaises(
+            ValueError, parse_date_parameter, params, "date", start_year=2020
+        )
+
+    def test_raises_error_when_a_year_after_last_judgment_given(self):
+        params = {"date_year": "2024"}
+        self.assertRaises(
+            ValueError, parse_date_parameter, params, "date", end_year=2023
+        )

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -190,7 +190,9 @@ def parse_parameter_as_int(params, parameter_name, default=None):
         return default
 
 
-def parse_date_parameter(params, param_name, default_to_last=False) -> Optional[date]:
+def parse_date_parameter(
+    params, param_name, default_to_last=False, start_year=None, end_year=None
+) -> Optional[date]:
     year_param_name = f"{param_name}_year"
     month_param_name = f"{param_name}_month"
     day_param_name = f"{param_name}_day"
@@ -198,6 +200,13 @@ def parse_date_parameter(params, param_name, default_to_last=False) -> Optional[
         return params[param_name]
     elif parameter_provided(params, year_param_name):
         year = parse_parameter_as_int(params, year_param_name)
+
+        if start_year and year < start_year:
+            raise ValueError("Year must not be before %s" % start_year)
+
+        if end_year and year > end_year:
+            raise ValueError("Year must not be after %s" % end_year)
+
         default_month = 12 if default_to_last else 1
         month = parse_parameter_as_int(params, month_param_name, default=default_month)
 

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -202,10 +202,10 @@ def parse_date_parameter(
         year = parse_parameter_as_int(params, year_param_name)
 
         if start_year and year < start_year:
-            raise ValueError("Year must not be before %s" % start_year)
+            raise ValueError("Find Case Law has no judgments before %s" % start_year)
 
         if end_year and year > end_year:
-            raise ValueError("Year must not be after %s" % end_year)
+            raise ValueError("Find Case Law has no judgments after %s" % end_year)
 
         default_month = 12 if default_to_last else 1
         month = parse_parameter_as_int(params, month_param_name, default=default_month)

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -10,7 +10,7 @@ from django.template.response import TemplateResponse
 from django.utils.translation import gettext
 from ds_caselaw_utils import courts as all_courts
 
-from judgments.models import SearchFormErrors
+from judgments.models import CourtDates, SearchFormErrors
 from judgments.utils import (
     MAX_RESULTS_PER_PAGE,
     api_client,
@@ -26,14 +26,25 @@ def advanced_search(request):
     params = request.GET
     errors = SearchFormErrors()
     try:
-        from_date = parse_date_parameter(params, "from")
+        from_date = parse_date_parameter(
+            params,
+            "from",
+            start_year=CourtDates.min_year(),
+            end_year=CourtDates.max_year(),
+        )
     except ValueError as error:
         from_date = None
         errors.add_error(
             gettext("search.errors.from_date_headline"), "from_date", str(error)
         )
     try:
-        to_date = parse_date_parameter(params, "to", default_to_last=True)
+        to_date = parse_date_parameter(
+            params,
+            "to",
+            default_to_last=True,
+            start_year=CourtDates.min_year(),
+            end_year=CourtDates.max_year(),
+        )
     except ValueError as error:
         to_date = None
         errors.add_error(


### PR DESCRIPTION
## Changes in this PR:

If users search for judgments outside the range of our collection, warn them early. The copy may need a tweak

`./manage.py recalculate_court_dates --write` needs to have been run in the past for this to work (it should be run by cron on staging and prod, but may lead to some head-scratching locally if no errors are raised)


## Trello card / Rollbar error (etc)
https://trello.com/c/wZwFBPAH/1086-pui-dont-allow-years-in-search-outside-our-collection-date
## Screenshots of UI changes:
<img width="1208" alt="Screenshot 2023-10-03 at 18 34 51" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/633cb475-e237-4a0b-81cf-7442cb2e63bd">

