### PR TITLE
Add search help text to homepage

### DIFF
--- a/ds_judgements_public_ui/templates/includes/search_term_component.html
+++ b/ds_judgements_public_ui/templates/includes/search_term_component.html
@@ -9,10 +9,8 @@
          type="text"
          value="{{ query }}"
          placeholder="{% translate "basicsearchform.placeholder" %}" />
-  {% if show_help_text %}
-    <p class="search-term-component__help-text">
-      <a href='{% url "how_to_use_this_service" %}#section-search'>{% translate "basic.search.helptext" %}</a>
-    </p>
-  {% endif %}
+  <p class="search-term-component__help-text">
+    <a href='{% url "how_to_use_this_service" %}#section-search'>{% translate "basic.search.helptext" %}</a>
+  </p>
 </div>
 <input type="submit" value="{% translate "basicsearchform.cta" %}" />


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Add search help text to homepage
## Trello card / Rollbar error (etc)
https://trello.com/c/AXXLe1Zy/1590-pui-how-to-use-this-search-help-under-the-search-on-the-home-page

## Screenshots of UI changes:

### Before
![before](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/eadcdada-389d-4252-8905-f221213fc945)

### After
![after](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/75584408/6363cbd1-82f0-49ea-ad06-b7193922b201)

- [ ] Requires env variable(s) to be updated
