### PR TITLE
FCL-181: Fix skipped test, test_pagination_links

### DIFF
--- a/judgments/tests/fixtures.py
+++ b/judgments/tests/fixtures.py
@@ -28,8 +28,19 @@ class FakeSearchResponseBaseClass:
     modify attributes
     """
 
-    total = 2
-    results = [FakeSearchResult(), FakeSearchResult()]
+    total = 200
+    results = [
+        FakeSearchResult(),
+        FakeSearchResult(),
+        FakeSearchResult(),
+        FakeSearchResult(),
+        FakeSearchResult(),
+        FakeSearchResult(),
+        FakeSearchResult(),
+        FakeSearchResult(),
+        FakeSearchResult(),
+        FakeSearchResult(),
+    ]
     facets = {
         "EAT": "3",
         "EWHC-KBD-TCC": "1",

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -1,5 +1,4 @@
 import re
-from unittest import skip
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -66,14 +65,13 @@ class TestPaginator(TestCase):
         }
         self.assertEqual(paginator(1, 5), expected_result)
 
-    @skip("This test works locally but fails on CI, to fix")
     @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
     def test_pagination_links(self, mock_search_judgments_and_parse_response):
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
-        response = self.client.get("/judgments/search?court=ukut-iac&order=&page=3")
+        response = self.client.get("/judgments/search?tribunal=ukut/iac&order=&page=3")
         decoded_response = response.content.decode("utf-8")
         self.assertIn(
-            "/judgments/search?court=ukut-iac&amp;order=&page=4",
+            "/judgments/search?tribunal=ukut%2Fiac&amp;order=&page=4",
             decoded_response,
         )
 


### PR DESCRIPTION
Noticed 
`SKIPPED [1] judgments/tests/tests.py:69: This test works locally but fails on CI, to fix`
in logs

The test does not work locally due to the tribunal query parameter being required, the fake search results not having enough pages, and the URL being not decoded. 

(It's possible this'll highlight why it was broken in CI)