### PR TITLE
Clean up as_integer

### DIFF
--- a/config/views.py
+++ b/config/views.py
@@ -10,6 +10,7 @@ from ds_caselaw_utils import courts
 
 from judgments.forms import AdvancedSearchForm
 from judgments.utils import api_client, as_integer, paginator
+from judgments.utils.utils import sanitise_input_to_integer
 
 # where the schemas can be downloaded from. Slash-terminated.
 SCHEMA_ROOT = "https://raw.githubusercontent.com/nationalarchives/ds-caselaw-marklogic/main/src/main/ml-schemas/"
@@ -53,7 +54,9 @@ class CourtOrTribunalView(TemplateViewWithContext):
 
     @property
     def page(self):
-        return str(as_integer(self.request.GET.get("page"), minimum=1))
+        return as_integer(
+            sanitise_input_to_integer(self.request.GET.get("page"), 1), minimum=1
+        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/config/views.py
+++ b/config/views.py
@@ -9,7 +9,7 @@ from django.views.generic import TemplateView
 from ds_caselaw_utils import courts
 
 from judgments.forms import AdvancedSearchForm
-from judgments.utils import api_client, as_integer, paginator
+from judgments.utils import api_client, clamp, paginator
 from judgments.utils.utils import sanitise_input_to_integer
 
 # where the schemas can be downloaded from. Slash-terminated.
@@ -54,7 +54,7 @@ class CourtOrTribunalView(TemplateViewWithContext):
 
     @property
     def page(self):
-        return as_integer(
+        return clamp(
             sanitise_input_to_integer(self.request.GET.get("page"), 1), minimum=1
         )
 

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -258,15 +258,10 @@ class TestBackLink(TestCase):
 def test_min_max():
     assert as_integer(0, minimum=1) == 1
     assert as_integer(0, minimum=1) == 1
-    assert as_integer(0, minimum=0, default=1) == 0
-    assert as_integer(-1, minimum=0, default=1) == 0
-    assert as_integer(0, minimum=1, default=10) == 1
     assert as_integer(2, 1, 3) == 2
     assert as_integer(2, 1) == 2
     assert as_integer(5, 1, 3) == 3
     assert as_integer(2, minimum=1, maximum=3) == 2
-    assert as_integer(None, minimum=1, default=4) == 4
-    assert as_integer(None, minimum=1) == 1
 
 
 def test_preprocess_query():

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -7,7 +7,7 @@ from factories import JudgmentFactory
 from judgments import converters, utils
 from judgments.models.court_dates import CourtDates
 from judgments.tests.fixtures import FakeSearchResponse
-from judgments.utils import as_integer, paginator, search_context_from_url
+from judgments.utils import clamp, paginator, search_context_from_url
 from judgments.views.detail import PdfDetailView
 
 
@@ -256,12 +256,12 @@ class TestBackLink(TestCase):
 
 
 def test_min_max():
-    assert as_integer(0, minimum=1) == 1
-    assert as_integer(0, minimum=1) == 1
-    assert as_integer(2, 1, 3) == 2
-    assert as_integer(2, 1) == 2
-    assert as_integer(5, 1, 3) == 3
-    assert as_integer(2, minimum=1, maximum=3) == 2
+    assert clamp(0, minimum=1) == 1
+    assert clamp(0, minimum=1) == 1
+    assert clamp(2, 1, 3) == 2
+    assert clamp(2, 1) == 2
+    assert clamp(5, 1, 3) == 3
+    assert clamp(2, minimum=1, maximum=3) == 2
 
 
 def test_preprocess_query():

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -256,7 +256,6 @@ class TestBackLink(TestCase):
 
 
 def test_min_max():
-    assert as_integer("cow", minimum=4) == 4
     assert as_integer(0, minimum=1) == 1
     assert as_integer(0, minimum=1) == 1
     assert as_integer(0, minimum=0, default=1) == 0

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -7,7 +7,7 @@ from .search_utils import (
 from .utils import (
     MAX_RESULTS_PER_PAGE,
     api_client,
-    as_integer,
+    clamp,
     formatted_document_uri,
     get_document_by_uri,
     get_press_summaries_for_document_uri,
@@ -31,7 +31,7 @@ __all__ = [
     "test_date_and_dict",
     "ALL_COURT_CODES",
     "api_client",
-    "as_integer",
+    "clamp",
     "formatted_document_uri",
     "get_document_by_uri",
     "get_minimum_valid_year",

--- a/judgments/utils/utils.py
+++ b/judgments/utils/utils.py
@@ -93,14 +93,13 @@ def sanitise_input_to_integer(input: Any, default: int) -> int:
         return default
 
 
-def as_integer(
+def clamp(
     number: int,
     minimum: int,
     maximum: Optional[int] = None,
 ) -> int:
     """
-    Return an integer for user input, making sure it's between the min and max,
-    and if it's not a valid number, that it's the default (or minimum if not set).
+    Clamp an integer, making sure it's between the min and max
     """
 
     min_bounded = max(minimum, number)
@@ -111,8 +110,8 @@ def as_integer(
 
 
 def paginator(current_page: int, total, size_per_page: int = RESULTS_PER_PAGE):
-    current_page = as_integer(current_page, minimum=1)
-    size_per_page = as_integer(
+    current_page = clamp(current_page, minimum=1)
+    size_per_page = clamp(
         size_per_page,
         minimum=1,
         maximum=MAX_RESULTS_PER_PAGE,

--- a/judgments/utils/utils.py
+++ b/judgments/utils/utils.py
@@ -1,6 +1,6 @@
 import math
 import re
-from typing import Any, Optional, TypedDict, Union
+from typing import Any, Optional, TypedDict
 from urllib.parse import parse_qs, urlparse
 
 from caselawclient.Client import DEFAULT_USER_AGENT, MarklogicApiClient
@@ -86,21 +86,22 @@ def solo_stop_word_regex(stops):
     return regex
 
 
+def sanitise_input_to_integer(input: Any, default: int) -> int:
+    try:
+        return int(input)
+    except (ValueError, TypeError):
+        return default
+
+
 def as_integer(
-    number: Union[int, None],
+    number: int,
     minimum: int,
     maximum: Optional[int] = None,
-    default: Optional[int] = None,
 ) -> int:
     """
     Return an integer for user input, making sure it's between the min and max,
     and if it's not a valid number, that it's the default (or minimum if not set).
     """
-
-    if default is None:
-        default = minimum
-    if number is None:
-        return default
 
     min_bounded = max(minimum, number)
     if maximum is not None:
@@ -109,10 +110,12 @@ def as_integer(
         return min_bounded
 
 
-def paginator(current_page, total, size_per_page=RESULTS_PER_PAGE):
+def paginator(current_page: int, total, size_per_page: int = RESULTS_PER_PAGE):
     current_page = as_integer(current_page, minimum=1)
     size_per_page = as_integer(
-        size_per_page, minimum=1, maximum=MAX_RESULTS_PER_PAGE, default=RESULTS_PER_PAGE
+        size_per_page,
+        minimum=1,
+        maximum=MAX_RESULTS_PER_PAGE,
     )
     number_of_pages = math.ceil(int(total) / size_per_page)
     next_pages = list(
@@ -253,10 +256,3 @@ def show_no_exact_ncn_warning(search_results, query_text, page):
         and bool(neutral_url(query_text))
         and page == "1"
     )
-
-
-def sanitise_input_to_integer(input: Any, default: int) -> int:
-    try:
-        return int(input)
-    except (ValueError, TypeError):
-        return default

--- a/judgments/utils/utils.py
+++ b/judgments/utils/utils.py
@@ -1,6 +1,6 @@
 import math
 import re
-from typing import Optional, TypedDict
+from typing import Any, Optional, TypedDict, Union
 from urllib.parse import parse_qs, urlparse
 
 from caselawclient.Client import DEFAULT_USER_AGENT, MarklogicApiClient
@@ -86,7 +86,12 @@ def solo_stop_word_regex(stops):
     return regex
 
 
-def as_integer(number_string, minimum, maximum=None, default=None):
+def as_integer(
+    number: Union[int, None],
+    minimum: int,
+    maximum: Optional[int] = None,
+    default: Optional[int] = None,
+) -> int:
     """
     Return an integer for user input, making sure it's between the min and max,
     and if it's not a valid number, that it's the default (or minimum if not set).
@@ -94,11 +99,7 @@ def as_integer(number_string, minimum, maximum=None, default=None):
 
     if default is None:
         default = minimum
-    if number_string is None:
-        return default
-    try:
-        number = int(number_string)
-    except ValueError:
+    if number is None:
         return default
 
     min_bounded = max(minimum, number)
@@ -252,3 +253,10 @@ def show_no_exact_ncn_warning(search_results, query_text, page):
         and bool(neutral_url(query_text))
         and page == "1"
     )
+
+
+def sanitise_input_to_integer(input: Any, default: int) -> int:
+    try:
+        return int(input)
+    except (ValueError, TypeError):
+        return default

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -26,6 +26,7 @@ from judgments.utils import (
     process_year_facets,
     show_no_exact_ncn_warning,
 )
+from judgments.utils.utils import sanitise_input_to_integer
 
 
 def _do_dates_require_warnings(from_date, total_results):
@@ -78,14 +79,14 @@ def advanced_search(request):
             year_facets: dict = {}
             query_params: dict = {}
             query_text: str = form.cleaned_data.get("query", "")
-            page: str = str(as_integer(params.get("page"), minimum=1))
-            per_page: str = str(
-                as_integer(
-                    params.get("per_page", "10"),
-                    minimum=1,
-                    maximum=MAX_RESULTS_PER_PAGE,
-                    default=RESULTS_PER_PAGE,
-                )
+            page: int = as_integer(
+                sanitise_input_to_integer(params.get("page"), 1), minimum=1
+            )
+            per_page: int = as_integer(
+                sanitise_input_to_integer(params.get("per_page"), 10),
+                minimum=1,
+                maximum=MAX_RESULTS_PER_PAGE,
+                default=RESULTS_PER_PAGE,
             )
             order = params.get("order", None)
             # If there is no query, order by -date, else order by relevance
@@ -144,7 +145,7 @@ def advanced_search(request):
                 date_from=from_date_for_search.strftime("%Y-%m-%d"),
                 date_to=to_date_as_search_param,
                 page_size=as_integer(
-                    params.get("per_page", "10"),
+                    sanitise_input_to_integer(params.get("per_page"), 10),
                     minimum=1,
                     maximum=MAX_RESULTS_PER_PAGE,
                     default=RESULTS_PER_PAGE,

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -18,7 +18,7 @@ from judgments.forms import AdvancedSearchForm
 from judgments.utils import (
     MAX_RESULTS_PER_PAGE,
     api_client,
-    as_integer,
+    clamp,
     get_minimum_valid_year,
     has_filters,
     paginator,
@@ -79,10 +79,10 @@ def advanced_search(request):
             year_facets: dict = {}
             query_params: dict = {}
             query_text: str = form.cleaned_data.get("query", "")
-            page: int = as_integer(
+            page: int = clamp(
                 sanitise_input_to_integer(params.get("page"), 1), minimum=1
             )
-            per_page: int = as_integer(
+            per_page: int = clamp(
                 sanitise_input_to_integer(params.get("per_page"), RESULTS_PER_PAGE),
                 minimum=1,
                 maximum=MAX_RESULTS_PER_PAGE,
@@ -143,7 +143,7 @@ def advanced_search(request):
                 order=order,
                 date_from=from_date_for_search.strftime("%Y-%m-%d"),
                 date_to=to_date_as_search_param,
-                page_size=as_integer(
+                page_size=clamp(
                     sanitise_input_to_integer(params.get("per_page"), RESULTS_PER_PAGE),
                     minimum=1,
                     maximum=MAX_RESULTS_PER_PAGE,

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -83,10 +83,9 @@ def advanced_search(request):
                 sanitise_input_to_integer(params.get("page"), 1), minimum=1
             )
             per_page: int = as_integer(
-                sanitise_input_to_integer(params.get("per_page"), 10),
+                sanitise_input_to_integer(params.get("per_page"), RESULTS_PER_PAGE),
                 minimum=1,
                 maximum=MAX_RESULTS_PER_PAGE,
-                default=RESULTS_PER_PAGE,
             )
             order = params.get("order", None)
             # If there is no query, order by -date, else order by relevance
@@ -145,10 +144,9 @@ def advanced_search(request):
                 date_from=from_date_for_search.strftime("%Y-%m-%d"),
                 date_to=to_date_as_search_param,
                 page_size=as_integer(
-                    sanitise_input_to_integer(params.get("per_page"), 10),
+                    sanitise_input_to_integer(params.get("per_page"), RESULTS_PER_PAGE),
                     minimum=1,
                     maximum=MAX_RESULTS_PER_PAGE,
-                    default=RESULTS_PER_PAGE,
                 ),
             )
 

--- a/judgments/views/browse.py
+++ b/judgments/views/browse.py
@@ -36,7 +36,6 @@ class BrowseView(TemplateView):
             ),
             minimum=1,
             maximum=MAX_RESULTS_PER_PAGE,
-            default=RESULTS_PER_PAGE,
         )
 
         try:

--- a/judgments/views/browse.py
+++ b/judgments/views/browse.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext
 from django.views.generic.base import TemplateView
 from ds_caselaw_utils import courts as all_courts
 
-from judgments.utils import MAX_RESULTS_PER_PAGE, api_client, as_integer, paginator
+from judgments.utils import MAX_RESULTS_PER_PAGE, api_client, clamp, paginator
 from judgments.utils.utils import sanitise_input_to_integer
 
 
@@ -27,10 +27,10 @@ class BrowseView(TemplateView):
 
         # All non-None values of court and subdivision should be truthy
         court_query = "/".join(filter(None, [court, subdivision]))
-        page = as_integer(
+        page = clamp(
             sanitise_input_to_integer(self.request.GET.get("page"), 1), minimum=1
         )
-        per_page = as_integer(
+        per_page = clamp(
             sanitise_input_to_integer(
                 self.request.GET.get("per_page"), RESULTS_PER_PAGE
             ),

--- a/judgments/views/browse.py
+++ b/judgments/views/browse.py
@@ -12,6 +12,7 @@ from django.views.generic.base import TemplateView
 from ds_caselaw_utils import courts as all_courts
 
 from judgments.utils import MAX_RESULTS_PER_PAGE, api_client, as_integer, paginator
+from judgments.utils.utils import sanitise_input_to_integer
 
 
 class BrowseView(TemplateView):
@@ -26,14 +27,16 @@ class BrowseView(TemplateView):
 
         # All non-None values of court and subdivision should be truthy
         court_query = "/".join(filter(None, [court, subdivision]))
-        page = str(as_integer(self.request.GET.get("page"), minimum=1))
-        per_page = str(
-            as_integer(
-                self.request.GET.get("per_page"),
-                minimum=1,
-                maximum=MAX_RESULTS_PER_PAGE,
-                default=RESULTS_PER_PAGE,
-            )
+        page = as_integer(
+            sanitise_input_to_integer(self.request.GET.get("page"), 1), minimum=1
+        )
+        per_page = as_integer(
+            sanitise_input_to_integer(
+                self.request.GET.get("per_page"), RESULTS_PER_PAGE
+            ),
+            minimum=1,
+            maximum=MAX_RESULTS_PER_PAGE,
+            default=RESULTS_PER_PAGE,
         )
 
         try:
@@ -50,8 +53,8 @@ class BrowseView(TemplateView):
                     else None
                 ),
                 order="-date",
-                page=as_integer(page, minimum=1),
-                page_size=as_integer(per_page, minimum=1),
+                page=page,
+                page_size=per_page,
             )
             search_response = search_judgments_and_parse_response(
                 api_client, search_parameters


### PR DESCRIPTION
Merge after #1276 

## Changes in this PR:

The `as_integer` function was quite convoluted so we've separated its clamping and input sanitisation functions.
