### PR TITLE
Remove weasyprint pinning

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,8 +18,6 @@ ds-caselaw-marklogic-api-client~=17.0.0
 ds-caselaw-utils==1.2.1
 rollbar
 django-weasyprint==2.2.1
-# pinned to avoid https://github.com/fdemmer/django-weasyprint/issues/71
-weasyprint~=58.0
 
 # Type stubs
 mypy-boto3-s3==1.28.55


### PR DESCRIPTION
The issue needing pinning to v58 (a signature change to the render method in v59) was resolved in django-weasyprint v2.2.1.