### PR TITLE
FCL117 - Date warning always appears and tribunals default to courts when sorting. 

### DIFF
--- a/ds_judgements_public_ui/templates/includes/result_controls.html
+++ b/ds_judgements_public_ui/templates/includes/result_controls.html
@@ -8,8 +8,10 @@
         id="analytics-result-controls">
     {% for key, value in context.query_params.items %}
       {% if value != None %}
-        {% if key == "court" or key == "tribunal" %}
+        {% if key == "court" %}
           {% for court in value %}<input type="hidden" name="court" value="{{ court }}" />{% endfor %}
+        {% elif key == "tribunal" %}
+          {% for tribunal in value %}<input type="hidden" name="tribunal" value="{{ tribunal }}" />{% endfor %}
         {% elif key == "from" or key == "to" %}
           <input type="hidden" name="{{ key }}" value="{{ value|date:'Y-m-d' }}" />
         {% elif key != "order" or key != "per_page" %}

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -88,9 +88,8 @@ def advanced_search(request):
             elif not order:
                 order = "relevance"
 
-            from_date: date = form.cleaned_data.get(
-                "from_date", date(get_minimum_valid_year(), 1, 1)
-            )
+            from_date: date = form.cleaned_data.get("from_date", None)
+            requires_from_warning: bool = _do_dates_require_warnings(from_date)
             to_date: Optional[date] = form.cleaned_data.get("to_date")
             # If a from_date is not specified, set it to the current min year
             # This allows the users to choose if they'd like to go beyond that range
@@ -162,8 +161,6 @@ def advanced_search(request):
                 unprocessed_facets, year_facets = process_year_facets(
                     unprocessed_facets
                 )
-
-            requires_from_warning: bool = _do_dates_require_warnings(from_date)
 
             changed_queries = {
                 key: value


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
* We should do the check for the date range warning before we default the from_date, preventing us accidentally rendering the warning all the time.
* Added tribunals hidden input to filter sorting, preventing them defaulting to courts, causing validation to raise an error.

## Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/browse/FCL-117

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
