### PR TITLE
send 'alternative contact' response as 'yes' or 'no' on transactional licence form

### DIFF
--- a/ds_judgements_public_ui/static/js/src/modules/transactional_licence_form.js
+++ b/ds_judgements_public_ui/static/js/src/modules/transactional_licence_form.js
@@ -11,8 +11,7 @@ let setupTogglableFields = function () {
     var licenceHolderEmailId = "div_id_contact-licence_holder_email";
     var licenceHolderControlSelector =
         "#div_id_contact-alternative_contact input";
-    var licenceHolderVisibleValue =
-        "This is a different person (please enter their details below)";
+    var licenceHolderVisibleValue = "Yes";
 
     let toggleFieldState = function (element) {
         if (element && element.value == licenceHolderVisibleValue) {

--- a/transactional_licence_form/choices.py
+++ b/transactional_licence_form/choices.py
@@ -3,8 +3,8 @@ YES_NO_CHOICES = ["Yes", "No"]
 # NOTE: please see comment in transactional_lcence_form.js if
 # changing the wording / order of the options for the alternative contact.
 ALTERNATIVE_CONTACT_CHOICES = [
-    "This is the same person as the main contact",
-    "This is a different person (please enter their details below)",
+    ("No", "This is the same person as the main contact"),
+    ("Yes", "This is a different person (please enter their details below)"),
 ]
 
 TNA_CONTACTTYPE_CHOICES = [

--- a/transactional_licence_form/forms.py
+++ b/transactional_licence_form/forms.py
@@ -38,7 +38,7 @@ class ContactForm(FCLForm):
             "for the licence. This should be someone senior who has overall responsibility "
             "for complaince with the terms and conditions of the licence."
         ),
-        choices=list_to_choices(choices.ALTERNATIVE_CONTACT_CHOICES),
+        choices=choices.ALTERNATIVE_CONTACT_CHOICES,
     )
     licence_holder_lastname = fields.FCLCharField(
         label="1a. Licence holder Full Name",


### PR DESCRIPTION

## Changes in this PR:

Another request from Chris Owens - the "is the licence holder the main contact" question should send either "Yes" or "No as the answer, rather than the user-facing value.