### PR TITLE
version bump API client to 19.1.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,9 +11,9 @@ django-model-utils==4.3.1  # https://github.com/jazzband/django-model-utils
 requests~=2.31.0
 xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
-lxml~=4.9.3
+lxml~=5.1.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=18.0.0
+ds-caselaw-marklogic-api-client~=19.1.0
 ds-caselaw-utils==1.3.4
 rollbar
 django-weasyprint==2.2.2


### PR DESCRIPTION

## Changes in this PR:

Once Marklogic is deployed, this will also enable https://trello.com/c/IQK3v7c5/1560-search-matching-text-should-reflect-search-query-in-quotations-over-other-words-in-search-results
