### PR TITLE
(Chore) Add presentation logic to a Presenter class

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
@@ -4,19 +4,19 @@
   <div class="judgment-download-options__options-list">
     <div class="judgment-download-options__download-option">
       <h3>
-        <a href="{{ context.pdf_uri }}"
+        <a href="{{ context.document.pdf_uri }}"
            aria-label="Download this document as a PDF"
            download="">
-          {% if context.document_noun == 'press summary' %}
+          {% if context.document.document_noun == 'press summary' %}
             {% translate "press_summary.downloadoptions.pdf.cta" %}
           {% else %}
             {% translate "judgment.downloadoptions.pdf.cta" %}
           {% endif %}
-          {{ context.pdf_size }}
+          {{ context.document.pdf_size }}
         </a>
       </h3>
       <p>
-        {% if context.document_noun == 'press summary' %}
+        {% if context.document.document_noun == 'press summary' %}
           {% translate "press_summary.downloadoptions.pdf.description" %}
         {% else %}
           {% translate "judgment.downloadoptions.pdf.description" %}
@@ -25,9 +25,9 @@
     </div>
     <div class="judgment-download-options__download-option">
       <h3>
-        <a href="{% formatted_document_uri context.document_uri 'xml' %}"
+        <a href="{% formatted_document_uri context.document.uri 'xml' %}"
            aria-label="Download this document as XML">
-          {% if context.document_noun == 'press summary' %}
+          {% if context.document.document_noun == 'press summary' %}
             {% translate "press_summary.downloadoptions.xml.cta" %}
           {% else %}
             {% translate "judgment.downloadoptions.xml.cta" %}
@@ -35,7 +35,7 @@
         </a>
       </h3>
       <p>
-        {% if context.document_noun == 'press summary' %}
+        {% if context.document.document_noun == 'press summary' %}
           {% translate "press_summary.downloadoptions.xml.description" %}
         {% else %}
           {% translate "judgment.downloadoptions.xml.description" %}

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -1,19 +1,21 @@
 {% load i18n document_utils utilities %}
 <div class="judgment-toolbar">
   <div class="judgment-toolbar__container">
-    {% if context.document_noun == "press summary" %}
+    {% if context.document.document_noun == "press summary" %}
       <p class="judgment-toolbar__press-summary-title">Press Summary</p>
     {% endif %}
-    <h1 class="judgment-toolbar__title">{{ context.page_title|get_title_to_display_in_html:context.document_noun }}</h1>
-    <p class="judgment-toolbar__reference">{{ context.judgment_ncn }}</p>
+    <h1 class="judgment-toolbar__title">
+      {{ context.document.page_title|get_title_to_display_in_html:context.document.document_noun }}
+    </h1>
+    <p class="judgment-toolbar__reference">{{ context.document.judgment_ncn }}</p>
     <div class="judgment-toolbar__buttons judgment-toolbar-buttons">
-      {% if context.linked_document_uri %}
+      {% if context.document.linked_document_uri %}
         {% spaceless %}
           <a class="judgment-toolbar-buttons__option--related-document btn-related-document"
              role="button"
              draggable="false"
-             href="{% url 'detail' document_uri=context.linked_document_uri %}{% if context.query %}?query={{ context.query | urlencode }}{% endif %}">
-            {% if context.document_noun == "judgment" %}
+             href="{% url 'detail' document_uri=context.document.linked_document_uri %}{% if context.query %}?query={{ context.query | urlencode }}{% endif %}">
+            {% if context.document.document_noun == "judgment" %}
               {% translate "judgment.view_press_summary" %}
             {% else %}
               {% translate "judgment.view_judgment" %}
@@ -25,9 +27,9 @@
       <a class="judgment-toolbar-buttons__option--pdf btn"
          role="button"
          draggable="false"
-         href="{{ context.pdf_uri }}"
-         aria-label="{{ context.page_title|get_title_to_display_in_html:context.document_noun }} - Download as PDF">{% translate "judgment.downloadaspdf" %}
-        <span style="font-weight:normal;font-size:0.9rem">{{ context.pdf_size }}</span></a>
+         href="{{ context.document.pdf_uri }}"
+         aria-label="{{ context.document.page_title|get_title_to_display_in_html:context.document.document_noun }} - Download as PDF">{% translate "judgment.downloadaspdf" %}
+        <span style="font-weight:normal;font-size:0.9rem">{{ context.documnent.pdf_size }}</span></a>
       <p class="judgment-toolbar-buttons__option--download-options"
          role="note">
         <a href="#download-options">{% translate "judgment.downloadoptions.shortcutlink" %}</a>

--- a/ds_judgements_public_ui/templates/judgment/detail.html
+++ b/ds_judgements_public_ui/templates/judgment/detail.html
@@ -4,7 +4,7 @@
   <meta name="robots" content="noindex,nofollow" />
 {% endblock robots %}
 {% block title %}
-  {% if context.page_title %}{{ context.page_title }} -{% endif %}
+  {% if context.document.page_title %}{{ context.document.page_title }} -{% endif %}
   Find case law
 {% endblock title %}
 {% block precontent %}
@@ -23,10 +23,10 @@
             <span class="document-navigation-links__query-text">{{ context.query }}</span>
           </span>&nbsp;
           <span class="document-navigation-links__match-count-wrapper matches">
-            (<span class="document-navigation-links__match-count count">{{ context.number_of_mentions }}</span> matches)
+            (<span class="document-navigation-links__match-count count">{{ context.document.number_of_mentions }}</span> matches)
             <a class="document-navigation-links__remove-query-link"
                title="Remove query highlights"
-               href="{% url 'detail' context.document_uri %}">Remove query highlights</a>
+               href="{% url 'detail' context.document.document_uri %}">Remove query highlights</a>
           </span>
         </span>
       {% endif %}
@@ -38,9 +38,9 @@
     </span>
   </div>
   <div id="start-of-document"></div>
-  {% if context.document %}
+  {% if context.document.content %}
     {% autoescape off %}
-      {{ context.document }}
+      {{ context.document.content }}
     {% endautoescape %}
   {% else %}
     {{ content }}

--- a/judgments/presenters/document_presenter.py
+++ b/judgments/presenters/document_presenter.py
@@ -1,0 +1,92 @@
+from functools import cached_property
+from typing import Optional, Union, cast
+
+from caselawclient.models.documents import Document, DocumentURIString
+from caselawclient.models.judgments import Judgment
+from caselawclient.models.press_summaries import PressSummary
+from django.template.defaultfilters import filesizeformat
+
+from judgments.models.document_pdf import DocumentPdf
+from judgments.utils import preprocess_query
+
+
+class DocumentPresenter:
+    MOST_RECENT_VERSION = DocumentURIString("")
+    PASSTHROUGH_PROPERTIES = [
+        "uri",
+        "document_noun",
+        "name",
+        "content_as_xml",
+    ]
+    PASSTHROUGH_ALIASES = {
+        "judgment_ncn": "best_human_identifier",
+        "document_uri": "uri",
+        "page_title": "name",
+    }
+
+    def __init__(self, doc: Document, pdf: DocumentPdf, query: Optional[str] = None):
+        self.doc: Union[PressSummary, Judgment]
+        if doc.document_noun == "press summary":
+            self.doc = cast(PressSummary, doc)
+        else:
+            self.doc = cast(Judgment, doc)
+        self.query = query
+        self.pdf = pdf
+
+    def __getattr__(self, name):
+        if name in self.PASSTHROUGH_PROPERTIES:
+            return getattr(self.doc, name)
+        elif name in self.PASSTHROUGH_ALIASES.keys():
+            return getattr(self.doc, self.PASSTHROUGH_ALIASES[name])
+        else:
+            raise AttributeError(name)
+
+    @cached_property
+    def number_of_mentions(self):
+        if self.query:
+            return self.doc.number_of_mentions(self.query)
+
+    @cached_property
+    def linked_document_uri(self):
+        return self.linked_document.uri
+
+    @cached_property
+    def linked_document(self):
+        return self.doc.linked_document
+
+    @cached_property
+    def content(self):
+        return self.doc.content_as_html(
+            self.MOST_RECENT_VERSION,
+            query=preprocess_query(self.query) if self.query is not None else None,
+        )
+
+    @cached_property
+    def pdf_size(self):
+        """Return the size of the S3 PDF for a document as a string in brackets, or an empty string if unavailable"""
+        size = self.pdf.size
+        if size is None:
+            return ""
+        else:
+            return f" ({filesizeformat(size)})"
+
+    @cached_property
+    def pdf_uri(self):
+        return self.pdf.uri
+
+    @property
+    def breadcrumbs(self):
+        if self.doc.document_noun == "press summary":
+            return [
+                {
+                    "url": "/" + self.linked_document_uri,
+                    "text": self.linked_document.name,
+                },
+                {
+                    "text": "Press Summary",
+                },
+            ]
+        else:
+            return [
+                {"text": self.name},
+            ]

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -67,9 +67,11 @@ class JudgmentFactory(DocumentFactory):
     target_class = Judgment
     PARAMS_MAP = dict(DocumentFactory.PARAMS_MAP)
     PARAMS_MAP["document_noun"] = "judgment"
+    PARAMS_MAP["linked_document"] = DocumentFactory.build()
 
 
 class PressSummaryFactory(DocumentFactory):
     target_class = PressSummary
     PARAMS_MAP = dict(DocumentFactory.PARAMS_MAP)
     PARAMS_MAP["document_noun"] = "press summary"
+    PARAMS_MAP["linked_document"] = DocumentFactory.build()

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -6,7 +6,7 @@ from caselawclient.errors import DocumentNotFoundError
 from django.http import Http404, HttpResponseRedirect
 from django.template.defaultfilters import filesizeformat
 from django.test import Client, TestCase
-from factories import JudgmentFactory, PressSummaryFactory
+from factories import DocumentFactory, JudgmentFactory, PressSummaryFactory
 
 from judgments.tests.utils.assertions import (
     assert_contains_html,
@@ -221,6 +221,11 @@ class TestPressSummaryLabel(TestCase):
         response = self.client.get(
             "/test/2023/123"
         )  # has to match factory to avoid redirect.
+
+        import logging
+
+        logging.info("xxxxxxxx Response: %s xxxxxx", response.content)
+
         self.assertContains(
             response,
             '<p class="judgment-toolbar__press-summary-title">Press Summary</p>',
@@ -285,11 +290,17 @@ class TestViewRelatedDocumentButton:
         def get_document_by_uri_side_effect(document_uri):
             if document_uri == uri:
                 return JudgmentFactory.build(
-                    uri=uri, is_published=True, document_noun=document_noun
+                    uri=uri,
+                    is_published=True,
+                    document_noun=document_noun,
+                    linked_document=DocumentFactory.build(uri=expected_href),
                 )
             elif document_uri == expected_href:
                 return JudgmentFactory.build(
-                    uri=expected_href, is_published=True, document_noun=document_noun
+                    uri=expected_href,
+                    is_published=True,
+                    document_noun=document_noun,
+                    linked_document=DocumentFactory.build(uri=expected_href),
                 )
             else:
                 raise DocumentNotFoundError()
@@ -346,11 +357,17 @@ class TestViewRelatedDocumentButton:
         def get_document_by_uri_side_effect(document_uri):
             if document_uri == uri:
                 return JudgmentFactory.build(
-                    uri=uri, is_published=True, document_noun=document_noun
+                    uri=uri,
+                    is_published=True,
+                    document_noun=document_noun,
+                    linked_document=DocumentFactory.build(uri=expected_href),
                 )
             elif document_uri == expected_href:
                 return JudgmentFactory.build(
-                    uri=expected_href, is_published=True, document_noun=document_noun
+                    uri=expected_href,
+                    is_published=True,
+                    document_noun=document_noun,
+                    linked_document=DocumentFactory.build(uri=expected_href),
                 )
             else:
                 raise DocumentNotFoundError()
@@ -432,21 +449,18 @@ class TestBreadcrumbs:
         AND an additional `Press Summary` breadcrumb
         """
 
-        def pj(uri):
-            if "press" in uri:
-                return PressSummaryFactory.build(
-                    uri="eat/2023/1/press-summary/1",
-                    is_published=True,
-                    name="Press Summary of Judgment A",
-                )
-            else:
-                return JudgmentFactory.build(
-                    uri="eat/2023/1/the_judgment_uri",
-                    is_published=True,
-                    name="The Title of Judgment A",
-                )
+        judgment = DocumentFactory.build(
+            uri="eat/2023/1/the_judgment_uri", name="Judgment A"
+        )
 
-        mock_get_document_by_uri.side_effect = pj
+        press_summary = PressSummaryFactory.build(
+            uri="eat/2023/1/press-summary/1",
+            is_published=True,
+            name="Press Summary of Judgment A",
+            linked_document=judgment,
+        )
+
+        mock_get_document_by_uri.return_value = press_summary
 
         response = self.client.get("/eat/2023/1/press-summary/1")
         breadcrumb_html = """

--- a/judgments/tests/test_document_presenter.py
+++ b/judgments/tests/test_document_presenter.py
@@ -1,0 +1,99 @@
+from unittest.mock import Mock
+
+import pytest
+from django.template.defaultfilters import filesizeformat
+
+from judgments.presenters.document_presenter import DocumentPresenter
+from judgments.tests.factories import JudgmentFactory, PressSummaryFactory
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        JudgmentFactory.build(),
+        PressSummaryFactory.build(),
+    ],
+)
+class TestDocumentPresenter:
+
+    def test_passthrough_properties_get_passed_from_model(self, document):
+        document_presenter = DocumentPresenter(document, Mock())
+
+        for key in document_presenter.PASSTHROUGH_PROPERTIES:
+            assert getattr(document_presenter, key) == getattr(document, key)
+
+        for key in document_presenter.PASSTHROUGH_ALIASES:
+            assert getattr(document_presenter, key) == getattr(
+                document, document_presenter.PASSTHROUGH_ALIASES[key]
+            )
+
+    def test_number_of_mentions_returns_nothing_without_query(self, document):
+        document_presenter = DocumentPresenter(document, Mock())
+
+        assert document_presenter.number_of_mentions is None
+
+    def test_number_of_mentions_calls_number_of_mentions_with_query(self, document):
+        query = "query=Query"
+        document_presenter = DocumentPresenter(document, Mock(), query)
+
+        assert document_presenter.number_of_mentions == document.number_of_mentions(
+            query
+        )
+
+    def test_linked_document_uri_returns_linked_uri(self, document):
+        document_presenter = DocumentPresenter(document, Mock())
+        assert document_presenter.linked_document_uri == document.linked_document.uri
+
+    def test_content_returns_latest_version_as_html(self, document):
+        document_presenter = DocumentPresenter(document, Mock())
+
+        assert document_presenter.content == document.content_as_html(
+            document_presenter.MOST_RECENT_VERSION, None
+        )
+
+    def test_content_returns_latest_version_as_html_when_query_provided(self, document):
+        query = "query=query"
+        document_presenter = DocumentPresenter(document, Mock(), query)
+
+        assert document_presenter.content == document.content_as_html(
+            document_presenter.MOST_RECENT_VERSION, query
+        )
+
+    def test_get_pdf_size_returns_formatted_pdf_size(self, document):
+        pdf = Mock(size=100)
+
+        document_presenter = DocumentPresenter(document, pdf)
+
+        assert document_presenter.pdf_size == f" ({filesizeformat(pdf.size)})"
+
+    def test_get_pdf_size_returns_blank_string_if_size_null(self, document):
+        pdf = Mock(size=None)
+
+        document_presenter = DocumentPresenter(document, pdf)
+
+        assert document_presenter.pdf_size == ""
+
+    def test_returns_pdf_uri_if_exists(self, document):
+        pdf = Mock(uri="foo/bar/baz")
+        document_presenter = DocumentPresenter(document, pdf)
+
+        assert document_presenter.pdf_uri == "foo/bar/baz"
+
+    def test_breadcrumbs(self, document):
+        pdf = Mock()
+        document_presenter = DocumentPresenter(document, pdf)
+
+        if document.document_noun == "press summary":
+            assert document_presenter.breadcrumbs == [
+                {
+                    "url": "/" + document.linked_document.uri,
+                    "text": document.linked_document.name,
+                },
+                {
+                    "text": "Press Summary",
+                },
+            ]
+        else:
+            assert document_presenter.breadcrumbs == [
+                {"text": document.name},
+            ]

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -7,20 +7,14 @@ from caselawclient.models.documents import Document, DocumentURIString
 from django.conf import settings
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
-from django.template.defaultfilters import filesizeformat
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.views.generic import TemplateView
 from django_weasyprint import WeasyTemplateResponseMixin
 
 from judgments.models.document_pdf import DocumentPdf
-from judgments.utils import (
-    get_document_by_uri,
-    linked_doc_title,
-    linked_doc_url,
-    preprocess_query,
-    search_context_from_url,
-)
+from judgments.presenters.document_presenter import DocumentPresenter
+from judgments.utils import get_document_by_uri, search_context_from_url
 
 MOST_RECENT_VERSION = DocumentURIString("")
 
@@ -90,62 +84,25 @@ def get_best_pdf(request, document_uri):
 
 def detail(request, document_uri):
     query = request.GET.get("query")
-    document = get_published_document_by_uri(document_uri)
     pdf = DocumentPdf(document_uri)
+    document = DocumentPresenter(
+        get_published_document_by_uri(document_uri), pdf, query
+    )
 
     # If the document_uri which was requested isn't the canonical URI of the document, redirect the user
-    if document_uri != document.uri:
+    if document_uri != document.document_uri:
         redirect_uri = reverse("detail", kwargs={"document_uri": document.uri})
         return HttpResponseRedirect(redirect_uri)
 
-    context = {}
-    context["document_noun"] = document.document_noun
-    if document.best_human_identifier is None:
+    if document.judgment_ncn is None:
         raise NoNeutralCitationError(document.uri)
-    context["judgment_ncn"] = document.best_human_identifier
-    if query:
-        context["number_of_mentions"] = str(document.number_of_mentions(query))
-        context["query"] = query
-
-    try:
-        context["linked_document_uri"] = get_published_document_by_uri(
-            linked_doc_url(document)
-        ).uri
-    except Http404:
-        context["linked_document_uri"] = ""
-
-    context["document"] = document.content_as_html(
-        MOST_RECENT_VERSION,
-        query=preprocess_query(query) if query is not None else None,
-    )  # "" is most recent version
-    context["document_uri"] = document.uri
-    context["page_title"] = document.name
-    context["pdf_size"] = (
-        f" ({filesizeformat(pdf.size)})" if pdf.size else " (unknown size)"
-    )
-    context["pdf_uri"] = pdf.uri
-
-    if document.document_noun == "press summary":
-        breadcrumbs = [
-            {
-                "url": "/" + context["linked_document_uri"],
-                "text": linked_doc_title(document),
-            },
-            {
-                "text": "Press Summary",
-            },
-        ]
-    else:
-        breadcrumbs = [
-            {"text": document.name},
-        ]
 
     return TemplateResponse(
         request,
         "judgment/detail.html",
         context={
-            "context": context,
-            "breadcrumbs": breadcrumbs,
+            "context": {"query": query, "document": document},
+            "breadcrumbs": document.breadcrumbs,
             "feedback_survey_type": "judgment",  # TODO: update the survey to allow for generalisation to `document`
             # https://trello.com/c/l0iBFM1e/1151-update-survey-to-account-for-judgment-the-fact-that-we-have-press-summaries-as-well-as-judgments-now
             "feedback_survey_document_uri": document.uri,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ xmltodict~=0.13.0
 requests-toolbelt~=1.0.0
 lxml~=5.1.0
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=22.0.2
+ds-caselaw-marklogic-api-client~=22.1.0
 ds-caselaw-utils==1.4.1
 rollbar
 django-weasyprint==2.2.2


### PR DESCRIPTION
This tidies up some of the logic in the detail view to get a better separation of concerns between the data layer and the presentation layer to make the view code simpler and the presentation stuff easier to test. It's by no means perfect, but hopefully gives us a base to build from.