### PR TITLE
Add highlighting for footnotes in documents

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_document_navigation_links.scss
+++ b/ds_judgements_public_ui/sass/includes/_document_navigation_links.scss
@@ -36,6 +36,7 @@
       grid-template-rows: 1fr;
       row-gap: $spacer-unit;
       column-gap: $spacer-unit;
+      z-index: 2000;
       @media (max-width: $grid-breakpoint-medium) {
         column-gap: 0;
       }


### PR DESCRIPTION
## Changes in this PR:

Aside from bumping the caselaw-frontend version, we need to tweak the z-index of the document navigation bar, so that focused footnotes don't jump on top of it.

Depends on https://github.com/nationalarchives/ds-caselaw-frontend/pull/31

## Trello card / Rollbar error (etc)

https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136?selectedIssue=FCL-41

## Screenshots of UI changes:

![image](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/238f23f5-72d7-4495-b113-eadd74276412)

![image](https://github.com/nationalarchives/ds-caselaw-public-ui/assets/4279/b5073b37-3562-4c1e-a65d-8c44ae647fe8)
