### PR TITLE
Further fixes to visual breakage introduced by integtrating tna-frontend

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_footer.scss
+++ b/ds_judgements_public_ui/sass/includes/_footer.scss
@@ -42,7 +42,6 @@
   h3 {
     @media (max-width: $grid-breakpoint-medium) {
       padding-top: calc($spacer-unit / 2);
-      margin-bottom: calc($spacer-unit / 3);
     }
   }
 

--- a/ds_judgements_public_ui/sass/includes/_header.scss
+++ b/ds_judgements_public_ui/sass/includes/_header.scss
@@ -12,14 +12,18 @@
   }
 
   &__site-logo a {
-    color: $color-white;
+    color: $color-white !important;
     font-size: 2rem;
     text-decoration: none;
 
     &:focus {
-      outline: 5px solid $color-white;
+      outline: 5px solid $color-white !important;
       outline-offset: 5px;
       z-index: 999;
+    }
+
+    &:visited {
+      color: $color-white !important;
     }
   }
 

--- a/ds_judgements_public_ui/sass/includes/_judgments_listing.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgments_listing.scss
@@ -1,5 +1,7 @@
 .judgment-listing {
   &__list {
+    margin-top: $spacer-unit;
+
     &--last-page {
       margin-bottom: 0;
     }

--- a/ds_judgements_public_ui/sass/includes/_mixins.scss
+++ b/ds_judgements_public_ui/sass/includes/_mixins.scss
@@ -80,20 +80,20 @@
 }
 
 @mixin link-on-dark-bg {
-  color: $color-white;
+  color: $color-white !important;
   text-decoration: underline;
 
   &:hover {
     text-decoration: none;
-    color: $color-white;
+    color: $color-white !important;
   }
 
   &:visited {
-    color: $color-white;
+    color: $color-white !important;
   }
 
   &:active {
-    color: $color-white;
+    color: $color-white !important;
   }
 
   &:focus {

--- a/ds_judgements_public_ui/sass/includes/_standard_text_template.scss
+++ b/ds_judgements_public_ui/sass/includes/_standard_text_template.scss
@@ -3,4 +3,8 @@
   line-height: 1.4em;
 
   min-height: 18rem;
+
+  p {
+    margin-bottom: $spacer-unit; /* Override global margin reset from tna-frontend */
+  }
 }

--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -161,6 +161,7 @@
 
   &__help-text {
     margin-top: calc($spacer-unit / 4);
+    margin-bottom: $spacer-unit;
     font-size: 0.8rem;
   }
 

--- a/ds_judgements_public_ui/sass/main.scss
+++ b/ds_judgements_public_ui/sass/main.scss
@@ -4,10 +4,16 @@
 // Override variables in tna-frontend
 @use "../../node_modules/@nationalarchives/frontend/nationalarchives/variables/colour"
   with (
-  $link-colour: $color-link-blue
+  $link-colour: $color-link-blue,
+  $link-colour-visited: $color-link-blue-visited
 );
 // Include all of tna-frontend
 @use "../../node_modules/@nationalarchives/frontend/nationalarchives/all";
+
+.judgment * {
+  /* The tna-frontend css overrides default margins on everything and sets them to 0, which breaks the formatting of judgments. This rule restores the original spacings within the judgment (at least to a degree of similarity perceptible by me (Tim)). We don't want to include this in the ds-caselaw-frontend shared code yet, as the tna-frontend issue is (for now) specific to PUI. */
+  margin-bottom: calc(0.5 * $spacer-unit);
+}
 
 // Core
 @import "includes/variables";

--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -1,7 +1,7 @@
 {% load static i18n %}
 <!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}
-<html lang="{{ LANGUAGE_CODE }}">
+<html lang="{{ LANGUAGE_CODE }}" class="tna-template--system-theme">
   <head>
     <meta charset="utf-8" />
     {% block meta_description %}

--- a/ds_judgements_public_ui/templates/pdf/judgment.html
+++ b/ds_judgements_public_ui/templates/pdf/judgment.html
@@ -1,6 +1,6 @@
 {% load static i18n %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="tna-template--system-theme">
   <head>
     <meta charset="UTF-8" />
     <meta name="robots" content="noindex,nofollow" />


### PR DESCRIPTION
## Changes in this PR:

A bit of a can of worms, this. Cristina noticed that footer links were the incorrect colour, in fixing that I noticed that the link-visited colour wasn't being applied without adding the global theme classname to the html element, which in turn reset some margins which broke various aspects of the layout subtley. 

I've addressed all of these as far as i can tell, and tested comprehensively (including checking a variety of judgments against production). we'll need all eyes on staging before we're ready for this to go live, but i think (fingers crossed) that this addresses the bulk of it.

 If we find any further issues i think we should reconsider using tna-frontend, at least for now (i'm going to raise an issue with them in order to ask them to scope their styles a little more closely).

