### PR TITLE
Update search form labels for 'or' judge search

### DIFF
--- a/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
@@ -3,7 +3,9 @@
   <div class="structured-search__limit-to-container">
     <fieldset class="{% if context.errors|has_errors_for_field:"from_date" %}with-errors{% endif %}">
       <legend class="structured-search__limit-to-label">From date</legend>
-      <p class="structured-search__help-text" id="from_date-help-text">For example 01 01 2003 or 2003</p>
+      <p class="structured-search__help-text" id="from_date-help-text">
+        For example <em>01 01 2003</em> or <em>2003</em>
+      </p>
       {% if context.errors|has_errors_for_field:"from_date" %}
         <p class="structured-search__from-date-error-message"
            id="from-date-error">{{ context.errors|errors_for_field:"from_date" }}</p>
@@ -39,7 +41,9 @@
   <div class="structured-search__limit-to-container">
     <fieldset class="{% if context.errors|has_errors_for_field:"to_date" %}with-errors{% endif %}">
       <legend class="structured-search__limit-to-label">To date</legend>
-      <p class="structured-search__help-text" id="to_date-help-text">For example 30 04 2023 or 2023</p>
+      <p class="structured-search__help-text" id="to_date-help-text">
+        For example <em>30 04 2023</em> or <em>2023</em>
+      </p>
       {% if context.errors|has_errors_for_field:"to_date" %}
         <p class="structured-search__to-date-error-message" id="from-date-error">
           {{ context.errors|errors_for_field:"to_date" }}
@@ -107,7 +111,7 @@
            class="structured-search__limit-to-label"
            aria-label="Search by judge name">Judge name</label>
     <p class="structured-search__help-text" id="judge_name-help-text">
-      For example 'Smith', 'Judge Smith' or 'Lord Justice Smith'
+      For example <em>Smith</em>, or multiple judges separated by commas: <em>Smith, Jones</em>
     </p>
     <input class="structured-search__limit-to-input"
            id="judge_name"


### PR DESCRIPTION
** please merge https://github.com/nationalarchives/ds-caselaw-marklogic/pull/43 first!! **

## Changes in this PR:
Adds instructions for 'or' judge search for when https://github.com/nationalarchives/ds-caselaw-marklogic/pull/43 is deployed. Also tweaks the typography to show example queries in italics rather than quotes (as literal quotes aren't required in the query, which was confusing), and removes the various variants on the judge's name in the example as this doesn't currently work as expected: searching for "Lord Justice Smith" for instance would not show judgments handed down by a "Judge Smith" and vice versa.

## Trello card / Rollbar error (etc)

https://trello.com/c/uhBHQPVS/1510-search-judge-metadata-box-to-allow-or-searching-on-the-dl-by-feb
## Screenshots of UI changes:

### Before
<img width="1279" alt="Screenshot 2023-11-29 at 16 08 04" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/a46bbaff-30f1-4197-b30c-78cb90c26e64">

### After
<img width="1270" alt="Screenshot 2023-11-29 at 15 49 28" src="https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/08d81388-2248-4eb2-857c-4ebc8e249a8b">


