### PR TITLE
version bump ds-caselaw-frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@nationalarchives/ds-caselaw-frontend": "github:nationalarchives/ds-caselaw-frontend#v2.0.1",
+        "@nationalarchives/ds-caselaw-frontend": "github:nationalarchives/ds-caselaw-frontend#v2.0.2",
         "nodemon": "^3.0.3",
         "sass": "^1.58.3"
       },
@@ -1757,8 +1757,9 @@
       }
     },
     "node_modules/@nationalarchives/ds-caselaw-frontend": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/nationalarchives/ds-caselaw-frontend.git#959551161ab207e7a053f795242487da2a175e97"
+      "version": "2.0.2",
+      "resolved": "git+ssh://git@github.com/nationalarchives/ds-caselaw-frontend.git#1513961ae3433a13f28521f615386630b2031372",
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "8.56.6",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "IE 11"
   ],
   "dependencies": {
-    "@nationalarchives/ds-caselaw-frontend": "github:nationalarchives/ds-caselaw-frontend#v2.0.1",
+    "@nationalarchives/ds-caselaw-frontend": "github:nationalarchives/ds-caselaw-frontend#v2.0.2",
     "nodemon": "^3.0.3",
     "sass": "^1.58.3"
   }


### PR DESCRIPTION
## Changes in this PR:

Version bumps caselaw-frontend, bringing in a fix for the lack of scroll-margin on judgment section headers!

## Trello card / Rollbar error (etc)

https://trello.com/c/nKBk3jZY/1788-harmonize-scroll-margins-for-links-within-judgments-not-obscured-by-skip-to-the-end-jump-to-the-top
