### PR TITLE
fix layout of search page at 200% zoom

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -1,8 +1,6 @@
 .structured-search {
   legend {
-    /* https://stackoverflow.com/questions/3973456/default-css-values-for-a-fieldset-legend */
-    float: left;
-    width: 100%;
+    padding: 0;
   }
 
   &__main-search {


### PR DESCRIPTION
## Changes in this PR:

Fixes a small bug found by Rose - in webkit browsers at high level of zoom, the first checkbox in the courts list floats over to the side of the legend. - Having a look at this, it wasn't quite clear why the legends were floating in the first place, so have simplified the CSS (and also fixed a tiny layout weirdness where some field titles had a small amount of left-padding and others not).



## Trello card / Rollbar error (etc)

https://trello.com/c/bxAVjcg4/1428-pui-court-checkboxes-on-screen-magnifiers-break


