### PR TITLE
[FCL-180] Save user input when pressing previous in licence application form

### DIFF
--- a/e2e_tests/test_transactional_licence_form.py
+++ b/e2e_tests/test_transactional_licence_form.py
@@ -300,3 +300,37 @@ def test_transactional_licence_form(page: Page):
     expect(get_review_row(page, "What is the full legal name")).to_have_text(
         "New Organisation name"
     )
+
+
+def test_data_saved_when_going_back(page: Page):
+    """
+    Test the process to apply for a computational analysis licence.
+    We stop on the review page (short of actually submitting the form)
+    (which triggers an email to the licencing team): the final step will be tested
+    in isolation with a mocked email service."""
+
+    # Fill contact details in full
+    page.goto("/re-use-find-case-law-records/steps/contact")
+    page.get_by_label("Contact Full Name").fill("Full Name")
+    page.get_by_label("Contact Email address").fill("contact@example.com")
+    page.get_by_label(
+        "This is a different person (please enter their details below)"
+    ).click()
+    page.get_by_label("Licence holder Full Name").fill("Licence Holder")
+    page.get_by_label("Licence holder Email").fill("licenceholder@example.com")
+
+    # On the next page, fill only 1 field, leaving others blank
+    page.get_by_text("Next").click()
+    page.get_by_label("What is the full legal name of your organisation?").fill(
+        "Organisation name"
+    )
+
+    # Check previous page has information
+    page.get_by_text("Previous").click()
+    expect(page.get_by_label("Contact Full Name")).to_have_value("Full Name")
+
+    # Check incomplete next page has information
+    page.get_by_text("Next").click()
+    expect(
+        page.get_by_label("What is the full legal name of your organisation?")
+    ).to_have_value("Organisation name")


### PR DESCRIPTION
## Changes in this PR:

The previous button in the transactional licence application form was not saving the user's answers, which has now been fixed.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136/backlog?selectedIssue=FCL-180
