### PR TITLE
Revert "Computational user research invitation"

### DIFF
--- a/ds_judgements_public_ui/templates/pages/computational_licence.html
+++ b/ds_judgements_public_ui/templates/pages/computational_licence.html
@@ -32,10 +32,6 @@
   <p>
     You can read more about case law as data and licences: <a href="https://caselaw.nationalarchives.gov.uk/about-this-service#section-data">https://caselaw.nationalarchives.gov.uk/about-this-service#section-data</a>.
   </p>
-  <p>
-    We want to understand how we can improve the experience for people applying for a licence. We are working with an independent research organisation to conduct a brief round of research on the 7th and 12th March 2024.
-    If you would like to take part in the research please register your interest by <a href='https://survey.alchemer.com/s3/7698805/BF4982-National-Archives-Case-Law-Research'>completing this short survey</a>.
-  </p>
   <h2>Before you start</h2>
   <h3>1. Check you need to apply</h3>
   <p>


### PR DESCRIPTION
## Changes in this PR:
- Remove invitation to research from the Computational licence page

## Trello card / Rollbar error (etc)

https://trello.com/c/fit5u0hK/1725-remove-invitation-to-research-from-github-docs-readme-and-public-ui-4th-march

## Screenshots of UI changes:

### Before
![Screenshot 2024-03-06 at 11 18 38](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/579522/db6ae520-5fbc-4076-914f-9e81ad3d04d7)

### After
![Screenshot 2024-03-06 at 11 18 58](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/579522/6ec846a7-34e3-492d-a586-4b25e8fcabdf)

- [ ] Requires env variable(s) to be updated
