### PR TITLE
Add date validation for too-large numbers

### DIFF
--- a/judgments/forms/fields.py
+++ b/judgments/forms/fields.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 from crispy_forms_gds.fields import DateInputField
 from django import forms
+from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 
 from .validators import ValidateYearRange
@@ -80,9 +81,14 @@ class DateRangeInputField(DateInputField):
                 month = 1
             if not day:
                 day = 1
-        if self.date_type == "to":
+        elif self.date_type == "to":
             if not month:
                 month = 12
             if not day:
                 day = monthrange(year, month)[1]
-        return date(year=year, month=month, day=day)  # type: ignore
+        else:
+            raise RuntimeError("date_type is neither `from` nor `to`")
+        try:
+            return date(day=day, month=month, year=year)
+        except ValueError as e:
+            raise ValidationError(str(e)) from e


### PR DESCRIPTION
Fix copied from https://github.com/wildfish/crispy-forms-gds/blob/ec2303771dbc6fecc0be1af41a225fb0a428d87c/src/crispy_forms_gds/fields.py

Currently staging 500s if a date like 99-99-2004 is entered.

<!-- Amend as appropriate -->

## Changes in this PR:

## Trello card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
