### PR TITLE
Add model for pdf logic

### DIFF
--- a/judgments/admin.py
+++ b/judgments/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from judgments.models import CourtDates
+from judgments.models.court_dates import CourtDates
 
 
 @admin.register(CourtDates)

--- a/judgments/management/commands/recalculate_court_dates.py
+++ b/judgments/management/commands/recalculate_court_dates.py
@@ -7,7 +7,7 @@ from caselawclient.search_parameters import SearchParameters
 from django.core.management.base import BaseCommand
 from ds_caselaw_utils import courts
 
-from judgments.models import CourtDates
+from judgments.models.court_dates import CourtDates
 from judgments.utils import api_client
 
 

--- a/judgments/models/court_dates.py
+++ b/judgments/models/court_dates.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from django.db import models
 from django.db.models import Max, Min
 
@@ -22,20 +20,3 @@ class CourtDates(models.Model):
     def max_year():
         result = CourtDates.objects.aggregate(Max("end_year"))
         return result["end_year__max"]
-
-
-class SearchFormErrors:
-    def __init__(self):
-        self.messages = []
-        self.fields = defaultdict(list)
-
-    def has_errors(self, field=None):
-        if field is None:
-            return len(self.messages) > 0 and len(self.fields.keys()) > 0
-        else:
-            return len(self.fields[field])
-
-    def add_error(self, message, field=None, fieldMessage=None):
-        self.messages.append(message)
-        if field is not None:
-            self.fields[field].append(fieldMessage)

--- a/judgments/models/document_pdf.py
+++ b/judgments/models/document_pdf.py
@@ -1,0 +1,47 @@
+import logging
+from functools import cached_property
+
+import environ
+import requests
+
+from judgments.utils import formatted_document_uri
+
+
+class DocumentPdf:
+    def __init__(self, document_uri: str):
+        self.document_uri = document_uri
+
+    @cached_property
+    def size(self):
+        """Return the size of the S3 PDF for a document, or None if unavailable"""
+        response = requests.head(
+            # it is possible that "" is a better value than None, but that is untested
+            self.generate_uri(),
+            headers={"Accept-Encoding": None},  # type: ignore
+        )
+        content_length = response.headers.get("Content-Length", None)
+        if response.status_code >= 400:
+            return None
+        if content_length:
+            return int(content_length)
+        else:
+            logging.warning(f"Unable to determine PDF size for {self.document_uri}")
+            return None
+
+    @cached_property
+    def uri(self):
+        return (
+            self.generate_uri()
+            if self.size
+            else formatted_document_uri(self.document_uri, "pdf")
+        )
+
+    def generate_uri(self):
+        env = environ.Env()
+        """Create a string saying where the S3 PDF will be for a judgment uri"""
+        pdf_path = f'{self.document_uri}/{self.document_uri.replace("/", "_")}.pdf'
+        assets = env("ASSETS_CDN_BASE_URL", default=None)
+        if assets:
+            return f"{assets}/{pdf_path}"
+        else:
+            return f'https://{env("PUBLIC_ASSET_BUCKET")}.s3.{env("S3_REGION")}.amazonaws.com/{pdf_path}'

--- a/judgments/models/search_form_errors.py
+++ b/judgments/models/search_form_errors.py
@@ -1,0 +1,18 @@
+from collections import defaultdict
+
+
+class SearchFormErrors:
+    def __init__(self):
+        self.messages = []
+        self.fields = defaultdict(list)
+
+    def has_errors(self, field=None):
+        if field is None:
+            return len(self.messages) > 0 and len(self.fields.keys()) > 0
+        else:
+            return len(self.fields[field])
+
+    def add_error(self, message, field=None, fieldMessage=None):
+        self.messages.append(message)
+        if field is not None:
+            self.fields[field].append(fieldMessage)

--- a/judgments/templatetags/court_utils.py
+++ b/judgments/templatetags/court_utils.py
@@ -6,7 +6,7 @@ from django.utils.safestring import mark_safe
 from ds_caselaw_utils.courts import CourtNotFoundException
 from ds_caselaw_utils.courts import courts as all_courts
 
-from judgments.models import CourtDates
+from judgments.models.court_dates import CourtDates
 
 register = template.Library()
 

--- a/judgments/tests/test_courts.py
+++ b/judgments/tests/test_courts.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
-from judgments.models import CourtDates
+from judgments.models.court_dates import CourtDates
 from judgments.templatetags.court_utils import get_court_date_range, get_court_name
 
 

--- a/judgments/tests/test_pdf.py
+++ b/judgments/tests/test_pdf.py
@@ -1,0 +1,79 @@
+from os import environ
+from unittest.mock import Mock, patch
+
+from judgments.models.document_pdf import DocumentPdf
+from judgments.tests.factories import JudgmentFactory
+from judgments.utils import formatted_document_uri
+
+
+class TestDocumentPdf:
+    @patch("judgments.models.document_pdf.requests")
+    def test_get_pdf_size_returns_pdf_size_if_it_exists(self, requests_mock):
+        content_length = "100"
+        head_mock = Mock(headers={"Content-Length": content_length}, status_code=200)
+        requests_mock.head.return_value = head_mock
+
+        document = JudgmentFactory.build()
+        document_pdf = DocumentPdf(document.uri)
+
+        assert document_pdf.size == 100
+
+        requests_mock.head.assert_called_once_with(
+            document_pdf.generate_uri(), headers={"Accept-Encoding": None}
+        )
+
+    @patch("judgments.models.document_pdf.requests")
+    def test_get_pdf_size_returns_blank_string_if_404(self, requests_mock):
+        head_mock = Mock(status_code=404)
+        requests_mock.head.return_value = head_mock
+
+        document = JudgmentFactory.build()
+        document_pdf = DocumentPdf(document.uri)
+
+        assert document_pdf.size is None
+
+    @patch("judgments.models.document_pdf.requests")
+    def test_get_pdf_size_returns_unknown_when_no_content_size(self, requests_mock):
+        head_mock = Mock(headers={}, status_code=200)
+        requests_mock.head.return_value = head_mock
+
+        document = JudgmentFactory.build()
+        document_pdf = DocumentPdf(document.uri)
+
+        assert document_pdf.size is None
+
+    def test_returns_pdf_uri_if_exists(self):
+        document = JudgmentFactory.build()
+        document_pdf = DocumentPdf(document.uri)
+        document_pdf.size = 100
+
+        assert document_pdf.uri == document_pdf.generate_uri()
+
+    def test_generates_uri_if_does_not_exist(self):
+        document = JudgmentFactory.build()
+        document_pdf = DocumentPdf(document.uri)
+        document_pdf.size = None
+
+        assert document_pdf.uri == formatted_document_uri(document.uri, "pdf")
+
+    @patch.dict(environ, {"ASSETS_CDN_BASE_URL": "https://example.org"})
+    def generate_uri_generates_the_correct_uri_with_base_url(self):
+        document_pdf = DocumentPdf("foo/bar/baz")
+
+        assert document_pdf.generate_uri() == "https://example.org/foo_bar_baz.pdf"
+
+    @patch.dict(
+        environ,
+        {
+            "ASSETS_CDN_BASE_URL": "",
+            "PUBLIC_ASSET_BUCKET": "bucket",
+            "S3_REGION": "region",
+        },
+    )
+    def test_generate_uri_generates_the_correct_uri_with_base_url(self):
+        document_pdf = DocumentPdf("foo/bar/baz")
+
+        assert (
+            document_pdf.generate_uri()
+            == "https://bucket.s3.region.amazonaws.com/foo/bar/baz/foo_bar_baz.pdf"
+        )

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from factories import JudgmentFactory
 
 from judgments import converters, utils
-from judgments.models import CourtDates
+from judgments.models.court_dates import CourtDates
 from judgments.tests.fixtures import FakeSearchResponse
 from judgments.utils import as_integer, paginator, search_context_from_url
 from judgments.views.detail import PdfDetailView

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -142,25 +142,27 @@ class TestRobotsDirectives(TestCase):
             response, '<meta name="robots" content="noindex,nofollow" />'
         )
 
+    @patch("judgments.views.detail.DocumentPdf")
     @patch("judgments.views.detail.requests.get")
-    def test_aws_pdf(self, get_pdf):
-        get_pdf.return_value.content = b"CAT"
-        get_pdf.return_value.status_code = 200
+    def test_aws_pdf(self, mock_get, mock_pdf):
+        url = "https://assets.caselaw.nationalarchives.gov.uk/eat/2023/1/eat_2023_1.pdf"
+        mock_pdf.return_value.uri = url
+        mock_get.return_value.content = b"CAT"
+        mock_get.return_value.status_code = 200
         response = self.client.get("/eat/2023/1/data.pdf")
-        get_pdf.assert_called_with(
-            "https://assets.caselaw.nationalarchives.gov.uk/eat/2023/1/eat_2023_1.pdf"
-        )
+        mock_get.assert_called_with(url)
         self.assertContains(response, "CAT")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
+    @patch("judgments.views.detail.DocumentPdf")
     @patch("judgments.views.detail.requests.get")
-    def test_aws_pdf_press_summary(self, get_pdf):
-        get_pdf.return_value.content = b"CAT"
-        get_pdf.return_value.status_code = 200
+    def test_aws_pdf_press_summary(self, mock_get, mock_pdf):
+        url = "https://assets.caselaw.nationalarchives.gov.uk/eat/2023/1/press-summary/1/eat_2023_1_press-summary_1.pdf"
+        mock_pdf.return_value.uri = url
+        mock_get.return_value.content = b"CAT"
+        mock_get.return_value.status_code = 200
         response = self.client.get("/eat/2023/1/press-summary/1/data.pdf")
-        get_pdf.assert_called_with(
-            "https://assets.caselaw.nationalarchives.gov.uk/eat/2023/1/press-summary/1/eat_2023_1_press-summary_1.pdf"
-        )
+        mock_get.assert_called_with(url)
         self.assertContains(response, "CAT")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -5,7 +5,6 @@ from datetime import date, datetime
 from typing import Optional, TypedDict
 from urllib.parse import parse_qs, urlparse
 
-import environ
 from caselawclient.Client import DEFAULT_USER_AGENT, MarklogicApiClient
 from caselawclient.models.documents import Document, DocumentURIString
 from caselawclient.models.press_summaries import PressSummary
@@ -129,17 +128,6 @@ def paginator(current_page, total, size_per_page=RESULTS_PER_PAGE):
         "next_pages": next_pages,
         "number_of_pages": number_of_pages,
     }
-
-
-def get_pdf_uri(document_uri: str) -> str:
-    env = environ.Env()
-    """Create a string saying where the S3 PDF will be for a judgment uri"""
-    pdf_path = f'{document_uri}/{document_uri.replace("/", "_")}.pdf'
-    assets = env("ASSETS_CDN_BASE_URL", default=None)
-    if assets:
-        return f"{assets}/{pdf_path}"
-    else:
-        return f'https://{env("PUBLIC_ASSET_BUCKET")}.s3.{env("S3_REGION")}.amazonaws.com/{pdf_path}'
 
 
 class SearchContextDict(TypedDict):

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -10,7 +10,8 @@ from django.template.response import TemplateResponse
 from django.utils.translation import gettext
 from ds_caselaw_utils import courts as all_courts
 
-from judgments.models import CourtDates, SearchFormErrors
+from judgments.models.court_dates import CourtDates
+from judgments.models.search_form_errors import SearchFormErrors
 from judgments.utils import (
     MAX_RESULTS_PER_PAGE,
     api_client,


### PR DESCRIPTION
This attempts to start tidying up some of the logic around PDF handling and have it in one model class. There's still some tidying up to do around the presentation layer, which will come later.