### PR TITLE
Turn JSON Cookie errors into 400 errors

### DIFF
--- a/judgments/context_processors.py
+++ b/judgments/context_processors.py
@@ -1,6 +1,8 @@
 import json
 from urllib.parse import unquote
 
+from django.core.exceptions import SuspiciousOperation
+
 from config.settings.base import env
 
 
@@ -12,7 +14,10 @@ def cookie_consent(request):
 
     if cookie_policy:
         decoder = json.JSONDecoder()
-        decoded = decoder.decode(unquote(cookie_policy))
+        try:
+            decoded = decoder.decode(unquote(cookie_policy))
+        except json.JSONDecodeError:
+            raise SuspiciousOperation("Cookie tampered with: not valid JSON")
         showGTM = decoded["usage"] or False
 
     if dont_show_cookie_notice == "true":

--- a/judgments/tests/test_cookies.py
+++ b/judgments/tests/test_cookies.py
@@ -1,0 +1,19 @@
+from http.cookies import SimpleCookie
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from judgments.tests.fixtures import FakeSearchResponse
+
+
+class TestBadCookie(TestCase):
+    @patch("judgments.views.index.api_client")
+    @patch("judgments.views.index.search_judgments_and_parse_response")
+    def test_bad_cookie(
+        self, mock_search_judgments_and_parse_response, mock_api_client
+    ):
+        self.client.cookies = SimpleCookie({"cookies_policy": "evil"})
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
+        response = self.client.get("/")
+        assert response.status_code == 400
+        assert b"Bad Request (400)" in response.content


### PR DESCRIPTION
Deliberately malformed cookies give a lot of false positives. More correctly flag these as being suspicious behaviour and then deprioritise in rollbar.