### PR TITLE
fix breakage to mobile logo alignment from tna-frontend

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_header.scss
+++ b/ds_judgements_public_ui/sass/includes/_header.scss
@@ -129,6 +129,10 @@
       outline-color: $color-white;
     }
 
+    img {
+      display: inline; /* tna-frontend unilaterally sets all images to block which breaks the layout without specifying this explicitly here */
+    }
+
     @media only screen and (max-width: $grid-breakpoint-medium) {
       text-align: center;
       padding-bottom: 0;


### PR DESCRIPTION

## Changes in this PR:

tna-frontend unilaterally sets images to be 'block' rather than 'inline' which breaks the header on mobile. This fixes by specifying that the header image is inline explicitly

## Screenshots of UI changes:

### Before
![Screenshot 2024-03-06 at 17 45 29](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/7f73aeb0-14b4-4bfe-9752-a4d9b3dbf88a)

### After
![Screenshot 2024-03-06 at 17 45 12](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/564bd083-0042-459b-9f29-759df17d01cd)

