### PR TITLE
Bugfix/date filter lost on change sort

### DIFF
--- a/ds_judgements_public_ui/templates/includes/recent_judgments.html
+++ b/ds_judgements_public_ui/templates/includes/recent_judgments.html
@@ -13,7 +13,7 @@
           </span>
           <span>
             <span class="judgment-listing__neutralcitation">{{ item.neutral_citation }}</span>
-            <time class="judgment-listing__date" datetime="{{ item.date }}">{{ item.date|date }}</time>
+            <time class="judgment-listing__date" datetime="{{ item.date }}">{{ item.date|date:"d M Y" }}</time>
           </span>
         </li>
       {% endfor %}

--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -10,6 +10,8 @@
       {% if value != None %}
         {% if key == "court" %}
           {% for court in value %}<input type="hidden" name="court" value="{{ court }}" />{% endfor %}
+        {% elif key == "from" or key == "to" %}
+          <input type="hidden" name="{{ key }}" value="{{ value|date:'Y-m-d' }}" />
         {% elif key != "order" or key != "per_page" %}
           <input type="hidden" name="{{ key }}" value="{{ value }}" />
         {% endif %}

--- a/ds_judgements_public_ui/templates/includes/results_applied_filters.html
+++ b/ds_judgements_public_ui/templates/includes/results_applied_filters.html
@@ -15,7 +15,13 @@
                href="{% url 'search' %}?{{ context.query_params|remove_query:key }}">
               <span class="results-search-component__removable-options-key">{{ key|capfirst }}:</span>
               <span class="results-search-component__removable-options-value">
-                <span class="results-search-component__removable-options-value-text">{{ value }}</span>
+                <span class="results-search-component__removable-options-value-text">
+                  {% if key == 'from' or key == 'to' %}
+                    {{ value|date:"d M Y" }}
+                  {% else %}
+                    {{ value }}
+                  {% endif %}
+                </span>
               </span>
             </a>
           </li>

--- a/ds_judgements_public_ui/templates/includes/results_list.html
+++ b/ds_judgements_public_ui/templates/includes/results_list.html
@@ -29,7 +29,7 @@
         </span>
         <span>
           <span class="judgment-listing__neutralcitation">{{ item.neutral_citation }}</span>
-          <time class="judgment-listing__date" datetime="{{ item.date }}">{{ item.date|date }}</time>
+          <time class="judgment-listing__date" datetime="{{ item.date }}">{{ item.date|date:"d M Y" }}</time>
         </span>
       </span>
       {% if item|show_matches:context.query %}

--- a/judgments/test_date_parsing.py
+++ b/judgments/test_date_parsing.py
@@ -22,7 +22,7 @@ class TestDateParsing(TestCase):
         """
         params = {"date": "2019-12-02"}
         parsed = parse_date_parameter(params, "date")
-        self.assertEqual(parsed, "2019-12-02")
+        self.assertEqual(parsed, date(2019, 12, 2))
 
     def test_provided_date_takes_precedence(self):
         """
@@ -35,7 +35,7 @@ class TestDateParsing(TestCase):
             "date_year": "2020",
         }
         parsed = parse_date_parameter(params, "date")
-        self.assertEqual(parsed, "2019-12-02")
+        self.assertEqual(parsed, date(2019, 12, 2))
 
     def test_a_blank_date_does_not_count_as_provided(self):
         """

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -224,6 +224,7 @@ class TestPressSummaryLabel(TestCase):
         self.assertContains(
             response,
             '<p class="judgment-toolbar__press-summary-title">Press Summary</p>',
+            html=True,
         )
 
     @patch("judgments.views.detail.DocumentPdf", autospec=True)

--- a/judgments/tests/test_homepage.py
+++ b/judgments/tests/test_homepage.py
@@ -15,7 +15,4 @@ class TestHomepage(TestCase):
         mock_search_judgments_and_parse_response.assert_called_with(
             mock_api_client, SearchParameters(order="-date")
         )
-        self.assertContains(
-            response,
-            "A SearchResult name!",
-        )
+        self.assertContains(response, "A SearchResult name!", html=True)

--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -28,10 +28,7 @@ class TestBrowseResults(TestCase):
                 page_size=10,
             ),
         )
-        self.assertContains(
-            response,
-            "A SearchResult name!",
-        )
+        self.assertContains(response, "A SearchResult name!", html=True)
 
 
 class TestSearchResults(TestCase):
@@ -45,6 +42,7 @@ class TestSearchResults(TestCase):
         self.assertContains(
             response,
             '<span class="results-search-component__removable-options-value-text">waltham forest</span>',
+            html=True,
         )
         mock_search_judgments_and_parse_response.assert_called_with(
             mock_api_client,
@@ -143,7 +141,9 @@ class TestSearchResults(TestCase):
         )
         message = html.escape(gettext("search.errors.from_date_headline"))
         self.assertContains(
-            response, f'<div class="page-notification--failure">{message}</div>'
+            response,
+            f'<div class="page-notification--failure">{message}</div>',
+            html=True,
         )
 
     @patch("judgments.views.advanced_search.api_client")
@@ -157,7 +157,9 @@ class TestSearchResults(TestCase):
         )
         message = html.escape(gettext("search.errors.to_date_headline"))
         self.assertContains(
-            response, f'<div class="page-notification--failure">{message}</div>'
+            response,
+            f'<div class="page-notification--failure">{message}</div>',
+            html=True,
         )
 
     @patch("judgments.views.advanced_search.api_client")
@@ -169,7 +171,9 @@ class TestSearchResults(TestCase):
         response = self.client.get("/judgments/search?to_year=2022&from_year=2023")
         message = html.escape(gettext("search.errors.to_before_from_headline"))
         self.assertContains(
-            response, f'<div class="page-notification--failure">{message}</div>'
+            response,
+            f'<div class="page-notification--failure">{message}</div>',
+            html=True,
         )
 
 

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -139,7 +139,7 @@ class TestRobotsDirectives(TestCase):
         # with nofollow,noindex
         response = self.client.get("/judgments/search?query=waltham+forest")
         self.assertContains(
-            response, '<meta name="robots" content="noindex,nofollow" />'
+            response, '<meta name="robots" content="noindex,nofollow" />', html=True
         )
 
     @patch("judgments.views.detail.DocumentPdf")
@@ -210,6 +210,7 @@ class TestRobotsDirectives(TestCase):
         self.assertContains(
             response,
             "The Find Case Law service provides public access to court judgments and tribunal decisions.",
+            html=True,
         )  # actual content of page
 
     def test_static_pages(self):

--- a/judgments/utils.py
+++ b/judgments/utils.py
@@ -30,7 +30,7 @@ def format_date(date):
     if date == "" or date is None:
         return None
 
-    time = datetime.strptime(date, "%Y-%m-%d")
+    time = date.strptime(date, "%Y-%m-%d")
     return time.strftime("%d-%m-%Y")
 
 
@@ -187,7 +187,7 @@ def parse_date_parameter(
     month_param_name = f"{param_name}_month"
     day_param_name = f"{param_name}_day"
     if parameter_provided(params, param_name):
-        return params[param_name]
+        return datetime.strptime(params[param_name], "%Y-%m-%d").date()
     elif parameter_provided(params, year_param_name):
         year = parse_parameter_as_int(params, year_param_name)
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

 - Fixed bug where date filters were lost on changing the page sort order / number of results per page. I also fixed an underlying bug in `parse_date_parameter` whereby if the date was provided as a string parameter (eg. `from=2021-01-01`) the parse function would return a string, but if i provided seperate date part parameters (eg. `from_year=2021&from_month=01&from_day=01`) then it would return a `date`. The function will now return a date object in all cases.
 - Made some tests less brittle by making them ignore whitespace when matching against http responses

## Trello card / Rollbar error (etc)

https://trello.com/c/xNlAGB0Z/1746-date-filters-broken-on-pui-on-hold-till-ncn-match-work-done


