### PR TITLE
Basic infrastructure for playwright end to end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,18 @@ jobs:
       - name: Run mypy
         run: docker-compose run django mypy ds_judgements_public_ui judgments
 
+      - name: Setup django server for e2e tests
+        run: docker-compose up -d
+
+      - name: Kick off the django server itself
+        run: docker-compose exec -d django python manage.py runserver 0.0.0.0:3000
+
+      - name: Build playwright runner container
+        run: docker-compose build e2e_tests
+
+      - name: Run playwright e2e tests
+        run: docker-compose run e2e_tests pytest --base-url http://django:3000
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,19 @@ python manage.py runserver_plus 0.0.0.0:3000
 
 #### Running the test suite
 
+Pytest unit tests can be run with:
+
 ```console
 fab test
 ```
+
+We also have a suite of end to end tests (in the `e2e_tests/` directory) written with [playwright-pytest](https://playwright.dev/python/docs/api/class-playwright), which can be run with:
+
+```console
+fab e2etest
+```
+
+These will run by default against the running `django` container. You can supply a `baseURL` argument to test against staging or production.
 
 #### Viewing code coverage
 

--- a/compose/local/e2e_tests/Dockerfile
+++ b/compose/local/e2e_tests/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.9
+
+WORKDIR /app
+
+RUN pip install pytest pytest-playwright
+RUN playwright install-deps
+RUN playwright install
+COPY . .
+
+EXPOSE 9222
+
+CMD ["true"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,14 @@ services:
       - "7000:7000"
     command: /start-docs
 
+  e2e_tests:
+    build:
+      context: ./e2e_tests
+      dockerfile: "../compose/local/e2e_tests/Dockerfile"
+    profiles: [e2e_tests]
+    volumes:
+      - "./e2e_tests:/app:z"
+
 networks:
   default:
     name: caselaw

--- a/e2e_tests/test_about_page.py
+++ b/e2e_tests/test_about_page.py
@@ -1,0 +1,14 @@
+from playwright.sync_api import Page, expect
+
+
+def test_about_page(page: Page):
+    """
+    A minimum-viable-integration test of a page
+    that doesn't talk to marklogic or any other
+    external services.
+    """
+    page.goto("/about-this-service")
+
+    expect(page).to_have_title(
+        "About this service - Find case law - The National Archives"
+    )

--- a/fabfile.py
+++ b/fabfile.py
@@ -193,6 +193,25 @@ def test(c, test=None):
         subprocess.run(["docker", "compose", "exec", "django", "pytest", test])
 
 
+@task(optional=["baseUrl"])
+def e2etest(c, baseUrl="http://django:3000"):
+    """
+    Run end-to-end playwright tests against the given base url -
+    the default is the running local django web container.
+    """
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            "build",
+            "e2e_tests",
+        ]
+    )
+    subprocess.run(
+        ["docker", "compose", "run", "e2e_tests", "pytest", "--base-url", baseUrl]
+    )
+
+
 @task
 def coverage(c):
     # Run pytest with coverage

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --ds=config.settings.test --reuse-db --disable-socket
+addopts = --ds=config.settings.test --reuse-db --disable-socket --ignore=e2e_tests/
 python_files = tests.py test_*.py
 markers =
     local: does not work in CI


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

End-to-end tests with [playwright](https://playwright.dev)!

They live in the `e2e_tests/` folder, and are run in a nicely dockerized fashion with `fab e2etest` as  well as in CI (by default against local, but you can run against staging, prod, or some other URL just by providing an argument).

The only missing piece of the puzzle is how to test things that rely on Marklogic from CI, an issue which i do not know how to fix. However, this will allow us to test eg. the transactional licence form, and hopefully start adding tests for other parts of the site!