### PR TITLE
re-order filters on search pages

### DIFF
--- a/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
@@ -82,7 +82,6 @@
     </fieldset>
   </div>
 </div>
-{% include "includes/structured_search_additional_inputs.html" %}
 <div class="structured-search__multi-fields-panel">
   <div class="structured-search__specific-field-container">
     <label for="party_name"

--- a/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
@@ -1,12 +1,4 @@
 {% load court_utils feature_flags errors %}
-<div class="structured-search__single-field-panel">
-  <div class="structured-search__limit-to-container">
-    <fieldset>
-      <legend class="structured-search__limit-to-label">From specific courts or tribunals</legend>
-      <div class="structured-search__court-options" id="court">{% include "includes/courts_options.html" %}</div>
-    </fieldset>
-  </div>
-</div>
 <div class="structured-search__multi-fields-panel">
   <div class="structured-search__limit-to-container">
     <fieldset class="{% if context.errors|has_errors_for_field:"from_date" %}with-errors{% endif %}">
@@ -82,6 +74,15 @@
     </fieldset>
   </div>
 </div>
+<div class="structured-search__single-field-panel">
+  <div class="structured-search__limit-to-container">
+    <fieldset>
+      <legend class="structured-search__limit-to-label">From specific courts or tribunals</legend>
+      <div class="structured-search__court-options" id="court">{% include "includes/courts_options.html" %}</div>
+    </fieldset>
+  </div>
+</div>
+{% include "includes/structured_search_additional_inputs.html" %}
 <div class="structured-search__multi-fields-panel">
   <div class="structured-search__specific-field-container">
     <label for="party_name"

--- a/ds_judgements_public_ui/templates/pages/structured_search.html
+++ b/ds_judgements_public_ui/templates/pages/structured_search.html
@@ -23,7 +23,10 @@
       <div class="structured-search">
         <div id="js-results-facets"
              class="structured-search__filter-options js-results-facets">
-          <div class="structured-search__container">{% include "includes/results_filters_inputs.html" %}</div>
+          <div class="structured-search__container">
+            {% include "includes/structured_search_additional_inputs.html" %}
+            {% include "includes/results_filters_inputs.html" %}
+          </div>
         </div>
       </div>
     </div>

--- a/ds_judgements_public_ui/templates/pages/structured_search.html
+++ b/ds_judgements_public_ui/templates/pages/structured_search.html
@@ -23,10 +23,7 @@
       <div class="structured-search">
         <div id="js-results-facets"
              class="structured-search__filter-options js-results-facets">
-          <div class="structured-search__container">
-            {% include "includes/structured_search_additional_inputs.html" %}
-            {% include "includes/results_filters_inputs.html" %}
-          </div>
+          <div class="structured-search__container">{% include "includes/results_filters_inputs.html" %}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Re-order filters on search pages
## Trello card / Rollbar error (etc)
https://trello.com/c/GIFCMk3B/1039-pui-re-order-filter-boxes-so-court-lists-are-lower
## Screenshots of UI changes:

### Before
![before-structured-search](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/5777e237-a10d-4397-a9cd-021f154418c3)
![before-filter-search](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/ce58fa06-2e8a-467a-9f93-d94d84fd99eb)

### After
![Screenshot from 2023-10-05 13-43-49](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/ad196938-e1d4-4cca-87c7-7aa355e9f6a1)

![after-filter-page](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/b2773cfb-f3f8-485e-a495-079d9857d9d7)


- [ ] Requires env variable(s) to be updated
