### PR TITLE
bump api client and utils to fix missing jurisdiction bug

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,8 +13,8 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=5.1.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=22.0.0
-ds-caselaw-utils==1.4.0
+ds-caselaw-marklogic-api-client~=22.0.1
+ds-caselaw-utils==1.4.1
 rollbar
 django-weasyprint==2.2.2
 django-waffle==4.1.0  # https://github.com/django-waffle/django-waffle


### PR DESCRIPTION
## Changes in this PR:

Fixes bug where GRC judgments have an unknown jurisdiction.

Requires a redeploy of `main` branch of marklogic too - we rolled back the production deploy as a temporary workaround.
