### PR TITLE
(1704) Handle press summary redirects and multiple summaries

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n utilities document_utils %}
 <div id="download-options" class="judgment-download-options">
   <h2 class="judgment-download-options__header">{% translate "judgment.downloadoptions.title" %}</h2>
   <div class="judgment-download-options__options-list">
@@ -25,7 +25,7 @@
     </div>
     <div class="judgment-download-options__download-option">
       <h3>
-        <a href="{% url 'detail_xml' context.document_uri %}"
+        <a href="{% formatted_document_uri context.document_uri 'xml' %}"
            aria-label="Download this document as XML">
           {% if context.document_noun == 'press summary' %}
             {% translate "press_summary.downloadoptions.xml.cta" %}

--- a/ds_judgements_public_ui/templates/judgment/press_summaries/list.html
+++ b/ds_judgements_public_ui/templates/judgment/press_summaries/list.html
@@ -1,0 +1,43 @@
+{% extends "layouts/base.html" %}
+{% load i18n document_utils waffle_tags %}
+{% block robots %}
+  <meta name="robots" content="noindex,nofollow" />
+{% endblock robots %}
+{% block title %}
+  {% if page_title %}{{ page_title }} -{% endif %}
+  Find case law
+{% endblock title %}
+{% block precontent %}
+  <div class="judgment-toolbar">
+    <div class="judgment-toolbar__container">
+      <h1 class="judgment-toolbar__title">{{ judgement_name }}</h1>
+      <p class="judgment-toolbar__reference">Press Summaries</p>
+    </div>
+  </div>
+{% endblock precontent %}
+{% block content %}
+  <div class="results">
+    <h1>{{ page_title }}</h1>
+    <div class="results__container">
+      <div class="results__list-layout-container">
+        <ul class="judgment-listing__list">
+          {% for press_summary in press_summaries %}
+            <li class="judgment-listing__judgment">
+              <span class="judgment-listing__judgment">
+                <span>
+                  <span class="judgment-listing__title">
+                    <a href="{% url 'detail' press_summary.uri %}">{{ press_summary.name }}</a>
+                  </span>
+                </span>
+                <span>
+                  <time class="judgment-listing__date"
+                        datetime="{{ press_summary.document_date_as_string }}">{{ press_summary.document_date_as_date|date }}</time>
+                </span>
+              </span>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/judgments/converters.py
+++ b/judgments/converters.py
@@ -62,3 +62,13 @@ class DocumentUriConverter:
 
     def to_url(self, value):
         return value
+
+
+class ComponentConverter:
+    regex = "press-summary"
+
+    def to_python(self, value):
+        return value
+
+    def to_url(self, value):
+        return value

--- a/judgments/converters.py
+++ b/judgments/converters.py
@@ -42,3 +42,23 @@ class SubdivisionConverter:
 
     def to_url(self, value):
         return value
+
+
+class FileFormatConverter:
+    regex = "data.pdf|generated.pdf|data.xml|data.html"
+
+    def to_python(self, value):
+        return value
+
+    def to_url(self, value):
+        return value
+
+
+class DocumentUriConverter:
+    regex = r".*/\d{4}/\d+.*"
+
+    def to_python(self, value):
+        return value
+
+    def to_url(self, value):
+        return value

--- a/judgments/resolvers/document_resolver_engine.py
+++ b/judgments/resolvers/document_resolver_engine.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+from django.http.request import HttpRequest
+from django.views.generic import View
+
+from judgments.views.detail import detail, detail_xml, get_best_pdf, get_generated_pdf
+
+
+class DocumentResolverEngine(View):
+    def dispatch(
+        self,
+        request: HttpRequest,
+        document_uri: str,
+        file_format: Optional[str] = None,
+    ):
+        fileformat_lookup = {
+            "data.pdf": get_best_pdf,
+            "generated.pdf": get_generated_pdf,
+            "data.xml": detail_xml,
+            "data.html": detail,
+        }
+        if file_format:
+            return fileformat_lookup[file_format](request, document_uri)
+
+        return detail(request, document_uri)

--- a/judgments/resolvers/document_resolver_engine.py
+++ b/judgments/resolvers/document_resolver_engine.py
@@ -4,6 +4,7 @@ from django.http.request import HttpRequest
 from django.views.generic import View
 
 from judgments.views.detail import detail, detail_xml, get_best_pdf, get_generated_pdf
+from judgments.views.press_summaries import press_summaries
 
 
 class DocumentResolverEngine(View):
@@ -12,6 +13,7 @@ class DocumentResolverEngine(View):
         request: HttpRequest,
         document_uri: str,
         file_format: Optional[str] = None,
+        component: Optional[str] = None,
     ):
         fileformat_lookup = {
             "data.pdf": get_best_pdf,
@@ -19,7 +21,13 @@ class DocumentResolverEngine(View):
             "data.xml": detail_xml,
             "data.html": detail,
         }
+        component_lookup = {
+            "press-summary": press_summaries,
+        }
         if file_format:
             return fileformat_lookup[file_format](request, document_uri)
+
+        if component:
+            return component_lookup[component](request, document_uri)
 
         return detail(request, document_uri)

--- a/judgments/templatetags/document_utils.py
+++ b/judgments/templatetags/document_utils.py
@@ -1,4 +1,8 @@
+from typing import Optional
+
 from django import template
+
+from judgments import utils
 
 register = template.Library()
 
@@ -8,3 +12,8 @@ def get_title_to_display_in_html(document_title, document_noun):
     if document_noun == "press summary":
         return document_title.removeprefix("Press Summary of ")
     return document_title
+
+
+@register.simple_tag
+def formatted_document_uri(document_uri: str, format: Optional[str] = None):
+    return utils.formatted_document_uri(document_uri, format)

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Any
 from unittest.mock import Mock
 
@@ -16,6 +17,8 @@ class DocumentFactory:
         "neutral_citation": "[2023] Test 123",
         "court": "Court of Testing",
         "judgment_date_as_string": "2023-02-03",
+        "document_date_as_string": "2023-02-03",
+        "document_date_as_date": datetime.date.today(),
         "is_published": False,
         "is_sensitive": False,
         "is_anonymised": False,

--- a/judgments/tests/template_tags/test_document_utils.py
+++ b/judgments/tests/template_tags/test_document_utils.py
@@ -1,0 +1,12 @@
+import unittest
+from unittest.mock import patch
+
+from judgments.templatetags.document_utils import formatted_document_uri
+
+
+class TestDocumentUtils(unittest.TestCase):
+    @patch("judgments.utils.formatted_document_uri")
+    def test_formatted_document_uri(self, mock_formatted_document_uri):
+        formatted_document_uri("/foo/bar", "xml")
+
+        mock_formatted_document_uri.assert_called_with("/foo/bar", "xml")

--- a/judgments/tests/test_document_resolver_engine.py
+++ b/judgments/tests/test_document_resolver_engine.py
@@ -33,3 +33,19 @@ class TestDocumentResolverEngine(TestCase):
                 resolver_engine.dispatch(request, document_uri, file_format=file_format)
 
                 view.assert_called_with(request, document_uri)
+
+    @patch("judgments.resolvers.document_resolver_engine.press_summaries")
+    def test_resolver_engine_with_components(self, mock_press_summaries):
+        document_uri = "ewhc/comm/2024/253"
+        test_params = [
+            ("press-summary", mock_press_summaries),
+        ]
+        for component, view in test_params:
+            with self.subTest(component=component, view=view):
+                path = document_uri + "/" + component
+                request = RequestFactory().get(path)
+                resolver_engine = DocumentResolverEngine()
+                resolver_engine.setup(request)
+                resolver_engine.dispatch(request, document_uri, component=component)
+
+                view.assert_called_with(request, document_uri)

--- a/judgments/tests/test_document_resolver_engine.py
+++ b/judgments/tests/test_document_resolver_engine.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+
+from django.test import RequestFactory, TestCase
+
+from judgments.resolvers.document_resolver_engine import DocumentResolverEngine
+
+
+class TestDocumentResolverEngine(TestCase):
+    @patch("judgments.resolvers.document_resolver_engine.get_best_pdf")
+    @patch("judgments.resolvers.document_resolver_engine.get_generated_pdf")
+    @patch("judgments.resolvers.document_resolver_engine.detail_xml")
+    @patch("judgments.resolvers.document_resolver_engine.detail")
+    def test_resolver_engine_with_fileformats(
+        self,
+        mock_detail,
+        mock_detail_xml,
+        mock_get_generated_pdf,
+        mock_get_best_pdf,
+    ):
+        document_uri = "ewhc/comm/2024/253"
+        test_params = [
+            ("data.pdf", mock_get_best_pdf),
+            ("generated.pdf", mock_get_generated_pdf),
+            ("data.xml", mock_detail_xml),
+            ("data.html", mock_detail),
+        ]
+        for file_format, view in test_params:
+            with self.subTest(filename=file_format, view=view):
+                path = document_uri + "/" + file_format
+                request = RequestFactory().get(path)
+                resolver_engine = DocumentResolverEngine()
+                resolver_engine.setup(request)
+                resolver_engine.dispatch(request, document_uri, file_format=file_format)
+
+                view.assert_called_with(request, document_uri)

--- a/judgments/tests/test_press_summaries.py
+++ b/judgments/tests/test_press_summaries.py
@@ -1,0 +1,99 @@
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+from django.urls import reverse
+from factories import PressSummaryFactory
+
+from judgments.utils import linked_doc_title, press_summary_list_breadcrumbs
+from judgments.views.press_summaries import press_summaries
+
+
+class TestPressSummaries(TestCase):
+    @patch("judgments.views.press_summaries.TemplateResponse", autospec=True)
+    @patch("judgments.views.press_summaries.get_press_summaries_for_document_uri")
+    def test_view_returns_template_response_for_multiple_press_summaries(
+        self, mock_get_press_summaries_for_document_uri, mock_template_response
+    ):
+        press_summary_1 = PressSummaryFactory.build()
+        press_summary_2 = PressSummaryFactory.build()
+
+        excepted_press_summaries = [
+            press_summary_1,
+            press_summary_2,
+        ]
+
+        mock_get_press_summaries_for_document_uri.return_value = (
+            excepted_press_summaries
+        )
+
+        request = Mock()
+        document_uri = "foo/bar/baz"
+
+        press_summaries(request, document_uri)
+
+        mock_template_response.assert_called_with(
+            request,
+            "judgment/press_summaries/list.html",
+            context={
+                "page_title": f"{linked_doc_title(press_summary_1)} - Press Summaries",
+                "judgement_name": linked_doc_title(press_summary_1),
+                "breadcrumbs": press_summary_list_breadcrumbs(press_summary_1),
+                "press_summaries": excepted_press_summaries,
+            },
+        )
+
+    @patch("judgments.views.press_summaries.get_press_summaries_for_document_uri")
+    def test_redirects_to_press_summaries_when_one_present(
+        self, mock_get_press_summaries_for_document_uri
+    ):
+        press_summary = PressSummaryFactory.build()
+        mock_get_press_summaries_for_document_uri.return_value = [press_summary]
+
+        response = self.client.get("/uksc/2023/35/press-summary", follow=False)
+
+        self.assertRedirects(
+            response,
+            reverse(
+                "detail",
+                kwargs={"document_uri": press_summary.uri},
+            ),
+            fetch_redirect_response=False,
+        )
+
+    @patch("judgments.views.press_summaries.get_press_summaries_for_document_uri")
+    def test_shows_multiple_when_multiple_present(
+        self, mock_get_press_summaries_for_document_uri
+    ):
+        press_summary_1 = PressSummaryFactory.build()
+        press_summary_2 = PressSummaryFactory.build()
+
+        mock_get_press_summaries_for_document_uri.return_value = [
+            press_summary_1,
+            press_summary_2,
+        ]
+
+        response = self.client.get("/uksc/2023/35/press-summary")
+        decoded_response = response.content.decode("utf-8")
+
+        self.assertIn(
+            f"{linked_doc_title(press_summary_1)} - Press Summaries",
+            decoded_response,
+        )
+        self.assertIn(
+            press_summary_1.name,
+            decoded_response,
+        )
+        self.assertIn(
+            press_summary_2.name,
+            decoded_response,
+        )
+
+    @patch("judgments.views.press_summaries.get_press_summaries_for_document_uri")
+    def test_throws_404_when_no_summaries_present(
+        self, mock_get_press_summaries_for_document_uri
+    ):
+        mock_get_press_summaries_for_document_uri.return_value = []
+
+        response = self.client.get("/uksc/2023/35/press-summary")
+
+        assert response.status_code == 404

--- a/judgments/tests/test_utils.py
+++ b/judgments/tests/test_utils.py
@@ -7,8 +7,10 @@ from judgments.tests.factories import JudgmentFactory, PressSummaryFactory
 from judgments.utils import (
     formatted_document_uri,
     get_document_by_uri,
+    get_press_summaries_for_document_uri,
     linked_doc_title,
     linked_doc_url,
+    press_summary_list_breadcrumbs,
 )
 
 
@@ -53,10 +55,29 @@ class TestGetDocumentByUri(unittest.TestCase):
 
     def test_linked_doc_title_removes_prefix_for_press_summary(self):
         document = PressSummaryFactory.build(name="Press Summary of Arkell v Pressdram")
-
         assert linked_doc_title(document) == "Arkell v Pressdram"
 
     def test_linked_doc_title_adds_prefix_for_judgment(self):
         document = JudgmentFactory.build(name="Arkell v Pressdram")
-
         assert linked_doc_title(document) == "Press Summary of Arkell v Pressdram"
+
+    def test_press_summary_list_breadcrumbs(self):
+        document = PressSummaryFactory.build()
+
+        assert press_summary_list_breadcrumbs(document) == [
+            {
+                "url": "/" + linked_doc_url(document),
+                "text": linked_doc_title(document),
+            },
+            {
+                "text": "Press Summaries",
+            },
+        ]
+
+    @mock.patch("judgments.utils.api_client")
+    def test_get_press_summaries_for_document_uri(self, mock_api_client):
+        summaries = [mock.Mock(), mock.Mock()]
+        mock_api_client.get_press_summaries_for_document_uri.return_value = summaries
+
+        result = get_press_summaries_for_document_uri("sample_uri")
+        self.assertEqual(result, summaries)

--- a/judgments/tests/test_utils.py
+++ b/judgments/tests/test_utils.py
@@ -3,7 +3,13 @@ from unittest import mock
 
 from caselawclient.errors import DocumentNotFoundError
 
-from judgments.utils import formatted_document_uri, get_document_by_uri
+from judgments.tests.factories import JudgmentFactory, PressSummaryFactory
+from judgments.utils import (
+    formatted_document_uri,
+    get_document_by_uri,
+    linked_doc_title,
+    linked_doc_url,
+)
 
 
 class TestGetDocumentByUri(unittest.TestCase):
@@ -34,3 +40,23 @@ class TestGetDocumentByUri(unittest.TestCase):
                     formatted_document_uri(document_uri, format),
                     "/" + document_uri + suffix,
                 )
+
+    def test_linked_doc_url_returns_press_summary_for_a_judgement(self):
+        document = JudgmentFactory.build()
+
+        assert linked_doc_url(document) == document.uri + "/press-summary/1"
+
+    def test_linked_doc_url_returns_judgement_for_a_press_summary(self):
+        document = PressSummaryFactory.build(uri="/foo/bar/press-summary/1")
+
+        assert linked_doc_url(document) == "/foo/bar"
+
+    def test_linked_doc_title_removes_prefix_for_press_summary(self):
+        document = PressSummaryFactory.build(name="Press Summary of Arkell v Pressdram")
+
+        assert linked_doc_title(document) == "Arkell v Pressdram"
+
+    def test_linked_doc_title_adds_prefix_for_judgment(self):
+        document = JudgmentFactory.build(name="Arkell v Pressdram")
+
+        assert linked_doc_title(document) == "Press Summary of Arkell v Pressdram"

--- a/judgments/tests/test_utils.py
+++ b/judgments/tests/test_utils.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from caselawclient.errors import DocumentNotFoundError
 
-from judgments.utils import get_document_by_uri
+from judgments.utils import formatted_document_uri, get_document_by_uri
 
 
 class TestGetDocumentByUri(unittest.TestCase):
@@ -19,3 +19,18 @@ class TestGetDocumentByUri(unittest.TestCase):
         mock_api_client.get_document_by_uri.side_effect = DocumentNotFoundError
         with self.assertRaises(DocumentNotFoundError):
             get_document_by_uri("nonexistent_uri")
+
+    def test_formatted_document_uri(self):
+        test_params = [
+            ("pdf", "/data.pdf"),
+            ("generated_pdf", "/generated.pdf"),
+            ("xml", "/data.xml"),
+            ("html", "/data.html"),
+        ]
+        document_uri = "ewhc/comm/2024/253"
+        for format, suffix in test_params:
+            with self.subTest(format=format, suffix=suffix):
+                self.assertEqual(
+                    formatted_document_uri(document_uri, format),
+                    "/" + document_uri + suffix,
+                )

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -1,15 +1,17 @@
-from django.urls import path, re_path, register_converter
+from django.urls import path, register_converter
 
 from . import converters, feeds
+from .resolvers.document_resolver_engine import DocumentResolverEngine
 from .views.advanced_search import advanced_search
 from .views.browse import browse
-from .views.detail import PdfDetailView, detail, detail_xml, get_best_pdf
 from .views.index import index
 
 register_converter(converters.YearConverter, "yyyy")
 register_converter(converters.DateConverter, "date")
 register_converter(converters.CourtConverter, "court")
 register_converter(converters.SubdivisionConverter, "subdivision")
+register_converter(converters.DocumentUriConverter, "document_uri")
+register_converter(converters.FileFormatConverter, "file_format")
 
 urlpatterns = [
     path("<court:court>", browse, name="browse"),
@@ -37,23 +39,16 @@ urlpatterns = [
         feeds.LatestJudgmentsFeed(),
         name="feed",
     ),
-    re_path(
-        r"^(?P<document_uri>.*/\d{4}/\d+.*)/data.pdf$",
-        get_best_pdf,
-        name="detail_pdf",
+    path(
+        "<document_uri:document_uri>/<file_format:file_format>",
+        DocumentResolverEngine.as_view(),
+        name="detail",
     ),
-    re_path(
-        r"^(?P<document_uri>.*/\d{4}/\d+.*)/generated.pdf$",
-        PdfDetailView.as_view(),
-        name="weasy_pdf",
+    path(
+        "<document_uri:document_uri>",
+        DocumentResolverEngine.as_view(),
+        name="detail",
     ),
-    re_path(
-        r"^(?P<document_uri>.*/\d{4}/\d+.*)/data.xml$", detail_xml, name="detail_xml"
-    ),
-    re_path(
-        r"^(?P<document_uri>.*/\d{4}/\d+.*)/data.html$", detail, name="detail_html"
-    ),
-    re_path(r"^(?P<document_uri>.*/\d{4}/\d+.*)/?$", detail, name="detail"),
     path("judgments/results", advanced_search),
     path("judgments/advanced_search", advanced_search),
     path("judgments/search", advanced_search, name="search"),

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -12,6 +12,7 @@ register_converter(converters.CourtConverter, "court")
 register_converter(converters.SubdivisionConverter, "subdivision")
 register_converter(converters.DocumentUriConverter, "document_uri")
 register_converter(converters.FileFormatConverter, "file_format")
+register_converter(converters.ComponentConverter, "component")
 
 urlpatterns = [
     path("<court:court>", browse, name="browse"),
@@ -41,6 +42,11 @@ urlpatterns = [
     ),
     path(
         "<document_uri:document_uri>/<file_format:file_format>",
+        DocumentResolverEngine.as_view(),
+        name="detail",
+    ),
+    path(
+        "<document_uri:document_uri>/<component:component>",
         DocumentResolverEngine.as_view(),
         name="detail",
     ),

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qs, urlparse
 import environ
 from caselawclient.Client import DEFAULT_USER_AGENT, MarklogicApiClient
 from caselawclient.models.documents import Document, DocumentURIString
+from caselawclient.models.press_summaries import PressSummary
 from caselawclient.search_parameters import RESULTS_PER_PAGE
 from django.conf import settings
 from django.urls import reverse
@@ -232,6 +233,12 @@ def get_document_by_uri(document_uri: str) -> Document:
     return api_client.get_document_by_uri(DocumentURIString(document_uri))
 
 
+def get_press_summaries_for_document_uri(document_uri: str) -> list[PressSummary]:
+    return api_client.get_press_summaries_for_document_uri(
+        DocumentURIString(document_uri)
+    )
+
+
 def formatted_document_uri(document_uri: str, format: Optional[str] = None) -> str:
     url = reverse("detail", args=[document_uri])
     if format == "pdf":
@@ -260,3 +267,15 @@ def linked_doc_title(document: Document):
         return document.name.removeprefix(press_summary_title_prefix)
     else:
         return press_summary_title_prefix + document.name
+
+
+def press_summary_list_breadcrumbs(press_summary: Document):
+    return [
+        {
+            "url": "/" + linked_doc_url(press_summary),
+            "text": linked_doc_title(press_summary),
+        },
+        {
+            "text": "Press Summaries",
+        },
+    ]

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -10,6 +10,7 @@ from caselawclient.Client import DEFAULT_USER_AGENT, MarklogicApiClient
 from caselawclient.models.documents import Document, DocumentURIString
 from caselawclient.search_parameters import RESULTS_PER_PAGE
 from django.conf import settings
+from django.urls import reverse
 from django.utils.translation import gettext
 
 from .fixtures.stop_words import stop_words
@@ -229,3 +230,17 @@ def parse_date_parameter(
 def get_document_by_uri(document_uri: str) -> Document:
     # raises a DocumentNotFoundError if it doesn't exist
     return api_client.get_document_by_uri(DocumentURIString(document_uri))
+
+
+def formatted_document_uri(document_uri: str, format: Optional[str] = None) -> str:
+    url = reverse("detail", args=[document_uri])
+    if format == "pdf":
+        url = url + "/data.pdf"
+    elif format == "generated_pdf":
+        url = url + "/generated.pdf"
+    elif format == "xml":
+        url = url + "/data.xml"
+    elif format == "html":
+        url = url + "/data.html"
+
+    return url

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -244,3 +244,19 @@ def formatted_document_uri(document_uri: str, format: Optional[str] = None) -> s
         url = url + "/data.html"
 
     return url
+
+
+def linked_doc_url(document: Document):
+    press_summary_suffix = "/press-summary/1"
+    if document.document_noun == "press summary":
+        return document.uri.removesuffix(press_summary_suffix)
+    else:
+        return document.uri + press_summary_suffix
+
+
+def linked_doc_title(document: Document):
+    press_summary_title_prefix = "Press Summary of "
+    if document.document_noun == "press summary":
+        return document.name.removeprefix(press_summary_title_prefix)
+    else:
+        return press_summary_title_prefix + document.name

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -14,6 +14,7 @@ from django.views.generic import TemplateView
 from django_weasyprint import WeasyTemplateResponseMixin
 
 from judgments.utils import (
+    formatted_document_uri,
     get_document_by_uri,
     get_pdf_uri,
     preprocess_query,
@@ -60,6 +61,10 @@ class PdfDetailView(WeasyTemplateResponseMixin, TemplateView):
         context["document"] = document.content_as_html(MOST_RECENT_VERSION)
 
         return context
+
+
+def get_generated_pdf(request, document_uri):
+    return PdfDetailView.as_view()(request, document_uri=document_uri)
 
 
 def get_best_pdf(request, document_uri):
@@ -121,7 +126,7 @@ def detail(request, document_uri):
     context["pdf_uri"] = (
         get_pdf_uri(document.uri)
         if context["pdf_size"]
-        else reverse("detail_pdf", args=[document.uri])
+        else formatted_document_uri(document.uri, "pdf")
     )
 
     if document.document_noun == "press summary":

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -17,6 +17,8 @@ from judgments.utils import (
     formatted_document_uri,
     get_document_by_uri,
     get_pdf_uri,
+    linked_doc_title,
+    linked_doc_url,
     preprocess_query,
     search_context_from_url,
 )
@@ -96,7 +98,6 @@ def detail(request, document_uri):
         return HttpResponseRedirect(redirect_uri)
 
     context = {}
-    press_summary_suffix = "/press-summary/1"
     context["document_noun"] = document.document_noun
     if document.best_human_identifier is None:
         raise NoNeutralCitationError(document.uri)
@@ -104,14 +105,10 @@ def detail(request, document_uri):
     if query:
         context["number_of_mentions"] = str(document.number_of_mentions(query))
         context["query"] = query
-    if document.document_noun == "press summary":
-        linked_doc_url = document_uri.removesuffix(press_summary_suffix)
-    else:
-        linked_doc_url = document_uri + press_summary_suffix
 
     try:
         context["linked_document_uri"] = get_published_document_by_uri(
-            linked_doc_url
+            linked_doc_url(document)
         ).uri
     except Http404:
         context["linked_document_uri"] = ""
@@ -133,7 +130,7 @@ def detail(request, document_uri):
         breadcrumbs = [
             {
                 "url": "/" + context["linked_document_uri"],
-                "text": document.name.removeprefix("Press Summary of "),
+                "text": linked_doc_title(document),
             },
             {
                 "text": "Press Summary",

--- a/judgments/views/press_summaries.py
+++ b/judgments/views/press_summaries.py
@@ -1,0 +1,34 @@
+from django.http import Http404
+from django.shortcuts import redirect
+from django.template.response import TemplateResponse
+from django.urls import reverse
+
+from judgments.utils import (
+    get_press_summaries_for_document_uri,
+    linked_doc_title,
+    press_summary_list_breadcrumbs,
+)
+
+
+def press_summaries(request, document_uri):
+    press_summaries = get_press_summaries_for_document_uri(document_uri)
+
+    if len(press_summaries) == 0:
+        raise Http404
+    elif len(press_summaries) == 1:
+        return redirect(
+            reverse("detail", kwargs={"document_uri": press_summaries[0].uri}),
+            permanent=False,
+        )
+
+    judgement_name = linked_doc_title(press_summaries[0])
+    return TemplateResponse(
+        request,
+        "judgment/press_summaries/list.html",
+        context={
+            "page_title": f"{judgement_name} - Press Summaries",
+            "judgement_name": judgement_name,
+            "breadcrumbs": press_summary_list_breadcrumbs(press_summaries[0]),
+            "press_summaries": press_summaries,
+        },
+    )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=5.1.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=22.0.1
+ds-caselaw-marklogic-api-client~=22.0.2
 ds-caselaw-utils==1.4.1
 rollbar
 django-weasyprint==2.2.2


### PR DESCRIPTION
This adds a resolver to handle the multiple formats that judgements may or may not have and sends the details to the relevant view. It also handles calls to `$documentUri/press-summary`, fetching all possible press summaries for a document and:

- If there is 1 press summary, we redirect
- If there are no press summaries, we 404
- If there are multiple press summaries, we return a list

Note that we expect case 3 to be very much an edge case, so the design is a bit rudimentary!

## Screenshot

![image](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/109774/013725ba-031c-46ce-b273-52c975c5235e)
