### PR TITLE
add support for ukait tribunal alias

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,8 +13,8 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=4.9.3
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=17.2.0
-ds-caselaw-utils==1.3.0
+ds-caselaw-marklogic-api-client~=17.3.0
+ds-caselaw-utils==1.3.1
 rollbar
 django-weasyprint==2.2.1
 django-waffle==4.0.0  # https://github.com/django-waffle/django-waffle


### PR DESCRIPTION
## Changes in this PR:

Add support for the `ukait` alias for the Upper Tribunal (Asylum & Immigration Chamber), also known as `ut/aic`



## Trello card / Rollbar error (etc)
https://trello.com/c/Cj856ck9/1373-%F0%9F%8F%94backlog-support-ukait-urls
