### PR TITLE
Use as_integer as int() doesn't like empty strings

### DIFF
--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -138,7 +138,12 @@ def advanced_search(request):
                 order=order,
                 date_from=from_date.strftime("%Y-%m-%d"),
                 date_to=to_date_as_search_param,
-                page_size=int(params.get("per_page", "10")),
+                page_size=as_integer(
+                    params.get("per_page", "10"),
+                    minimum=1,
+                    maximum=MAX_RESULTS_PER_PAGE,
+                    default=RESULTS_PER_PAGE,
+                ),
             )
 
             # Get the response from Marklogic


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
(hopefully) Fix a bug encountered by a user from an empty page length

## Jira card / Rollbar error (etc)
https://app.rollbar.com/a/dxw/fix/item/tna-caselaw-public-ui/323?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
