### PR TITLE
weasy_pdf no longer has name, hardcode reference instead for now

### DIFF
--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -85,7 +85,13 @@ def get_best_pdf(request, document_uri):
             f"Unexpected {response.status_code} error on {document_uri} whilst trying to get_best_pdf"
         )
     # fall back to weasy_pdf
-    return redirect(reverse("weasy_pdf", kwargs={"document_uri": document_uri}))
+
+    return redirect(
+        reverse(
+            "detail",
+            kwargs={"document_uri": document_uri, "file_format": "generated.pdf"},
+        )
+    )
 
 
 def detail(request, document_uri):


### PR DESCRIPTION
Not sure what the best fix for the redirect is -- should probably be a reverse, but that's not possible any more.

The generated.xml endpoint had a name, but that went away in the refactor, so now we need to be a bit more explicit.