### PR TITLE
Add gitignores for nixOS development environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,3 +288,7 @@ docker/*
 /ds_judgements_public_ui/static/css/judgmentpdf.css.map
 /ds_judgements_public_ui/static/js/dist/app.js
 .vscode
+
+# Extra config for development environments on NixOS (I'm sorry - Tim)
+.envrc
+shell.nix


### PR DESCRIPTION

## Changes in this PR:

I've finally got a new computer that works! It's not a mac this time, and I'm running [NixOS](https://nixos.org/) on it (which is fantastic! but i won't bore you with the details now.). One thing of note however is that it allows isolated and reproducible per-project build environments which is extremely useful, however, it involves creating a couple of extra files in the project directory. This commit adds those files to the .gitignore :-)

