### PR TITLE
Reinstate context.query

### DIFF
--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -167,6 +167,7 @@ def advanced_search(request):
             }
             # Populate context to provide feedback about filters etc. back to user
             context = context | {
+                "query": query_text,
                 "requires_from_warning": requires_from_warning,
                 "court_facets": court_facets,
                 "year_facets": year_facets,


### PR DESCRIPTION
[Searches for NCNs that do not exist](https://caselaw.nationalarchives.gov.uk/judgments/search?query=[2024]+EWHC+1168+(Admin)) 500. 

Fix that by reinstating `context.query`

## Jira card / Rollbar error (etc)
https://app.rollbar.com/a/dxw/fix/item/tna-caselaw-public-ui/322?utm_campaign=exp_repeat_item_message&utm_medium=slack&utm_source=rollbar-notification

