### PR TITLE
version bumpt to utils and api client for GRC jurisdiction display

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,8 +13,8 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=5.1.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=19.1.0
-ds-caselaw-utils==1.3.5
+ds-caselaw-marklogic-api-client~=22.0.0
+ds-caselaw-utils==1.4.0
 rollbar
 django-weasyprint==2.2.2
 django-waffle==4.1.0  # https://github.com/django-waffle/django-waffle


### PR DESCRIPTION

## Changes in this PR:

Displays the jurisdiction for GRC judgments in search results

## Trello card / Rollbar error (etc)

https://trello.com/c/JDoWjYsa/1602-medium-grcfollow-logic-for-the-courts-and-expose-grc-subdivisions-on-pui-prototype-first

## Screenshots of UI changes:

![Screenshot 2024-02-01 at 16 36 50](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/9d6147b1-211c-46f2-9be4-33db462d3404)

