### PR TITLE
New courts index page links to search instead of court homepage

### DIFF
--- a/ds_judgements_public_ui/templates/includes/courts_and_tribunals_court.html
+++ b/ds_judgements_public_ui/templates/includes/courts_and_tribunals_court.html
@@ -1,7 +1,7 @@
 {% load court_utils %}
 <div>
   <h4>
-    <a href="{% url 'court_or_tribunal' param=court.canonical_param %}">{{ court.grouped_name }}</a>
+    <a href="{% url "search" %}?court={{ court.canonical_param }}">{{ court.grouped_name }}</a>
   </h4>
   <p>
     {{ court | get_court_judgments_count }} documents from


### PR DESCRIPTION
## Changes in this PR:

As discussed in sprint review 4/3/24, to ensure users can refine and filter after arriving at court page, until the persistent search work has been advanced.
