### PR TITLE
Fix judgment navigation bar at small breakpoints

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_document_navigation_links.scss
+++ b/ds_judgements_public_ui/sass/includes/_document_navigation_links.scss
@@ -27,7 +27,7 @@
       top: 0;
       background-color: $color__white;
       box-sizing: border-box;
-      width: 100%;
+      width: 100vw;
       justify-content: space-between;
       margin: 0;
       box-shadow: $color__dark-grey 1px 1px 6px;
@@ -37,7 +37,7 @@
       row-gap: $spacer__unit;
       column-gap: $spacer__unit;
       @media (max-width: $grid__breakpoint-medium) {
-        column-gap: calc(0.5 * $spacer__unit);
+        column-gap: 0;
       }
 
       .up-wrapper {
@@ -61,7 +61,7 @@
       &.with-query {
         grid-template-columns: 1fr 1fr auto 1fr 1fr;
         @media (max-width: $grid__breakpoint-medium) {
-          grid-template-columns: 1fr 3fr 1fr;
+          grid-template-columns: 2fr 4fr 2fr;
           grid-template-rows: 2fr;
         }
 

--- a/ds_judgements_public_ui/sass/includes/_layout.scss
+++ b/ds_judgements_public_ui/sass/includes/_layout.scss
@@ -25,3 +25,7 @@ body {
 .container {
   @include container;
 }
+
+#main-content {
+  overflow-x: hidden;
+}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Tiny tweak to the judgments navigation bar so that (a) the 'previous' button doesn't reflow onto a second line, and (b) overflowing elements in the judgment don't cause a weird horizontal scroll, on mobile. There's a [Frontend PR](https://github.com/nationalarchives/ds-caselaw-frontend/pull/21) which also addresses part of this.
 
## Screenshots of UI changes:

### Before
<img width="452" alt="Screenshot 2023-11-15 at 15 32 00" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/8b6bfe88-4fcb-4ea6-a3f9-0e8464a959f9">

### After
<img width="452" alt="Screenshot 2023-11-15 at 16 06 03" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/88a3b144-20ec-4e4b-b08f-57bd03fd255a">


