### PR TITLE
Loosen django-environ version pinning

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ whitenoise==6.6.0  # https://github.com/evansd/whitenoise
 # Django
 # ------------------------------------------------------------------------------
 django==3.2.22  # pyup: < 4.0  # https://www.djangoproject.com/
-django-environ==0.10.0 # https://github.com/joke2k/django-environ
+django-environ>=0.10.0 # https://github.com/joke2k/django-environ
 django-flags==5.0.13 #  https://cfpb.github.io/django-flags/
 django-model-utils==4.3.1  # https://github.com/jazzband/django-model-utils
 


### PR DESCRIPTION
We had this pinned to exactly 0.10.0, which meant we couldn't upgrade API Client. Loosen this to >0.11.0.