### PR TITLE
Catch MarklogicNotPermitted errors

### DIFF
--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 import requests
-from caselawclient.errors import DocumentNotFoundError
+from caselawclient.errors import DocumentNotFoundError, MarklogicNotPermittedError
 from caselawclient.models.documents import Document, DocumentURIString
 from django.conf import settings
 from django.http import Http404, HttpResponse, HttpResponseRedirect
@@ -37,6 +37,8 @@ def get_published_document_by_uri(document_uri: str) -> Document:
         document = get_document_by_uri(document_uri)
     except DocumentNotFoundError:
         raise Http404(f"Document {document_uri} was not found")
+    except MarklogicNotPermittedError:
+        raise Http404(f"Document {document_uri} is not available")
 
     if not document.is_published:
         raise Http404(f"Document {document_uri} is not available")


### PR DESCRIPTION
If a judgment was published and its press summary existed but was not published, the press summary would raise a MarklogicNotPermitted error. We didn't catch that.

The function returns a Http404 which feels like the wrong type for something returning a Document. But that's not worth trying to fix right now, I think.