### PR TITLE
add dependencies and config for django-formtools and gds-crispy-forms

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -74,6 +74,8 @@ DJANGO_APPS = [
 
 THIRD_PARTY_APPS = [
     "waffle",
+    "crispy_forms",
+    "crispy_forms_gds",
 ]
 
 LOCAL_APPS = [
@@ -191,6 +193,9 @@ TEMPLATES = [
         },
     }
 ]
+
+CRISPY_ALLOWED_TEMPLATE_PACKS = ["gds"]
+CRISPY_TEMPLATE_PACK = "gds"
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#form-renderer
 FORM_RENDERER = "django.forms.renderers.TemplatesSetting"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,6 +18,8 @@ ds-caselaw-utils==1.4.1
 rollbar
 django-weasyprint==2.3.0
 django-waffle==4.1.0  # https://github.com/django-waffle/django-waffle
+django-formtools~=2.5.1
+crispy-forms-gds~=0.3.1
 markdown-it-py~=3.0.0
 mdit-py-plugins~=0.4.0
 


### PR DESCRIPTION
## Changes in this PR:

-add dependencies and config for django-formtools and gds-crispy-forms

to support both @adam-murray's work on search and mine on the transactional licence form, it makes sense to get this into `main` early so that we can both work on top of it
