### PR TITLE
First pass at heirarchical courts list

### DIFF
--- a/config/views.py
+++ b/config/views.py
@@ -70,7 +70,8 @@ class StructuredSearchView(TemplateViewWithContext):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["context"]["courts"] = courts.get_selectable_groups()
+        context["context"]["courts"] = courts.get_grouped_selectable_courts()
+        context["context"]["tribunals"] = courts.get_grouped_selectable_tribunals()
         context["feedback_survey_type"] = "structured_search"
         return context
 

--- a/config/views.py
+++ b/config/views.py
@@ -70,7 +70,7 @@ class StructuredSearchView(TemplateViewWithContext):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["context"]["courts"] = courts.get_selectable()
+        context["context"]["courts"] = courts.get_selectable_groups()
         context["feedback_survey_type"] = "structured_search"
         return context
 

--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -252,6 +252,16 @@
     }
   }
 
+  &__court-group-label {
+    margin-top: calc(0.5 * $spacer__unit);
+    margin-bottom: calc(0.5 * $spacer__unit);
+  }
+
+  &__court-group {
+    margin-left: calc(2 * $spacer__unit);
+    break-inside: avoid;
+  }
+
   &__court-option-label {
     margin-left: calc(0.5 * $spacer__unit);
   }

--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -198,9 +198,13 @@
     width: 100%;
 
     @media (min-width: $grid__breakpoint-medium) {
-      column-count: 2;
-      column-gap: calc(2 * $spacer__unit);
+      display: flex;
+      gap: calc(2 * $spacer__unit);
     }
+  }
+
+  &__court-options-column {
+    break-inside: avoid;
   }
 
   &__court-option {
@@ -254,6 +258,8 @@
 
   &__court-group-label {
     margin-top: calc(0.5 * $spacer__unit);
+    line-height: calc(1.5 * $spacer__unit);
+    vertical-align: baseline;
     margin-bottom: calc(0.5 * $spacer__unit);
   }
 
@@ -264,6 +270,8 @@
 
   &__court-option-label {
     margin-left: calc(0.5 * $spacer__unit);
+    line-height: calc(1.5 * $spacer__unit);
+    vertical-align: baseline;
   }
   &__court-date-range {
     color: $color__dark-grey;

--- a/ds_judgements_public_ui/templates/includes/browse_by_court.html
+++ b/ds_judgements_public_ui/templates/includes/browse_by_court.html
@@ -9,7 +9,7 @@
           {% for court in courts %}
             <li class="judgment-browse__list-item">
               <a class="judgment-browse__link"
-                 href="{% url "search" %}?court={{ court.canonical_param }}">{{ court.list_name }}</a>
+                 href="{% url "search" %}?court={{ court.canonical_param }}">{{ court.name }}</a>
               <span class="judgment-browse__year-range">&mdash; {{ court|get_court_date_range }}</span>
             </li>
           {% endfor %}
@@ -24,7 +24,7 @@
           {% for tribunal in tribunals %}
             <li class="judgment-browse__list-item">
               <a class="judgment-browse__link"
-                 href="{% url "search" %}?court={{ tribunal.canonical_param }}">{{ tribunal.list_name }}</a>
+                 href="{% url "search" %}?court={{ tribunal.canonical_param }}">{{ tribunal.name }}</a>
               <span class="judgment-browse__year-range">&mdash; {{ tribunal|get_court_date_range }}</span>
             </li>
           {% endfor %}

--- a/ds_judgements_public_ui/templates/includes/court_option.html
+++ b/ds_judgements_public_ui/templates/includes/court_option.html
@@ -1,0 +1,14 @@
+{% load query_filters court_utils %}
+<div class="structured-search__court-option">
+  <label for="court_{{ court.canonical_param }}">
+    <input type="checkbox"
+           name="court"
+           value="{{ court.canonical_param }}"
+           id="court_{{ court.canonical_param }}"
+           {% for alias in context.court %}{% if alias in court.param_aliases %}checked="checked"{% endif %}
+           {% endfor %} />
+    <span class="structured-search__court-option-label">{{ court.name }}
+      <span class="structured-search__court-date-range">&mdash; {{ court|get_court_date_range }}</span>
+    </span>
+  </label>
+</div>

--- a/ds_judgements_public_ui/templates/includes/court_option.html
+++ b/ds_judgements_public_ui/templates/includes/court_option.html
@@ -1,5 +1,5 @@
 {% load query_filters court_utils %}
-<div class="structured-search__court-option">
+<div class="structured-search__court-option {% if ungrouped %}ungrouped{% endif %}">
   <label for="court_{{ court.canonical_param }}">
     <input type="checkbox"
            name="court"
@@ -7,7 +7,7 @@
            id="court_{{ court.canonical_param }}"
            {% for alias in context.court %}{% if alias in court.param_aliases %}checked="checked"{% endif %}
            {% endfor %} />
-    <span class="structured-search__court-option-label">{{ court.name }}
+    <span class="structured-search__court-option-label">{{ court.grouped_name }}
       <span class="structured-search__court-date-range">&mdash; {{ court|get_court_date_range }}</span>
     </span>
   </label>

--- a/ds_judgements_public_ui/templates/includes/courts_options.html
+++ b/ds_judgements_public_ui/templates/includes/courts_options.html
@@ -1,4 +1,4 @@
-{% for group in context.courts %}
+{% for group in courts %}
   {% if group.display_heading %}
     <div class="structured-search__court-group-label">{{ group.name }}</div>
     <div class="structured-search__court-group">
@@ -8,7 +8,7 @@
     </div>
   {% else %}
     {% for court in group.courts %}
-      {% include "includes/court_option.html" with court=court %}
+      {% include "includes/court_option.html" with court=court ungrouped=True %}
     {% endfor %}
   {% endif %}
 {% endfor %}

--- a/ds_judgements_public_ui/templates/includes/courts_options.html
+++ b/ds_judgements_public_ui/templates/includes/courts_options.html
@@ -1,16 +1,14 @@
-{% load query_filters court_utils %}
-{% for court in context.courts %}
-  <div class="structured-search__court-option">
-    <label for="court_{{ court.canonical_param }}">
-      <input type="checkbox"
-             name="court"
-             value="{{ court.canonical_param }}"
-             id="court_{{ court.canonical_param }}"
-             {% for alias in context.court %}{% if alias in court.param_aliases %}checked="checked"{% endif %}
-             {% endfor %} />
-      <span class="structured-search__court-option-label">{{ court.name }}
-        <span class="structured-search__court-date-range">&mdash; {{ court|get_court_date_range }}</span>
-      </span>
-    </label>
-  </div>
+{% for group in context.courts %}
+  {% if group.display_heading %}
+    <div class="structured-search__court-group-label">{{ group.name }}</div>
+    <div class="structured-search__court-group">
+      {% for court in group.courts %}
+        {% include "includes/court_option.html" with court=court %}
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for court in group.courts %}
+      {% include "includes/court_option.html" with court=court %}
+    {% endfor %}
+  {% endif %}
 {% endfor %}

--- a/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
@@ -78,7 +78,14 @@
   <div class="structured-search__limit-to-container">
     <fieldset>
       <legend class="structured-search__limit-to-label">From specific courts or tribunals</legend>
-      <div class="structured-search__court-options" id="court">{% include "includes/courts_options.html" %}</div>
+      <div class="structured-search__court-options" id="court">
+        <div class="structured-search__court-options-column">
+          {% include "includes/courts_options.html" with courts=context.courts %}
+        </div>
+        <div class="structured-search__court-options-column">
+          {% include "includes/courts_options.html" with courts=context.tribunals %}
+        </div>
+      </div>
     </fieldset>
   </div>
 </div>

--- a/ds_judgements_public_ui/templates/pages/about_this_service.html
+++ b/ds_judgements_public_ui/templates/pages/about_this_service.html
@@ -89,15 +89,15 @@
   <h3>Date ranges for judgments and decisions available on Find Case Law</h3>
   <ul class="court-listing">
     {% for group in context.courts %}
-      {% if group.name %}
+      {% if group.display_heading %}
         <li>
           <span>{{ group.name }}</span>
           <ul>
-            {% for court in group.courts %}<li>{{ court.list_name }} &mdash;{{ court|get_court_date_range }}</li>{% endfor %}
+            {% for court in group.courts %}<li>{{ court.grouped_name }} &mdash; {{ court|get_court_date_range }}</li>{% endfor %}
           </ul>
         </li>
       {% else %}
-        {% for court in group.courts %}<li>{{ court.list_name }} &mdash;{{ court|get_court_date_range }}</li>{% endfor %}
+        {% for court in group.courts %}<li>{{ court.grouped_name }} &mdash; {{ court|get_court_date_range }}</li>{% endfor %}
       {% endif %}
     {% endfor %}
   </ul>

--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -103,10 +103,10 @@ class TestSearchResults(TestCase):
                  draggable="false"
                  class="results-search-component__removable-options-link"
                  href="/judgments/search?query=&amp;court=ewhc/ipec&amp;judge=&amp;party=&amp;neutral_citation=&amp;specific_keyword=&amp;order=&amp;from=&amp;from_day=&amp;from_month=&amp;from_year=&amp;to=&amp;to_day=&amp;to_month=&amp;to_year=&amp;per_page=&amp;page="
-                 title="Chancery Division of the High Court">
+                 title="High Court (Chancery Division)">
                 <span class="results-search-component__removable-options-value">
                   <span class="results-search-component__removable-options-value-text">
-                    Chancery Division of the High Court
+                    High Court (Chancery Division)
                   </span>
                 </span>
               </a>
@@ -118,10 +118,10 @@ class TestSearchResults(TestCase):
                  draggable="false"
                  class="results-search-component__removable-options-link"
                  href="/judgments/search?query=&amp;court=ewhc/ch&amp;judge=&amp;party=&amp;neutral_citation=&amp;specific_keyword=&amp;order=&amp;from=&amp;from_day=&amp;from_month=&amp;from_year=&amp;to=&amp;to_day=&amp;to_month=&amp;to_year=&amp;per_page=&amp;page="
-                 title="Intellectual Property Enterprise Court">
+                 title="High Court (Intellectual Property Enterprise Court)">
                 <span class="results-search-component__removable-options-value">
                   <span class="results-search-component__removable-options-value-text">
-                    Intellectual Property Enterprise Court
+                    High Court (Intellectual Property Enterprise Court)
                   </span>
                 </span>
               </a>

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -96,7 +96,8 @@ def advanced_search(request):
     context = {
         "errors": errors,
         "query": query_params["query"],
-        "courts": all_courts.get_selectable_groups(),
+        "courts": all_courts.get_grouped_selectable_courts(),
+        "tribunals": all_courts.get_grouped_selectable_tribunals(),
         "query_params": query_params,
     }
 

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -96,7 +96,7 @@ def advanced_search(request):
     context = {
         "errors": errors,
         "query": query_params["query"],
-        "courts": all_courts.get_selectable(),
+        "courts": all_courts.get_selectable_groups(),
         "query_params": query_params,
     }
 

--- a/judgments/views/browse.py
+++ b/judgments/views/browse.py
@@ -49,8 +49,8 @@ def browse(request, court=None, subdivision=None, year=None):
         context["total"] = search_response.total
         context["per_page"] = per_page
         context["paginator"] = paginator(page, search_response.total, per_page)
-        context["courts"] = all_courts.get_selectable_groups()
-
+        context["courts"] = all_courts.get_grouped_selectable_courts()
+        context["tribunals"] = all_courts.get_grouped_selectable_tribunals()
         context["page_title"] = gettext("results.search.title")
 
     except MarklogicResourceNotFoundError:

--- a/judgments/views/browse.py
+++ b/judgments/views/browse.py
@@ -49,7 +49,7 @@ def browse(request, court=None, subdivision=None, year=None):
         context["total"] = search_response.total
         context["per_page"] = per_page
         context["paginator"] = paginator(page, search_response.total, per_page)
-        context["courts"] = all_courts.get_selectable()
+        context["courts"] = all_courts.get_selectable_groups()
 
         context["page_title"] = gettext("results.search.title")
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ requests-toolbelt~=1.0.0
 lxml~=4.9.3
 wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client~=14.1.0
-ds-caselaw-utils~=1.0.2
+ds-caselaw-utils==1.1.0
 rollbar
 django-weasyprint==2.2.0
 # pinned to avoid https://github.com/fdemmer/django-weasyprint/issues/71

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ requests-toolbelt~=1.0.0
 lxml~=4.9.3
 wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client~=14.1.0
-ds-caselaw-utils==1.1.0
+ds-caselaw-utils==1.2.1
 rollbar
 django-weasyprint==2.2.0
 # pinned to avoid https://github.com/fdemmer/django-weasyprint/issues/71


### PR DESCRIPTION
## Changes in this PR:

Show the courts heirarchy on the structured search page and in the filters list.

This doesn't include 'select all' functionality, and needs some tidying up - both presentationally here, and in terms of names / structure of courts in the utils library.

In particular, we need to
 - Group the courts so that courts show in the left column, and tribunals in the right (work in both places)
 - Rename court divisions / tribunals so that they don't repeat the group heading (eg "Family division" vs "Family division of the High Court", "Lands Chamber" vs "Upper Tribunal Lands Chamber") (work in utils library - this may involve giving each court a 'grouped' and 'ungrouped' name, and using the correct one depending on context)

## Trello card / Rollbar error (etc)

https://trello.com/c/Gj60XUIp/1380-investigate-court-hierarchy-work-finalize-design

## Screenshots of UI changes:

### Before
<img width="1162" alt="Screenshot 2023-10-05 at 11 30 13" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/a22a3f06-3276-41a8-afba-3523bd9e1b35">

### After
<img width="1208" alt="Screenshot 2023-10-04 at 18 02 31" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/1092acf0-a550-4359-95e9-268978e6f78d">
