### PR TITLE
Serve schemas at /schema/akn-modified.xsd, caselaw.xsd and xml.xsd from Github.

### DIFF
--- a/config/converters.py
+++ b/config/converters.py
@@ -1,0 +1,8 @@
+class SchemaFileConverter:
+    regex = r"(?:xml|caselaw|akn-modified)\.xsd"
+
+    def to_python(self, value):
+        return str(value)
+
+    def to_url(self, value):
+        return str(value)

--- a/config/tests.py
+++ b/config/tests.py
@@ -1,4 +1,10 @@
+from unittest.mock import patch
+
+import pytest
+from django.http import Http404
 from django.test import TestCase
+
+from config import views
 
 
 class TestCacheHeaders(TestCase):
@@ -11,3 +17,52 @@ class TestCacheHeaders(TestCase):
         url = "/about-this-service"
         response = self.client.get(url)
         assert response.headers["Cache-Control"] == "max-age=900, public"
+
+
+class TestSchemas(TestCase):
+    @patch("config.views.requests.get")
+    def test_cached(self, get):
+        # Tests caching behaviour; happy path
+        "We return a 200 with the content but only call it once"
+        get.return_value.status_code = 200
+        get.return_value.content = b"content-a"
+        response = self.client.get("/schema/akn-modified.xsd")
+        assert response.content == b"content-a"
+        assert response.status_code == 200
+        response = self.client.get("/schema/akn-modified.xsd")
+        get.assert_called_once()
+
+    @patch("config.views.requests.get")
+    def test_error_gives_404(self, get):
+        # Does not test caching behaviour and needs to not use an old filename
+        "We handle errors from Github correctly"
+        get.return_value.status_code = 419
+        get.return_value.content = b"content-b"
+        with pytest.raises(Http404):
+            views.schema(None, "caselaw.xsd")
+
+    @patch("config.views.requests.get")
+    def test_bad_url(self, get):
+        # Doesn't care either way about caching
+        "Given a bad URL, we don't request anything"
+        response = self.client.get("/schema/bad-url.xsd")
+        assert response.status_code == 404
+        get.assert_not_called()
+
+    @patch("config.views.requests.get")
+    def test_no_cache_errors(self, get):
+        # Tests caching behaviour -- uses different URI for that reason
+        "Errors downloading the document aren't persistent"
+        with patch("config.views.requests.get") as get_bad:
+            get_bad.return_value.status_code = 419
+            get_bad.return_value.content = b"content-c"
+            response = self.client.get("/schema/xml.xsd")
+            assert response.status_code == 404
+        with patch("config.views.requests.get") as get_good:
+            get_good.return_value.status_code = 200
+            get_good.return_value.content = b"content-d"
+            response = self.client.get("/schema/xml.xsd")
+        assert response.status_code == 200
+        assert response.content == b"content-d"
+        get_bad.assert_called_once()
+        get_good.assert_called_once()

--- a/config/urls.py
+++ b/config/urls.py
@@ -2,11 +2,15 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.http import HttpResponseRedirect
-from django.urls import include, path
+from django.urls import include, path, register_converter
 from django.views import defaults as default_views
+from django.views.decorators.cache import cache_page
 from django.views.generic.base import TemplateView
 
 from . import views
+from .converters import SchemaFileConverter
+
+register_converter(SchemaFileConverter, "schemafile")
 
 urlpatterns = [
     # Django Admin, use {% url 'admin:index' %}
@@ -76,6 +80,11 @@ urlpatterns = [
         TemplateView.as_view(
             template_name="googleb0ce3f99fae65e7c.html", content_type="text/html"
         ),
+    ),
+    path(
+        "schema/<schemafile:schemafile>",
+        cache_page(60 * 60)(views.schema),
+        name="schema",
     ),
     path("", include("judgments.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/config/views.py
+++ b/config/views.py
@@ -1,6 +1,11 @@
+import requests
+from django.http import Http404, HttpResponse
 from django.utils.translation import gettext
 from django.views.generic import TemplateView
 from ds_caselaw_utils import courts
+
+# where the schemas can be downloaded from. Slash-terminated.
+SCHEMA_ROOT = "https://raw.githubusercontent.com/nationalarchives/ds-caselaw-marklogic/main/src/main/ml-schemas/"
 
 
 class TemplateViewWithContext(TemplateView):
@@ -108,3 +113,11 @@ class PrivacyNotice(TemplateViewWithContext):
         context = super().get_context_data(**kwargs)
         context["feedback_survey_type"] = "privacy_notice"
         return context
+
+
+def schema(request, schemafile: str):
+    response = requests.get(f"{SCHEMA_ROOT}{schemafile}")
+    if response.status_code != 200:
+        raise Http404("Could not get schema")
+
+    return HttpResponse(response.content, content_type="application/xml")


### PR DESCRIPTION
Questions to answer:

Is these the right URL?

> Also, the “schemaLocation” on legislation.gov.uk is http://www.legislation.gov.uk/schema/legislation.xsd, so maybe we could use https://caselaw.nationalarchives.gov.uk/schema/filename.xsd -- Jim

Is this the right approach?

Should /akn redirect here?