### PR TITLE
[FCL-176] Tooling configuration audit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,20 @@
-exclude: "^docs/|/migrations/"
-default_install_hook_types: [pre-commit, pre-push]
+exclude: "/migrations/"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-xml
       - id: check-yaml
+      - id: end-of-file-fixer
+      - id: forbid-submodules
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
     rev: 24.4.2
@@ -42,9 +49,3 @@ repos:
     hooks:
       - id: prettier
         types_or: [scss, yaml, markdown, javascript, xml]
-
-# sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
-ci:
-  autoupdate_schedule: weekly
-  skip: []
-  submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,22 +16,10 @@ repos:
       - id: no-commit-to-branch
       - id: trailing-whitespace
 
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.0
     hooks:
-      - id: black
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.0
-    hooks:
-      - id: flake8
-        args: ["--config=setup.cfg"]
+      - id: ruff-format
 
   - repo: https://github.com/Riverside-Healthcare/djLint
     rev: v1.34.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: djhtml
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
-        types_or: [scss, yaml, markdown, javascript, xml]
+        types_or: [yaml, json, xml, markdown, scss, javascript]

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -50,9 +50,7 @@ class CacheHeaderMiddleware:
 
 
 class FeedbackLinkMiddleware:
-    BASE_FEEDBACK_URL: str = (
-        "https://corexmsnp4n42lf2kht3.qualtrics.com/jfe/form/SV_0lyyYAzfv9bGcyW"
-    )
+    BASE_FEEDBACK_URL: str = "https://corexmsnp4n42lf2kht3.qualtrics.com/jfe/form/SV_0lyyYAzfv9bGcyW"
 
     def __init__(self, get_response):
         self.get_response = get_response
@@ -75,14 +73,10 @@ class FeedbackLinkMiddleware:
         if "feedback_survey_document_uri" in response.context_data:
             # TODO: update the survey to allow for generalisation to `document`
             # https://trello.com/c/l0iBFM1e/1151-update-survey-to-account-for-judgment-the-fact-that-we-have-press-summaries-as-well-as-judgments-now
-            params["judgment_uri"] = response.context_data[
-                "feedback_survey_document_uri"
-            ]
+            params["judgment_uri"] = response.context_data["feedback_survey_document_uri"]
 
         if "feedback_survey_court" in response.context_data:
             params["court"] = response.context_data["feedback_survey_court"]
 
-        response.context_data["feedback_survey_link"] = (
-            self.BASE_FEEDBACK_URL + "?" + urlencode(params)
-        )
+        response.context_data["feedback_survey_link"] = self.BASE_FEEDBACK_URL + "?" + urlencode(params)
         return response

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -116,9 +116,7 @@ PASSWORD_HASHERS = [
 ]
 # https://docs.djangoproject.com/en/dev/ref/settings/#auth-password-validators
 AUTH_PASSWORD_VALIDATORS = [
-    {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
-    },
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
@@ -246,12 +244,7 @@ MANAGERS = ADMINS
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "formatters": {
-        "verbose": {
-            "format": "%(levelname)s %(asctime)s %(module)s "
-            "%(process)d %(thread)d %(message)s"
-        }
-    },
+    "formatters": {"verbose": {"format": "%(levelname)s %(asctime)s %(module)s " "%(process)d %(thread)d %(message)s"}},
     "handlers": {
         "console": {
             "level": "DEBUG",
@@ -275,12 +268,8 @@ MARKLOGIC_USE_HTTPS = env("MARKLOGIC_USE_HTTPS", default=False)
 # SMTP credentials for transaacitonal licence form delivery
 
 TRANSACTIONAL_LICENCE_FROM_EMAIL = env("TRANSACTIONAL_LICENCE_FROM_EMAIL", default=None)
-TRANSACTIONAL_LICENCE_DELIVERY_EMAIL = env(
-    "TRANSACTIONAL_LICENCE_DELIVERY_EMAIL", default=None
-)
-TRANSACTIONAL_LICENCE_EMAIL_SUBJECT = env(
-    "TRANSACTIONAL_LICENCE_EMAIL_SUBJECT", default=None
-)
+TRANSACTIONAL_LICENCE_DELIVERY_EMAIL = env("TRANSACTIONAL_LICENCE_DELIVERY_EMAIL", default=None)
+TRANSACTIONAL_LICENCE_EMAIL_SUBJECT = env("TRANSACTIONAL_LICENCE_EMAIL_SUBJECT", default=None)
 SES_SMTP_USERNAME = env("SES_SMTP_USERNAME", default=None)
 SES_SMTP_PASSWORD = env("SES_SMTP_PASSWORD", default=None)
 SES_SMTP_SERVER = env("SES_SMTP_SERVER", default=None)

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -22,9 +22,7 @@ CACHES = {
 # EMAIL
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
-EMAIL_BACKEND = env(
-    "DJANGO_EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
-)
+EMAIL_BACKEND = env("DJANGO_EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend")
 
 # WhiteNoise
 # ------------------------------------------------------------------------------

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -40,15 +40,11 @@ CSRF_COOKIE_SECURE = True
 # TODO: set this to 60 seconds first and then to 518400 once you prove the former works
 SECURE_HSTS_SECONDS = 6 * 24 * 3600
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-hsts-include-subdomains
-SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool(
-    "DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS", default=True
-)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool("DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS", default=True)
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-hsts-preload
 SECURE_HSTS_PRELOAD = env.bool("DJANGO_SECURE_HSTS_PRELOAD", default=True)
 # https://docs.djangoproject.com/en/dev/ref/middleware/#x-content-type-options-nosniff
-SECURE_CONTENT_TYPE_NOSNIFF = env.bool(
-    "DJANGO_SECURE_CONTENT_TYPE_NOSNIFF", default=True
-)
+SECURE_CONTENT_TYPE_NOSNIFF = env.bool("DJANGO_SECURE_CONTENT_TYPE_NOSNIFF", default=True)
 
 # STATIC
 # ------------------------
@@ -91,12 +87,7 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "filters": {"require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}},
-    "formatters": {
-        "verbose": {
-            "format": "%(levelname)s %(asctime)s %(module)s "
-            "%(process)d %(thread)d %(message)s"
-        }
-    },
+    "formatters": {"verbose": {"format": "%(levelname)s %(asctime)s %(module)s " "%(process)d %(thread)d %(message)s"}},
     "handlers": {
         "mail_admins": {
             "level": "ERROR",

--- a/config/urls.py
+++ b/config/urls.py
@@ -92,9 +92,7 @@ urlpatterns = [
     ),
     path(
         "googleb0ce3f99fae65e7c.html",
-        TemplateView.as_view(
-            template_name="googleb0ce3f99fae65e7c.html", content_type="text/html"
-        ),
+        TemplateView.as_view(template_name="googleb0ce3f99fae65e7c.html", content_type="text/html"),
     ),
     path(
         "schema/<schemafile:schemafile>",

--- a/config/views.py
+++ b/config/views.py
@@ -54,29 +54,21 @@ class CourtOrTribunalView(TemplateViewWithContext):
 
     @property
     def page(self):
-        return clamp(
-            sanitise_input_to_integer(self.request.GET.get("page"), 1), minimum=1
-        )
+        return clamp(sanitise_input_to_integer(self.request.GET.get("page"), 1), minimum=1)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
         search_response = search_judgments_and_parse_response(
             api_client,
-            SearchParameters(
-                court=self.court.canonical_param, order="-date", page=self.page
-            ),
+            SearchParameters(court=self.court.canonical_param, order="-date", page=self.page),
         )
 
-        context["feedback_survey_type"] = (
-            "court_or_tribunal_%s" % self.court.canonical_param
-        )
+        context["feedback_survey_type"] = "court_or_tribunal_%s" % self.court.canonical_param
         context["request"] = self.request
         context["court"] = self.court
         context["judgments"] = search_response.results
-        context["paginator"] = paginator(
-            self.page, search_response.total, RESULTS_PER_PAGE
-        )
+        context["paginator"] = paginator(self.page, search_response.total, RESULTS_PER_PAGE)
 
         return context
 

--- a/ds_judgements_public_ui/__init__.py
+++ b/ds_judgements_public_ui/__init__.py
@@ -1,7 +1,2 @@
 __version__ = "0.1.0"
-__version_info__ = tuple(
-    [
-        int(num) if num.isdigit() else num
-        for num in __version__.replace("-", ".", 1).split(".")
-    ]
-)
+__version_info__ = tuple([int(num) if num.isdigit() else num for num in __version__.replace("-", ".", 1).split(".")])

--- a/ds_judgements_public_ui/static/js/location-autocomplete-canonical-list.json
+++ b/ds_judgements_public_ui/static/js/location-autocomplete-canonical-list.json
@@ -1,1114 +1,280 @@
 [
-  [
-    "Abu Dhabi",
-    "territory:AE-AZ"
-  ],
-  [
-    "Afghanistan",
-    "country:AF"
-  ],
-  [
-    "Ajman",
-    "territory:AE-AJ"
-  ],
-  [
-    "Akrotiri",
-    "territory:XQZ"
-  ],
-  [
-    "Albania",
-    "country:AL"
-  ],
-  [
-    "Algeria",
-    "country:DZ"
-  ],
-  [
-    "American Samoa",
-    "territory:AS"
-  ],
-  [
-    "Andorra",
-    "country:AD"
-  ],
-  [
-    "Angola",
-    "country:AO"
-  ],
-  [
-    "Anguilla",
-    "territory:AI"
-  ],
-  [
-    "Antarctica",
-    "territory:AQ"
-  ],
-  [
-    "Antigua and Barbuda",
-    "country:AG"
-  ],
-  [
-    "Argentina",
-    "country:AR"
-  ],
-  [
-    "Armenia",
-    "country:AM"
-  ],
-  [
-    "Aruba",
-    "territory:AW"
-  ],
-  [
-    "Ascension",
-    "territory:SH-AC"
-  ],
-  [
-    "Australia",
-    "country:AU"
-  ],
-  [
-    "Austria",
-    "country:AT"
-  ],
-  [
-    "Azerbaijan",
-    "country:AZ"
-  ],
-  [
-    "Bahrain",
-    "country:BH"
-  ],
-  [
-    "Baker Island",
-    "territory:UM-81"
-  ],
-  [
-    "Bangladesh",
-    "country:BD"
-  ],
-  [
-    "Barbados",
-    "country:BB"
-  ],
-  [
-    "Belarus",
-    "country:BY"
-  ],
-  [
-    "Belgium",
-    "country:BE"
-  ],
-  [
-    "Belize",
-    "country:BZ"
-  ],
-  [
-    "Benin",
-    "country:BJ"
-  ],
-  [
-    "Bermuda",
-    "territory:BM"
-  ],
-  [
-    "Bhutan",
-    "country:BT"
-  ],
-  [
-    "Bolivia",
-    "country:BO"
-  ],
-  [
-    "Bonaire",
-    "territory:BQ-BO"
-  ],
-  [
-    "Bosnia and Herzegovina",
-    "country:BA"
-  ],
-  [
-    "Botswana",
-    "country:BW"
-  ],
-  [
-    "Bouvet Island",
-    "territory:BV"
-  ],
-  [
-    "Brazil",
-    "country:BR"
-  ],
-  [
-    "British Antarctic Territory",
-    "territory:BAT"
-  ],
-  [
-    "British Indian Ocean Territory",
-    "territory:IO"
-  ],
-  [
-    "British Virgin Islands",
-    "territory:VG"
-  ],
-  [
-    "Brunei",
-    "country:BN"
-  ],
-  [
-    "Bulgaria",
-    "country:BG"
-  ],
-  [
-    "Burkina Faso",
-    "country:BF"
-  ],
-  [
-    "Myanmar (Burma)",
-    "country:MM"
-  ],
-  [
-    "Burundi",
-    "country:BI"
-  ],
-  [
-    "Cambodia",
-    "country:KH"
-  ],
-  [
-    "Cameroon",
-    "country:CM"
-  ],
-  [
-    "Canada",
-    "country:CA"
-  ],
-  [
-    "Cape Verde",
-    "country:CV"
-  ],
-  [
-    "Cayman Islands",
-    "territory:KY"
-  ],
-  [
-    "Central African Republic",
-    "country:CF"
-  ],
-  [
-    "Ceuta",
-    "territory:ES-CE"
-  ],
-  [
-    "Chad",
-    "country:TD"
-  ],
-  [
-    "Chile",
-    "country:CL"
-  ],
-  [
-    "China",
-    "country:CN"
-  ],
-  [
-    "Christmas Island",
-    "territory:CX"
-  ],
-  [
-    "Cocos (Keeling) Islands",
-    "territory:CC"
-  ],
-  [
-    "Colombia",
-    "country:CO"
-  ],
-  [
-    "Comoros",
-    "country:KM"
-  ],
-  [
-    "Congo",
-    "country:CG"
-  ],
-  [
-    "Congo (Democratic Republic)",
-    "country:CD"
-  ],
-  [
-    "Cook Islands",
-    "territory:CK"
-  ],
-  [
-    "Costa Rica",
-    "country:CR"
-  ],
-  [
-    "Croatia",
-    "country:HR"
-  ],
-  [
-    "Cuba",
-    "country:CU"
-  ],
-  [
-    "Curaçao",
-    "territory:CW"
-  ],
-  [
-    "Cyprus",
-    "country:CY"
-  ],
-  [
-    "Czechia",
-    "country:CZ"
-  ],
-  [
-    "Czechoslovakia",
-    "country:CS"
-  ],
-  [
-    "Denmark",
-    "country:DK"
-  ],
-  [
-    "Dhekelia",
-    "territory:XXD"
-  ],
-  [
-    "Djibouti",
-    "country:DJ"
-  ],
-  [
-    "Dominica",
-    "country:DM"
-  ],
-  [
-    "Dominican Republic",
-    "country:DO"
-  ],
-  [
-    "Dubai",
-    "territory:AE-DU"
-  ],
-  [
-    "East Germany",
-    "country:DD"
-  ],
-  [
-    "East Timor",
-    "country:TL"
-  ],
-  [
-    "Ecuador",
-    "country:EC"
-  ],
-  [
-    "Egypt",
-    "country:EG"
-  ],
-  [
-    "El Salvador",
-    "country:SV"
-  ],
-  [
-    "Equatorial Guinea",
-    "country:GQ"
-  ],
-  [
-    "Eritrea",
-    "country:ER"
-  ],
-  [
-    "Estonia",
-    "country:EE"
-  ],
-  [
-    "Eswatini",
-    "country:SZ"
-  ],
-  [
-    "Ethiopia",
-    "country:ET"
-  ],
-  [
-    "Falkland Islands",
-    "territory:FK"
-  ],
-  [
-    "Faroe Islands",
-    "territory:FO"
-  ],
-  [
-    "Fiji",
-    "country:FJ"
-  ],
-  [
-    "Finland",
-    "country:FI"
-  ],
-  [
-    "France",
-    "country:FR"
-  ],
-  [
-    "French Guiana",
-    "territory:GF"
-  ],
-  [
-    "French Polynesia",
-    "territory:PF"
-  ],
-  [
-    "French Southern Territories",
-    "territory:TF"
-  ],
-  [
-    "Fujairah",
-    "territory:AE-FU"
-  ],
-  [
-    "Gabon",
-    "country:GA"
-  ],
-  [
-    "Georgia",
-    "country:GE"
-  ],
-  [
-    "Germany",
-    "country:DE"
-  ],
-  [
-    "Ghana",
-    "country:GH"
-  ],
-  [
-    "Gibraltar",
-    "territory:GI"
-  ],
-  [
-    "Greece",
-    "country:GR"
-  ],
-  [
-    "Greenland",
-    "territory:GL"
-  ],
-  [
-    "Grenada",
-    "country:GD"
-  ],
-  [
-    "Guadeloupe",
-    "territory:GP"
-  ],
-  [
-    "Guam",
-    "territory:GU"
-  ],
-  [
-    "Guatemala",
-    "country:GT"
-  ],
-  [
-    "Guernsey",
-    "territory:GG"
-  ],
-  [
-    "Guinea",
-    "country:GN"
-  ],
-  [
-    "Guinea-Bissau",
-    "country:GW"
-  ],
-  [
-    "Guyana",
-    "country:GY"
-  ],
-  [
-    "Haiti",
-    "country:HT"
-  ],
-  [
-    "Heard Island and McDonald Islands",
-    "territory:HM"
-  ],
-  [
-    "Honduras",
-    "country:HN"
-  ],
-  [
-    "Hong Kong",
-    "territory:HK"
-  ],
-  [
-    "Howland Island",
-    "territory:UM-84"
-  ],
-  [
-    "Hungary",
-    "country:HU"
-  ],
-  [
-    "Iceland",
-    "country:IS"
-  ],
-  [
-    "India",
-    "country:IN"
-  ],
-  [
-    "Indonesia",
-    "country:ID"
-  ],
-  [
-    "Iran",
-    "country:IR"
-  ],
-  [
-    "Iraq",
-    "country:IQ"
-  ],
-  [
-    "Ireland",
-    "country:IE"
-  ],
-  [
-    "Isle of Man",
-    "territory:IM"
-  ],
-  [
-    "Israel",
-    "country:IL"
-  ],
-  [
-    "Italy",
-    "country:IT"
-  ],
-  [
-    "Ivory Coast",
-    "country:CI"
-  ],
-  [
-    "Jamaica",
-    "country:JM"
-  ],
-  [
-    "Japan",
-    "country:JP"
-  ],
-  [
-    "Jarvis Island",
-    "territory:UM-86"
-  ],
-  [
-    "Jersey",
-    "territory:JE"
-  ],
-  [
-    "Johnston Atoll",
-    "territory:UM-67"
-  ],
-  [
-    "Jordan",
-    "country:JO"
-  ],
-  [
-    "Kazakhstan",
-    "country:KZ"
-  ],
-  [
-    "Kenya",
-    "country:KE"
-  ],
-  [
-    "Kingman Reef",
-    "territory:UM-89"
-  ],
-  [
-    "Kiribati",
-    "country:KI"
-  ],
-  [
-    "Kosovo",
-    "country:XK"
-  ],
-  [
-    "Kuwait",
-    "country:KW"
-  ],
-  [
-    "Kyrgyzstan",
-    "country:KG"
-  ],
-  [
-    "Laos",
-    "country:LA"
-  ],
-  [
-    "Latvia",
-    "country:LV"
-  ],
-  [
-    "Lebanon",
-    "country:LB"
-  ],
-  [
-    "Lesotho",
-    "country:LS"
-  ],
-  [
-    "Liberia",
-    "country:LR"
-  ],
-  [
-    "Libya",
-    "country:LY"
-  ],
-  [
-    "Liechtenstein",
-    "country:LI"
-  ],
-  [
-    "Lithuania",
-    "country:LT"
-  ],
-  [
-    "Luxembourg",
-    "country:LU"
-  ],
-  [
-    "Macao",
-    "territory:MO"
-  ],
-  [
-    "Madagascar",
-    "country:MG"
-  ],
-  [
-    "Malawi",
-    "country:MW"
-  ],
-  [
-    "Malaysia",
-    "country:MY"
-  ],
-  [
-    "Maldives",
-    "country:MV"
-  ],
-  [
-    "Mali",
-    "country:ML"
-  ],
-  [
-    "Malta",
-    "country:MT"
-  ],
-  [
-    "Marshall Islands",
-    "country:MH"
-  ],
-  [
-    "Martinique",
-    "territory:MQ"
-  ],
-  [
-    "Mauritania",
-    "country:MR"
-  ],
-  [
-    "Mauritius",
-    "country:MU"
-  ],
-  [
-    "Mayotte",
-    "territory:YT"
-  ],
-  [
-    "Melilla",
-    "territory:ES-ML"
-  ],
-  [
-    "Mexico",
-    "country:MX"
-  ],
-  [
-    "Micronesia",
-    "country:FM"
-  ],
-  [
-    "Midway Islands",
-    "territory:UM-71"
-  ],
-  [
-    "Moldova",
-    "country:MD"
-  ],
-  [
-    "Monaco",
-    "country:MC"
-  ],
-  [
-    "Mongolia",
-    "country:MN"
-  ],
-  [
-    "Montenegro",
-    "country:ME"
-  ],
-  [
-    "Montserrat",
-    "territory:MS"
-  ],
-  [
-    "Morocco",
-    "country:MA"
-  ],
-  [
-    "Mozambique",
-    "country:MZ"
-  ],
-  [
-    "Namibia",
-    "country:NA"
-  ],
-  [
-    "Nauru",
-    "country:NR"
-  ],
-  [
-    "Navassa Island",
-    "territory:UM-76"
-  ],
-  [
-    "Nepal",
-    "country:NP"
-  ],
-  [
-    "Netherlands",
-    "country:NL"
-  ],
-  [
-    "New Caledonia",
-    "territory:NC"
-  ],
-  [
-    "New Zealand",
-    "country:NZ"
-  ],
-  [
-    "Nicaragua",
-    "country:NI"
-  ],
-  [
-    "Niger",
-    "country:NE"
-  ],
-  [
-    "Nigeria",
-    "country:NG"
-  ],
-  [
-    "Niue",
-    "territory:NU"
-  ],
-  [
-    "Norfolk Island",
-    "territory:NF"
-  ],
-  [
-    "North Korea",
-    "country:KP"
-  ],
-  [
-    "North Macedonia",
-    "country:MK"
-  ],
-  [
-    "Northern Mariana Islands",
-    "territory:MP"
-  ],
-  [
-    "Norway",
-    "country:NO"
-  ],
-  [
-    "Occupied Palestinian Territories",
-    "territory:PS"
-  ],
-  [
-    "Oman",
-    "country:OM"
-  ],
-  [
-    "Pakistan",
-    "country:PK"
-  ],
-  [
-    "Palau",
-    "country:PW"
-  ],
-  [
-    "Palmyra Atoll",
-    "territory:UM-95"
-  ],
-  [
-    "Panama",
-    "country:PA"
-  ],
-  [
-    "Papua New Guinea",
-    "country:PG"
-  ],
-  [
-    "Paraguay",
-    "country:PY"
-  ],
-  [
-    "Peru",
-    "country:PE"
-  ],
-  [
-    "Philippines",
-    "country:PH"
-  ],
-  [
-    "Pitcairn, Henderson, Ducie and Oeno Islands",
-    "territory:PN"
-  ],
-  [
-    "Poland",
-    "country:PL"
-  ],
-  [
-    "Portugal",
-    "country:PT"
-  ],
-  [
-    "Puerto Rico",
-    "territory:PR"
-  ],
-  [
-    "Qatar",
-    "country:QA"
-  ],
-  [
-    "Ras al-Khaimah",
-    "territory:AE-RK"
-  ],
-  [
-    "Romania",
-    "country:RO"
-  ],
-  [
-    "Russia",
-    "country:RU"
-  ],
-  [
-    "Rwanda",
-    "country:RW"
-  ],
-  [
-    "Réunion",
-    "territory:RE"
-  ],
-  [
-    "Saba",
-    "territory:BQ-SA"
-  ],
-  [
-    "Saint Barthélemy",
-    "territory:BL"
-  ],
-  [
-    "Saint Helena",
-    "territory:SH-HL"
-  ],
-  [
-    "Saint Pierre and Miquelon",
-    "territory:PM"
-  ],
-  [
-    "Saint-Martin (French part)",
-    "territory:MF"
-  ],
-  [
-    "Samoa",
-    "country:WS"
-  ],
-  [
-    "San Marino",
-    "country:SM"
-  ],
-  [
-    "Sao Tome and Principe",
-    "country:ST"
-  ],
-  [
-    "Saudi Arabia",
-    "country:SA"
-  ],
-  [
-    "Senegal",
-    "country:SN"
-  ],
-  [
-    "Serbia",
-    "country:RS"
-  ],
-  [
-    "Seychelles",
-    "country:SC"
-  ],
-  [
-    "Sharjah",
-    "territory:AE-SH"
-  ],
-  [
-    "Sierra Leone",
-    "country:SL"
-  ],
-  [
-    "Singapore",
-    "country:SG"
-  ],
-  [
-    "Sint Eustatius",
-    "territory:BQ-SE"
-  ],
-  [
-    "Sint Maarten (Dutch part)",
-    "territory:SX"
-  ],
-  [
-    "Slovakia",
-    "country:SK"
-  ],
-  [
-    "Slovenia",
-    "country:SI"
-  ],
-  [
-    "Solomon Islands",
-    "country:SB"
-  ],
-  [
-    "Somalia",
-    "country:SO"
-  ],
-  [
-    "South Africa",
-    "country:ZA"
-  ],
-  [
-    "South Georgia and South Sandwich Islands",
-    "territory:GS"
-  ],
-  [
-    "South Korea",
-    "country:KR"
-  ],
-  [
-    "South Sudan",
-    "country:SS"
-  ],
-  [
-    "Spain",
-    "country:ES"
-  ],
-  [
-    "Sri Lanka",
-    "country:LK"
-  ],
-  [
-    "St Kitts and Nevis",
-    "country:KN"
-  ],
-  [
-    "St Lucia",
-    "country:LC"
-  ],
-  [
-    "St Vincent",
-    "country:VC"
-  ],
-  [
-    "Sudan",
-    "country:SD"
-  ],
-  [
-    "Suriname",
-    "country:SR"
-  ],
-  [
-    "Svalbard and Jan Mayen",
-    "territory:SJ"
-  ],
-  [
-    "Sweden",
-    "country:SE"
-  ],
-  [
-    "Switzerland",
-    "country:CH"
-  ],
-  [
-    "Syria",
-    "country:SY"
-  ],
-  [
-    "Taiwan",
-    "territory:TW"
-  ],
-  [
-    "Tajikistan",
-    "country:TJ"
-  ],
-  [
-    "Tanzania",
-    "country:TZ"
-  ],
-  [
-    "Thailand",
-    "country:TH"
-  ],
-  [
-    "The Bahamas",
-    "country:BS"
-  ],
-  [
-    "The Gambia",
-    "country:GM"
-  ],
-  [
-    "Togo",
-    "country:TG"
-  ],
-  [
-    "Tokelau",
-    "territory:TK"
-  ],
-  [
-    "Tonga",
-    "country:TO"
-  ],
-  [
-    "Trinidad and Tobago",
-    "country:TT"
-  ],
-  [
-    "Tristan da Cunha",
-    "territory:SH-TA"
-  ],
-  [
-    "Tunisia",
-    "country:TN"
-  ],
-  [
-    "Turkey",
-    "country:TR"
-  ],
-  [
-    "Turkmenistan",
-    "country:TM"
-  ],
-  [
-    "Turks and Caicos Islands",
-    "territory:TC"
-  ],
-  [
-    "Tuvalu",
-    "country:TV"
-  ],
-  [
-    "USSR",
-    "country:SU"
-  ],
-  [
-    "Uganda",
-    "country:UG"
-  ],
-  [
-    "Ukraine",
-    "country:UA"
-  ],
-  [
-    "Umm al-Quwain",
-    "territory:AE-UQ"
-  ],
-  [
-    "United Arab Emirates",
-    "country:AE"
-  ],
-  [
-    "United Kingdom",
-    "country:GB"
-  ],
-  [
-    "United States",
-    "country:US"
-  ],
-  [
-    "United States Virgin Islands",
-    "territory:VI"
-  ],
-  [
-    "Uruguay",
-    "country:UY"
-  ],
-  [
-    "Uzbekistan",
-    "country:UZ"
-  ],
-  [
-    "Vanuatu",
-    "country:VU"
-  ],
-  [
-    "Vatican City",
-    "country:VA"
-  ],
-  [
-    "Venezuela",
-    "country:VE"
-  ],
-  [
-    "Vietnam",
-    "country:VN"
-  ],
-  [
-    "Wake Island",
-    "territory:UM-79"
-  ],
-  [
-    "Wallis and Futuna",
-    "territory:WF"
-  ],
-  [
-    "Western Sahara",
-    "territory:EH"
-  ],
-  [
-    "Yemen",
-    "country:YE"
-  ],
-  [
-    "Yugoslavia",
-    "country:YU"
-  ],
-  [
-    "Zambia",
-    "country:ZM"
-  ],
-  [
-    "Zimbabwe",
-    "country:ZW"
-  ],
-  [
-    "Åland Islands",
-    "territory:AX"
-  ]
+  ["Abu Dhabi", "territory:AE-AZ"],
+  ["Afghanistan", "country:AF"],
+  ["Ajman", "territory:AE-AJ"],
+  ["Akrotiri", "territory:XQZ"],
+  ["Albania", "country:AL"],
+  ["Algeria", "country:DZ"],
+  ["American Samoa", "territory:AS"],
+  ["Andorra", "country:AD"],
+  ["Angola", "country:AO"],
+  ["Anguilla", "territory:AI"],
+  ["Antarctica", "territory:AQ"],
+  ["Antigua and Barbuda", "country:AG"],
+  ["Argentina", "country:AR"],
+  ["Armenia", "country:AM"],
+  ["Aruba", "territory:AW"],
+  ["Ascension", "territory:SH-AC"],
+  ["Australia", "country:AU"],
+  ["Austria", "country:AT"],
+  ["Azerbaijan", "country:AZ"],
+  ["Bahrain", "country:BH"],
+  ["Baker Island", "territory:UM-81"],
+  ["Bangladesh", "country:BD"],
+  ["Barbados", "country:BB"],
+  ["Belarus", "country:BY"],
+  ["Belgium", "country:BE"],
+  ["Belize", "country:BZ"],
+  ["Benin", "country:BJ"],
+  ["Bermuda", "territory:BM"],
+  ["Bhutan", "country:BT"],
+  ["Bolivia", "country:BO"],
+  ["Bonaire", "territory:BQ-BO"],
+  ["Bosnia and Herzegovina", "country:BA"],
+  ["Botswana", "country:BW"],
+  ["Bouvet Island", "territory:BV"],
+  ["Brazil", "country:BR"],
+  ["British Antarctic Territory", "territory:BAT"],
+  ["British Indian Ocean Territory", "territory:IO"],
+  ["British Virgin Islands", "territory:VG"],
+  ["Brunei", "country:BN"],
+  ["Bulgaria", "country:BG"],
+  ["Burkina Faso", "country:BF"],
+  ["Myanmar (Burma)", "country:MM"],
+  ["Burundi", "country:BI"],
+  ["Cambodia", "country:KH"],
+  ["Cameroon", "country:CM"],
+  ["Canada", "country:CA"],
+  ["Cape Verde", "country:CV"],
+  ["Cayman Islands", "territory:KY"],
+  ["Central African Republic", "country:CF"],
+  ["Ceuta", "territory:ES-CE"],
+  ["Chad", "country:TD"],
+  ["Chile", "country:CL"],
+  ["China", "country:CN"],
+  ["Christmas Island", "territory:CX"],
+  ["Cocos (Keeling) Islands", "territory:CC"],
+  ["Colombia", "country:CO"],
+  ["Comoros", "country:KM"],
+  ["Congo", "country:CG"],
+  ["Congo (Democratic Republic)", "country:CD"],
+  ["Cook Islands", "territory:CK"],
+  ["Costa Rica", "country:CR"],
+  ["Croatia", "country:HR"],
+  ["Cuba", "country:CU"],
+  ["Curaçao", "territory:CW"],
+  ["Cyprus", "country:CY"],
+  ["Czechia", "country:CZ"],
+  ["Czechoslovakia", "country:CS"],
+  ["Denmark", "country:DK"],
+  ["Dhekelia", "territory:XXD"],
+  ["Djibouti", "country:DJ"],
+  ["Dominica", "country:DM"],
+  ["Dominican Republic", "country:DO"],
+  ["Dubai", "territory:AE-DU"],
+  ["East Germany", "country:DD"],
+  ["East Timor", "country:TL"],
+  ["Ecuador", "country:EC"],
+  ["Egypt", "country:EG"],
+  ["El Salvador", "country:SV"],
+  ["Equatorial Guinea", "country:GQ"],
+  ["Eritrea", "country:ER"],
+  ["Estonia", "country:EE"],
+  ["Eswatini", "country:SZ"],
+  ["Ethiopia", "country:ET"],
+  ["Falkland Islands", "territory:FK"],
+  ["Faroe Islands", "territory:FO"],
+  ["Fiji", "country:FJ"],
+  ["Finland", "country:FI"],
+  ["France", "country:FR"],
+  ["French Guiana", "territory:GF"],
+  ["French Polynesia", "territory:PF"],
+  ["French Southern Territories", "territory:TF"],
+  ["Fujairah", "territory:AE-FU"],
+  ["Gabon", "country:GA"],
+  ["Georgia", "country:GE"],
+  ["Germany", "country:DE"],
+  ["Ghana", "country:GH"],
+  ["Gibraltar", "territory:GI"],
+  ["Greece", "country:GR"],
+  ["Greenland", "territory:GL"],
+  ["Grenada", "country:GD"],
+  ["Guadeloupe", "territory:GP"],
+  ["Guam", "territory:GU"],
+  ["Guatemala", "country:GT"],
+  ["Guernsey", "territory:GG"],
+  ["Guinea", "country:GN"],
+  ["Guinea-Bissau", "country:GW"],
+  ["Guyana", "country:GY"],
+  ["Haiti", "country:HT"],
+  ["Heard Island and McDonald Islands", "territory:HM"],
+  ["Honduras", "country:HN"],
+  ["Hong Kong", "territory:HK"],
+  ["Howland Island", "territory:UM-84"],
+  ["Hungary", "country:HU"],
+  ["Iceland", "country:IS"],
+  ["India", "country:IN"],
+  ["Indonesia", "country:ID"],
+  ["Iran", "country:IR"],
+  ["Iraq", "country:IQ"],
+  ["Ireland", "country:IE"],
+  ["Isle of Man", "territory:IM"],
+  ["Israel", "country:IL"],
+  ["Italy", "country:IT"],
+  ["Ivory Coast", "country:CI"],
+  ["Jamaica", "country:JM"],
+  ["Japan", "country:JP"],
+  ["Jarvis Island", "territory:UM-86"],
+  ["Jersey", "territory:JE"],
+  ["Johnston Atoll", "territory:UM-67"],
+  ["Jordan", "country:JO"],
+  ["Kazakhstan", "country:KZ"],
+  ["Kenya", "country:KE"],
+  ["Kingman Reef", "territory:UM-89"],
+  ["Kiribati", "country:KI"],
+  ["Kosovo", "country:XK"],
+  ["Kuwait", "country:KW"],
+  ["Kyrgyzstan", "country:KG"],
+  ["Laos", "country:LA"],
+  ["Latvia", "country:LV"],
+  ["Lebanon", "country:LB"],
+  ["Lesotho", "country:LS"],
+  ["Liberia", "country:LR"],
+  ["Libya", "country:LY"],
+  ["Liechtenstein", "country:LI"],
+  ["Lithuania", "country:LT"],
+  ["Luxembourg", "country:LU"],
+  ["Macao", "territory:MO"],
+  ["Madagascar", "country:MG"],
+  ["Malawi", "country:MW"],
+  ["Malaysia", "country:MY"],
+  ["Maldives", "country:MV"],
+  ["Mali", "country:ML"],
+  ["Malta", "country:MT"],
+  ["Marshall Islands", "country:MH"],
+  ["Martinique", "territory:MQ"],
+  ["Mauritania", "country:MR"],
+  ["Mauritius", "country:MU"],
+  ["Mayotte", "territory:YT"],
+  ["Melilla", "territory:ES-ML"],
+  ["Mexico", "country:MX"],
+  ["Micronesia", "country:FM"],
+  ["Midway Islands", "territory:UM-71"],
+  ["Moldova", "country:MD"],
+  ["Monaco", "country:MC"],
+  ["Mongolia", "country:MN"],
+  ["Montenegro", "country:ME"],
+  ["Montserrat", "territory:MS"],
+  ["Morocco", "country:MA"],
+  ["Mozambique", "country:MZ"],
+  ["Namibia", "country:NA"],
+  ["Nauru", "country:NR"],
+  ["Navassa Island", "territory:UM-76"],
+  ["Nepal", "country:NP"],
+  ["Netherlands", "country:NL"],
+  ["New Caledonia", "territory:NC"],
+  ["New Zealand", "country:NZ"],
+  ["Nicaragua", "country:NI"],
+  ["Niger", "country:NE"],
+  ["Nigeria", "country:NG"],
+  ["Niue", "territory:NU"],
+  ["Norfolk Island", "territory:NF"],
+  ["North Korea", "country:KP"],
+  ["North Macedonia", "country:MK"],
+  ["Northern Mariana Islands", "territory:MP"],
+  ["Norway", "country:NO"],
+  ["Occupied Palestinian Territories", "territory:PS"],
+  ["Oman", "country:OM"],
+  ["Pakistan", "country:PK"],
+  ["Palau", "country:PW"],
+  ["Palmyra Atoll", "territory:UM-95"],
+  ["Panama", "country:PA"],
+  ["Papua New Guinea", "country:PG"],
+  ["Paraguay", "country:PY"],
+  ["Peru", "country:PE"],
+  ["Philippines", "country:PH"],
+  ["Pitcairn, Henderson, Ducie and Oeno Islands", "territory:PN"],
+  ["Poland", "country:PL"],
+  ["Portugal", "country:PT"],
+  ["Puerto Rico", "territory:PR"],
+  ["Qatar", "country:QA"],
+  ["Ras al-Khaimah", "territory:AE-RK"],
+  ["Romania", "country:RO"],
+  ["Russia", "country:RU"],
+  ["Rwanda", "country:RW"],
+  ["Réunion", "territory:RE"],
+  ["Saba", "territory:BQ-SA"],
+  ["Saint Barthélemy", "territory:BL"],
+  ["Saint Helena", "territory:SH-HL"],
+  ["Saint Pierre and Miquelon", "territory:PM"],
+  ["Saint-Martin (French part)", "territory:MF"],
+  ["Samoa", "country:WS"],
+  ["San Marino", "country:SM"],
+  ["Sao Tome and Principe", "country:ST"],
+  ["Saudi Arabia", "country:SA"],
+  ["Senegal", "country:SN"],
+  ["Serbia", "country:RS"],
+  ["Seychelles", "country:SC"],
+  ["Sharjah", "territory:AE-SH"],
+  ["Sierra Leone", "country:SL"],
+  ["Singapore", "country:SG"],
+  ["Sint Eustatius", "territory:BQ-SE"],
+  ["Sint Maarten (Dutch part)", "territory:SX"],
+  ["Slovakia", "country:SK"],
+  ["Slovenia", "country:SI"],
+  ["Solomon Islands", "country:SB"],
+  ["Somalia", "country:SO"],
+  ["South Africa", "country:ZA"],
+  ["South Georgia and South Sandwich Islands", "territory:GS"],
+  ["South Korea", "country:KR"],
+  ["South Sudan", "country:SS"],
+  ["Spain", "country:ES"],
+  ["Sri Lanka", "country:LK"],
+  ["St Kitts and Nevis", "country:KN"],
+  ["St Lucia", "country:LC"],
+  ["St Vincent", "country:VC"],
+  ["Sudan", "country:SD"],
+  ["Suriname", "country:SR"],
+  ["Svalbard and Jan Mayen", "territory:SJ"],
+  ["Sweden", "country:SE"],
+  ["Switzerland", "country:CH"],
+  ["Syria", "country:SY"],
+  ["Taiwan", "territory:TW"],
+  ["Tajikistan", "country:TJ"],
+  ["Tanzania", "country:TZ"],
+  ["Thailand", "country:TH"],
+  ["The Bahamas", "country:BS"],
+  ["The Gambia", "country:GM"],
+  ["Togo", "country:TG"],
+  ["Tokelau", "territory:TK"],
+  ["Tonga", "country:TO"],
+  ["Trinidad and Tobago", "country:TT"],
+  ["Tristan da Cunha", "territory:SH-TA"],
+  ["Tunisia", "country:TN"],
+  ["Turkey", "country:TR"],
+  ["Turkmenistan", "country:TM"],
+  ["Turks and Caicos Islands", "territory:TC"],
+  ["Tuvalu", "country:TV"],
+  ["USSR", "country:SU"],
+  ["Uganda", "country:UG"],
+  ["Ukraine", "country:UA"],
+  ["Umm al-Quwain", "territory:AE-UQ"],
+  ["United Arab Emirates", "country:AE"],
+  ["United Kingdom", "country:GB"],
+  ["United States", "country:US"],
+  ["United States Virgin Islands", "territory:VI"],
+  ["Uruguay", "country:UY"],
+  ["Uzbekistan", "country:UZ"],
+  ["Vanuatu", "country:VU"],
+  ["Vatican City", "country:VA"],
+  ["Venezuela", "country:VE"],
+  ["Vietnam", "country:VN"],
+  ["Wake Island", "territory:UM-79"],
+  ["Wallis and Futuna", "territory:WF"],
+  ["Western Sahara", "territory:EH"],
+  ["Yemen", "country:YE"],
+  ["Yugoslavia", "country:YU"],
+  ["Zambia", "country:ZM"],
+  ["Zimbabwe", "country:ZW"],
+  ["Åland Islands", "territory:AX"]
 ]

--- a/e2e_tests/test_about_page.py
+++ b/e2e_tests/test_about_page.py
@@ -9,6 +9,4 @@ def test_about_page(page: Page):
     """
     page.goto("/about-this-service")
 
-    expect(page).to_have_title(
-        "About this service - Find case law - The National Archives"
-    )
+    expect(page).to_have_title("About this service - Find case law - The National Archives")

--- a/e2e_tests/test_transactional_licence_form.py
+++ b/e2e_tests/test_transactional_licence_form.py
@@ -20,56 +20,36 @@ def test_transactional_licence_form(page: Page):
     # Contact details
     page.get_by_label("Contact Full Name").fill("Full Name")
     page.get_by_label("Contact Email address").fill("contact@example.com")
-    page.get_by_label(
-        "This is a different person (please enter their details below)"
-    ).click()
+    page.get_by_label("This is a different person (please enter their details below)").click()
     page.get_by_label("Licence holder Full Name").fill("Licence Holder")
     page.get_by_label("Licence holder Email").fill("licenceholder@example.com")
     page.get_by_text("Next").click()
 
     # Organization details
-    page.get_by_label("What is the full legal name of your organisation?").fill(
-        "Organisation name"
-    )
-    page.get_by_label(
-        "Please enter any other names your organisation is known by"
-    ).fill("Organisation alias")
+    page.get_by_label("What is the full legal name of your organisation?").fill("Organisation name")
+    page.get_by_label("Please enter any other names your organisation is known by").fill("Organisation alias")
     page.get_by_label("Which country is your organisation registered in?").fill("Chi")
     page.get_by_role("option", name="Chile").click()
     page.get_by_label("Private limited company").click()
     page.get_by_label("Other (please specify)").click()
-    page.locator("input[name='organization-tna_contacttype_other']").fill(
-        "Other organisation type"
-    )
+    page.locator("input[name='organization-tna_contacttype_other']").fill("Other organisation type")
     page.get_by_label(
         "Please provide your organisation identifier (e.g. company number or charity registration number) "
     ).fill("Organisation identifier")
-    page.get_by_label(
-        "Please provide the name of any partners or organisations you are working with"
-    ).fill("Partners")
+    page.get_by_label("Please provide the name of any partners or organisations you are working with").fill("Partners")
     page.get_by_text("Next").click()
 
     # Purpose and Activities
-    page.get_by_label(
-        "Please give any project or product name associated with this work"
-    ).fill("Project name")
-    page.get_by_label("Please share a link to the project or product site").fill(
-        "https://example.com"
-    )
+    page.get_by_label("Please give any project or product name associated with this work").fill("Project name")
+    page.get_by_label("Please share a link to the project or product site").fill("https://example.com")
     page.get_by_label("Publish legal information").click()
-    page.get_by_role("group", name="What is the main purpose").get_by_label(
+    page.get_by_role("group", name="What is the main purpose").get_by_label("Other (please specify)").click()
+    page.locator("input[name='project-purpose-project_purpose_other']").fill("Other purpose")
+    page.get_by_label("Restricted access (e.g. only subscribers or research peers)").click()
+    page.get_by_label("Public bodies").click()
+    page.get_by_role("group", name="Which Individuals or communities will benefit").get_by_label(
         "Other (please specify)"
     ).click()
-    page.locator("input[name='project-purpose-project_purpose_other']").fill(
-        "Other purpose"
-    )
-    page.get_by_label(
-        "Restricted access (e.g. only subscribers or research peers)"
-    ).click()
-    page.get_by_label("Public bodies").click()
-    page.get_by_role(
-        "group", name="Which Individuals or communities will benefit"
-    ).get_by_label("Other (please specify)").click()
     page.locator("input[name='project-purpose-benefit_other']").fill("Other benefit")
     page.get_by_text("Next").click()
 
@@ -82,15 +62,11 @@ def test_transactional_licence_form(page: Page):
         "group",
         name="Will the computational analysis focus on specific individuals or specific groups of people?",
     ).get_by_label("No").click()
-    page.get_by_role(
-        "group", name=" Will you anonymise individuals before you analyse records?"
-    ).get_by_label("Yes").click()
-    page.get_by_role(
-        "group", name="Will you regularly review algorithms for bias?"
-    ).get_by_label("No").click()
-    page.get_by_role("group", name="Will you abide by a code of ethics?").get_by_label(
+    page.get_by_role("group", name=" Will you anonymise individuals before you analyse records?").get_by_label(
         "Yes"
     ).click()
+    page.get_by_role("group", name="Will you regularly review algorithms for bias?").get_by_label("No").click()
+    page.get_by_role("group", name="Will you abide by a code of ethics?").get_by_label("Yes").click()
     page.get_by_role(
         "group",
         name="Will an impartial party review your work against an ethical framework?",
@@ -98,21 +74,15 @@ def test_transactional_licence_form(page: Page):
     page.get_by_text("Next").click()
 
     # Working practices - 2
-    page.get_by_role(
-        "group", name="Will you make the entire record available online?"
-    ).get_by_label("No").click()
-    page.get_by_role(
-        "group", name="Will data extracted from these records be published online?"
-    ).get_by_label("Yes").click()
-    page.get_by_role(
-        "group", name="will you make your methodology available to others for scrutiny?"
-    ).get_by_label("No").click()
-    page.get_by_role(
-        "group", name="Will you analyse and publish findings online?"
-    ).get_by_label("Yes").click()
-    page.get_by_label(
-        "Directly inform or influence the decision of a third-party"
+    page.get_by_role("group", name="Will you make the entire record available online?").get_by_label("No").click()
+    page.get_by_role("group", name="Will data extracted from these records be published online?").get_by_label(
+        "Yes"
     ).click()
+    page.get_by_role("group", name="will you make your methodology available to others for scrutiny?").get_by_label(
+        "No"
+    ).click()
+    page.get_by_role("group", name="Will you analyse and publish findings online?").get_by_label("Yes").click()
+    page.get_by_label("Directly inform or influence the decision of a third-party").click()
     page.get_by_label("Not using Generative AI").click()
     page.get_by_role(
         "group",
@@ -125,9 +95,7 @@ def test_transactional_licence_form(page: Page):
     page.get_by_text("Next").click()
 
     # Nine principles - 2
-    page.get_by_label(
-        "Please describe how you will meet the 9 principles as terms."
-    ).fill("Nine principles statement")
+    page.get_by_label("Please describe how you will meet the 9 principles as terms.").fill("Nine principles statement")
     page.get_by_text("Next").click()
 
     # Additional comments
@@ -138,78 +106,38 @@ def test_transactional_licence_form(page: Page):
 
     # Review
     def get_review_row(page, label):
-        return (
-            page.locator("dt", has_text=label)
-            .locator("..")
-            .locator("dd.govuk-summary-list__value")
-        )
+        return page.locator("dt", has_text=label).locator("..").locator("dd.govuk-summary-list__value")
 
     expect(get_review_row(page, "Contact Full Name")).to_have_text("Full Name")
-    expect(get_review_row(page, "Contact Email address")).to_have_text(
-        "contact@example.com"
-    )
-    expect(
-        get_review_row(page, "We need the contact details of the person")
-    ).to_have_text("Yes")
-    expect(get_review_row(page, "Licence holder full name")).to_have_text(
-        "Licence Holder"
-    )
-    expect(get_review_row(page, "Licence holder Email")).to_have_text(
-        "licenceholder@example.com"
-    )
+    expect(get_review_row(page, "Contact Email address")).to_have_text("contact@example.com")
+    expect(get_review_row(page, "We need the contact details of the person")).to_have_text("Yes")
+    expect(get_review_row(page, "Licence holder full name")).to_have_text("Licence Holder")
+    expect(get_review_row(page, "Licence holder Email")).to_have_text("licenceholder@example.com")
 
-    expect(get_review_row(page, "What is the full legal name")).to_have_text(
-        "Organisation name"
-    )
-    expect(get_review_row(page, "Please enter any other names")).to_have_text(
-        "Organisation alias"
-    )
-    expect(get_review_row(page, "Which country is your organisation")).to_have_text(
-        "Chile"
-    )
-    expect(get_review_row(page, "What type of organisation")).to_have_text(
-        re.compile("Private limited company")
-    )
-    expect(get_review_row(page, "What type of organisation")).to_have_text(
-        re.compile("Other organisation type")
-    )
+    expect(get_review_row(page, "What is the full legal name")).to_have_text("Organisation name")
+    expect(get_review_row(page, "Please enter any other names")).to_have_text("Organisation alias")
+    expect(get_review_row(page, "Which country is your organisation")).to_have_text("Chile")
+    expect(get_review_row(page, "What type of organisation")).to_have_text(re.compile("Private limited company"))
+    expect(get_review_row(page, "What type of organisation")).to_have_text(re.compile("Other organisation type"))
 
-    expect(
-        get_review_row(page, "Please provide your organisation identifier")
-    ).to_have_text("Organisation identifier")
-    expect(
-        get_review_row(page, "Please provide the name of any partners or organisations")
-    ).to_have_text("Partners")
+    expect(get_review_row(page, "Please provide your organisation identifier")).to_have_text("Organisation identifier")
+    expect(get_review_row(page, "Please provide the name of any partners or organisations")).to_have_text("Partners")
 
-    expect(
-        get_review_row(
-            page, "Please give any project or product name associated with this work"
-        )
-    ).to_have_text("Project name")
-    expect(
-        get_review_row(page, "Please share a link to the project or product site")
-    ).to_have_text("https://example.com")
-    expect(get_review_row(page, "What is the main purpose")).to_have_text(
-        re.compile("Publish legal information")
+    expect(get_review_row(page, "Please give any project or product name associated with this work")).to_have_text(
+        "Project name"
     )
-    expect(get_review_row(page, "What is the main purpose")).to_have_text(
-        re.compile("Other purpose")
+    expect(get_review_row(page, "Please share a link to the project or product site")).to_have_text(
+        "https://example.com"
     )
-    expect(
-        get_review_row(
-            page, "Which one best describes who will be able to access the outcomes"
-        )
-    ).to_have_text("Restricted access (e.g. only subscribers or research peers)")
-    expect(get_review_row(page, "Which individuals or communities")).to_have_text(
-        re.compile("Public bodies")
+    expect(get_review_row(page, "What is the main purpose")).to_have_text(re.compile("Publish legal information"))
+    expect(get_review_row(page, "What is the main purpose")).to_have_text(re.compile("Other purpose"))
+    expect(get_review_row(page, "Which one best describes who will be able to access the outcomes")).to_have_text(
+        "Restricted access (e.g. only subscribers or research peers)"
     )
-    expect(get_review_row(page, "Which individuals or communities")).to_have_text(
-        re.compile("Other benefit")
-    )
+    expect(get_review_row(page, "Which individuals or communities")).to_have_text(re.compile("Public bodies"))
+    expect(get_review_row(page, "Which individuals or communities")).to_have_text(re.compile("Other benefit"))
 
-    expect(get_review_row(page, "Please provide a public statement")).to_have_text(
-        "Public statement"
-    )
+    expect(get_review_row(page, "Please provide a public statement")).to_have_text("Public statement")
 
     expect(
         get_review_row(
@@ -217,17 +145,9 @@ def test_transactional_licence_form(page: Page):
             "Will the computational analysis focus on specific individuals or specific groups of people?",
         )
     ).to_have_text("No")
-    expect(
-        get_review_row(
-            page, "Will you anonymise individuals before you analyse records?"
-        )
-    ).to_have_text("Yes")
-    expect(
-        get_review_row(page, "Will you regularly review algorithms for bias?")
-    ).to_have_text("No")
-    expect(get_review_row(page, "Will you abide by a code of ethics?")).to_have_text(
-        "Yes"
-    )
+    expect(get_review_row(page, "Will you anonymise individuals before you analyse records?")).to_have_text("Yes")
+    expect(get_review_row(page, "Will you regularly review algorithms for bias?")).to_have_text("No")
+    expect(get_review_row(page, "Will you abide by a code of ethics?")).to_have_text("Yes")
     expect(
         get_review_row(
             page,
@@ -235,30 +155,16 @@ def test_transactional_licence_form(page: Page):
         )
     ).to_have_text("No")
 
-    expect(
-        get_review_row(page, "Will you make the entire record available online?")
-    ).to_have_text("No")
-    expect(
-        get_review_row(
-            page, "Will data extracted from these records be published online?"
-        )
-    ).to_have_text("Yes")
-    expect(
-        get_review_row(
-            page, "will you make your methodology available to others for scrutiny?"
-        )
-    ).to_have_text("No")
-    expect(
-        get_review_row(page, "Will you analyse and publish findings online?")
-    ).to_have_text("Yes")
-    expect(
-        get_review_row(page, "Do you intend to use computational analysis")
-    ).to_have_text(
+    expect(get_review_row(page, "Will you make the entire record available online?")).to_have_text("No")
+    expect(get_review_row(page, "Will data extracted from these records be published online?")).to_have_text("Yes")
+    expect(get_review_row(page, "will you make your methodology available to others for scrutiny?")).to_have_text("No")
+    expect(get_review_row(page, "Will you analyse and publish findings online?")).to_have_text("Yes")
+    expect(get_review_row(page, "Do you intend to use computational analysis")).to_have_text(
         re.compile("Directly inform or influence the decision of a third-party")
     )
-    expect(
-        get_review_row(page, "Will you notify people when they are using generative AI")
-    ).to_have_text("Not using Generative AI")
+    expect(get_review_row(page, "Will you notify people when they are using generative AI")).to_have_text(
+        "Not using Generative AI"
+    )
     expect(
         get_review_row(
             page,
@@ -266,17 +172,13 @@ def test_transactional_licence_form(page: Page):
         )
     ).to_have_text("No")
 
-    expect(
-        get_review_row(
-            page, "Licence holders must acknowledge and abide by all the 9 principles."
-        )
-    ).to_have_text("Yes")
+    expect(get_review_row(page, "Licence holders must acknowledge and abide by all the 9 principles.")).to_have_text(
+        "Yes"
+    )
 
-    expect(
-        get_review_row(
-            page, "Please describe how you will meet the 9 principles as terms."
-        )
-    ).to_have_text("Nine principles statement")
+    expect(get_review_row(page, "Please describe how you will meet the 9 principles as terms.")).to_have_text(
+        "Nine principles statement"
+    )
 
     expect(
         get_review_row(
@@ -286,20 +188,14 @@ def test_transactional_licence_form(page: Page):
     ).to_have_text("Additional comments")
 
     # Editing responses
-    page.locator("dt", has_text="Contact Full Name").locator("..").get_by_text(
-        "Change"
-    ).click()
+    page.locator("dt", has_text="Contact Full Name").locator("..").get_by_text("Change").click()
     page.get_by_label("Contact Full Name").fill("New Full Name")
     page.get_by_text("Next").click()
-    page.get_by_label("What is the full legal name of your organisation?").fill(
-        "New Organisation name"
-    )
+    page.get_by_label("What is the full legal name of your organisation?").fill("New Organisation name")
     page.get_by_text("Save and review").click()
 
     expect(get_review_row(page, "Contact Full Name")).to_have_text("New Full Name")
-    expect(get_review_row(page, "What is the full legal name")).to_have_text(
-        "New Organisation name"
-    )
+    expect(get_review_row(page, "What is the full legal name")).to_have_text("New Organisation name")
 
 
 def test_data_saved_when_going_back(page: Page):
@@ -313,17 +209,13 @@ def test_data_saved_when_going_back(page: Page):
     page.goto("/re-use-find-case-law-records/steps/contact")
     page.get_by_label("Contact Full Name").fill("Full Name")
     page.get_by_label("Contact Email address").fill("contact@example.com")
-    page.get_by_label(
-        "This is a different person (please enter their details below)"
-    ).click()
+    page.get_by_label("This is a different person (please enter their details below)").click()
     page.get_by_label("Licence holder Full Name").fill("Licence Holder")
     page.get_by_label("Licence holder Email").fill("licenceholder@example.com")
 
     # On the next page, fill only 1 field, leaving others blank
     page.get_by_text("Next").click()
-    page.get_by_label("What is the full legal name of your organisation?").fill(
-        "Organisation name"
-    )
+    page.get_by_label("What is the full legal name of your organisation?").fill("Organisation name")
 
     # Check previous page has information
     page.get_by_text("Previous").click()
@@ -331,6 +223,4 @@ def test_data_saved_when_going_back(page: Page):
 
     # Check incomplete next page has information
     page.get_by_text("Next").click()
-    expect(
-        page.get_by_label("What is the full legal name of your organisation?")
-    ).to_have_value("Organisation name")
+    expect(page.get_by_label("What is the full legal name of your organisation?")).to_have_value("Organisation name")

--- a/fabfile.py
+++ b/fabfile.py
@@ -24,9 +24,7 @@ LOCAL_DB_DUMP_DIR = "database_dumps"
 
 
 def container_exec(cmd, container_name="django", check_returncode=False):
-    result = subprocess.run(
-        ["docker", "compose", "exec", "-T", container_name, "bash", "-c", cmd]
-    )
+    result = subprocess.run(["docker", "compose", "exec", "-T", container_name, "bash", "-c", cmd])
     if check_returncode:
         result.check_returncode()
     return result
@@ -207,9 +205,7 @@ def e2etest(c, baseUrl="http://django:3000"):
             "e2e_tests",
         ]
     )
-    subprocess.run(
-        ["docker", "compose", "run", "e2e_tests", "pytest", "--base-url", baseUrl]
-    )
+    subprocess.run(["docker", "compose", "run", "e2e_tests", "pytest", "--base-url", baseUrl])
 
 
 @task
@@ -266,12 +262,8 @@ def psql(c, command=None):
 
 
 def delete_db(c):
-    postgres_exec(
-        f"dropdb --if-exists --host db --username={LOCAL_DATABASE_USERNAME} {LOCAL_DATABASE_NAME}"
-    )
-    postgres_exec(
-        f"createdb --host db --username={LOCAL_DATABASE_USERNAME} {LOCAL_DATABASE_NAME}"
-    )
+    postgres_exec(f"dropdb --if-exists --host db --username={LOCAL_DATABASE_USERNAME} {LOCAL_DATABASE_NAME}")
+    postgres_exec(f"createdb --host db --username={LOCAL_DATABASE_USERNAME} {LOCAL_DATABASE_NAME}")
 
 
 @task
@@ -279,9 +271,7 @@ def dump_db(c, filename):
     """Snapshot the database, files will be stored in the db container"""
     if not filename.endswith(".dmp"):
         filename += ".dmp"
-    postgres_exec(
-        f"pg_dump -d {LOCAL_DATABASE_NAME} -U {LOCAL_DATABASE_USERNAME} > {filename}"
-    )
+    postgres_exec(f"pg_dump -d {LOCAL_DATABASE_NAME} -U {LOCAL_DATABASE_USERNAME} > {filename}")
     print(f"Database dumped to: {filename}")
 
 

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -31,9 +31,7 @@ class JudgmentAtomFeed(Atom1Feed):
         super().add_root_elements(handler)
         pagination = paginator(self.feed["page"], self.feed["total"])
 
-        handler.addQuickElement(
-            "link", "", {"rel": "first", "href": f'{self.feed["feed_url"]}?page=1'}
-        )
+        handler.addQuickElement("link", "", {"rel": "first", "href": f'{self.feed["feed_url"]}?page=1'})
         handler.addQuickElement(
             "link",
             "",
@@ -84,22 +82,12 @@ class LatestJudgmentsFeed(Feed):
 
         search_parameters = SearchParameters(
             court=court_query if court_query else None,
-            date_from=(
-                datetime.date(year=year, month=1, day=1).strftime("%Y-%m-%d")
-                if year
-                else None
-            ),
-            date_to=(
-                datetime.date(year=year, month=12, day=31).strftime("%Y-%m-%d")
-                if year
-                else None
-            ),
+            date_from=(datetime.date(year=year, month=1, day=1).strftime("%Y-%m-%d") if year else None),
+            date_to=(datetime.date(year=year, month=12, day=31).strftime("%Y-%m-%d") if year else None),
             order=order,
             page=int(page),
         )
-        search_response = search_judgments_and_parse_response(
-            api_client, search_parameters
-        )
+        search_response = search_judgments_and_parse_response(api_client, search_parameters)
 
         return {
             "slug": slug,

--- a/judgments/forms/search_forms.py
+++ b/judgments/forms/search_forms.py
@@ -24,15 +24,9 @@ def _get_choices_by_group(courts):
     options: dict = {}
     for group in courts:
         if group.display_heading:
-            option = {
-                group.name: {
-                    court.canonical_param: court.grouped_name for court in group.courts
-                }
-            }
+            option = {group.name: {court.canonical_param: court.grouped_name for court in group.courts}}
         else:
-            option = {
-                court.canonical_param: court.grouped_name for court in group.courts
-            }
+            option = {court.canonical_param: court.grouped_name for court in group.courts}
         options = options | option
     return options
 

--- a/judgments/management/commands/recalculate_court_dates.py
+++ b/judgments/management/commands/recalculate_court_dates.py
@@ -27,9 +27,7 @@ class Command(BaseCommand):
             self.stdout.write(self.style.NOTICE(f"{court.name}"))
 
             if not court.canonical_param:
-                self.stdout.write(
-                    self.style.ERROR(f"{court.name} has no canonical_param! Skipping.")
-                )
+                self.stdout.write(self.style.ERROR(f"{court.name} has no canonical_param! Skipping."))
                 continue
 
             start_year = self.get_start_year(court)
@@ -78,9 +76,7 @@ falling back to config value of {fallback_end_year}"
 
         return end_year
 
-    def _get_year_of_first_document_in_order(
-        self, canonical_court_param, order, document_reference, fallback
-    ):
+    def _get_year_of_first_document_in_order(self, canonical_court_param, order, document_reference, fallback):
         search_response = search_judgments_and_parse_response(
             api_client, SearchParameters(court=canonical_court_param, order=order)
         )

--- a/judgments/models/document_pdf.py
+++ b/judgments/models/document_pdf.py
@@ -30,11 +30,7 @@ class DocumentPdf:
 
     @cached_property
     def uri(self):
-        return (
-            self.generate_uri()
-            if self.size
-            else formatted_document_uri(self.document_uri, "pdf")
-        )
+        return self.generate_uri() if self.size else formatted_document_uri(self.document_uri, "pdf")
 
     def generate_uri(self):
         env = environ.Env()

--- a/judgments/templatetags/court_utils.py
+++ b/judgments/templatetags/court_utils.py
@@ -71,9 +71,7 @@ def get_court_date_range(court):
 
 @register.filter
 def get_court_judgments_count(court):
-    return search_judgments_and_parse_response(
-        api_client, SearchParameters(court=court.canonical_param)
-    ).total
+    return search_judgments_and_parse_response(api_client, SearchParameters(court=court.canonical_param)).total
 
 
 @register.filter

--- a/judgments/templatetags/query_filters.py
+++ b/judgments/templatetags/query_filters.py
@@ -71,9 +71,7 @@ def remove_court(query_params, court):
     params = dict(query_params)
     params["page"] = None
     params["court"] = [court2 for court2 in params.get("court", []) if court != court2]
-    params["tribunal"] = [
-        court2 for court2 in params.get("tribunal", []) if court != court2
-    ]
+    params["tribunal"] = [court2 for court2 in params.get("tribunal", []) if court != court2]
     return make_query_string(params)
 
 

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -60,9 +60,9 @@ class DocumentFactory:
             else:
                 setattr(judgment_mock.return_value, param, value)
 
-        judgment_mock.return_value.best_human_identifier = kwargs.get(
+        judgment_mock.return_value.best_human_identifier = kwargs.get("neutral_citation") or cls.PARAMS_MAP.get(
             "neutral_citation"
-        ) or cls.PARAMS_MAP.get("neutral_citation")
+        )
         return judgment_mock()
 
 

--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -9,9 +9,7 @@ from judgments.tests.fixtures import FakeSearchResponse
 class TestAtomFeed(TestCase):
     @patch("judgments.feeds.search_judgments_and_parse_response")
     @patch("judgments.feeds.api_client")
-    def test_feed_exists(
-        self, mock_api_client, mock_search_judgments_and_parse_response
-    ):
+    def test_feed_exists(self, mock_api_client, mock_search_judgments_and_parse_response):
         search_response = FakeSearchResponse()
         mock_search_judgments_and_parse_response.return_value = search_response
 
@@ -33,9 +31,7 @@ class TestAtomFeed(TestCase):
         # that there is a successful response
         self.assertEqual(response.status_code, 200)
         # that it is an atom feed
-        self.assertEqual(
-            response["Content-Type"], "application/atom+xml; charset=utf-8"
-        )
+        self.assertEqual(response["Content-Type"], "application/atom+xml; charset=utf-8")
 
         # that it has the correct site name
         self.assertIn("<name>The National Archives</name>", decoded_response)

--- a/judgments/tests/test_cookies.py
+++ b/judgments/tests/test_cookies.py
@@ -9,9 +9,7 @@ from judgments.tests.fixtures import FakeSearchResponse
 class TestBadCookie(TestCase):
     @patch("judgments.views.index.api_client")
     @patch("judgments.views.index.search_judgments_and_parse_response")
-    def test_bad_cookie(
-        self, mock_search_judgments_and_parse_response, mock_api_client
-    ):
+    def test_bad_cookie(self, mock_search_judgments_and_parse_response, mock_api_client):
         self.client.cookies = SimpleCookie({"cookies_policy": "evil"})
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
         response = self.client.get("/")

--- a/judgments/tests/test_courts.py
+++ b/judgments/tests/test_courts.py
@@ -32,52 +32,37 @@ class TestCourtDatesHelper(TestCase):
 
     def mock_court_with_param(self, canonical_param, start_year, end_year):
         mock = Mock()
-        mock.configure_mock(
-            canonical_param=canonical_param, start_year=start_year, end_year=end_year
-        )
+        mock.configure_mock(canonical_param=canonical_param, start_year=start_year, end_year=end_year)
         return mock
 
     @patch("ds_caselaw_utils.courts.courts.get_by_param")
-    def test_when_court_with_param_exists_and_no_dates_in_db_and_start_end_same(
-        self, get, mock
-    ):
+    def test_when_court_with_param_exists_and_no_dates_in_db_and_start_end_same(self, get, mock):
         get.side_effect = CourtDates.DoesNotExist
-        court = self.mock_court_with_param(
-            canonical_param="ehwc", start_year=2011, end_year=2011
-        )
+        court = self.mock_court_with_param(canonical_param="ehwc", start_year=2011, end_year=2011)
         mock.return_value = court
 
         self.assertEqual(get_court_date_range(court), "2011")
 
     @patch("ds_caselaw_utils.courts.courts.get_by_param")
-    def test_when_court_with_param_exists_and_no_dates_in_db_and_start_end_different(
-        self, get, mock
-    ):
+    def test_when_court_with_param_exists_and_no_dates_in_db_and_start_end_different(self, get, mock):
         get.side_effect = CourtDates.DoesNotExist
-        court = self.mock_court_with_param(
-            canonical_param="ehwc", start_year=2011, end_year=2012
-        )
+        court = self.mock_court_with_param(canonical_param="ehwc", start_year=2011, end_year=2012)
         mock.return_value = court
 
-        self.assertEqual(
-            get_court_date_range(court.canonical_param), "2011&nbsp;to&nbsp;2012"
-        )
+        self.assertEqual(get_court_date_range(court.canonical_param), "2011&nbsp;to&nbsp;2012")
 
     def test_when_court_with_param_exists_and_dates_in_db_and_start_end_same(self, get):
         get.return_value = self.mock_court_dates(2013, 2013)
         court = self.mock_court_dates(2011, 2012)
         self.assertEqual(get_court_date_range(court), "2013")
 
-    def test_when_court_with_param_exists_and_dates_in_db_and_start_end_different(
-        self, get
-    ):
+    def test_when_court_with_param_exists_and_dates_in_db_and_start_end_different(self, get):
         get.return_value = self.mock_court_dates(2013, 2015)
         court = self.mock_court_dates(2011, 2012)
         self.assertEqual(get_court_date_range(court), "2013&nbsp;to&nbsp;2015")
 
 
 class TestCourtContentHelpers(TestCase):
-
     def mock_court_param(self, param):
         mock = Mock()
         mock.configure_mock(canonical_param=param)

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -39,24 +39,18 @@ class TestGetPublishedDocument:
 
     @patch("judgments.views.detail.get_document_by_uri")
     def test_judgment_is_unpublished(self, mock_get_document_by_uri):
-        mock_get_document_by_uri.return_value = JudgmentFactory.build(
-            is_published=False
-        )
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(is_published=False)
         with pytest.raises(Http404):
             get_published_document_by_uri("2099/eat/1")
 
-    @patch(
-        "judgments.views.detail.get_document_by_uri", side_effect=DocumentNotFoundError
-    )
+    @patch("judgments.views.detail.get_document_by_uri", side_effect=DocumentNotFoundError)
     def test_judgment_missing(self, mock_get_document_by_uri):
         with pytest.raises(Http404):
             get_published_document_by_uri("not-a-judgment")
 
     @patch("judgments.views.detail.get_document_by_uri")
     def test_press_summary_is_published(self, mock_get_document_by_uri):
-        judgment = JudgmentFactory.build(
-            is_published=True, uri="2022/eat/1/press-summary/1"
-        )
+        judgment = JudgmentFactory.build(is_published=True, uri="2022/eat/1/press-summary/1")
         mock_get_document_by_uri.return_value = judgment
         assert get_published_document_by_uri("2022/eat/1/press-summary/1") == judgment
 
@@ -74,9 +68,7 @@ class TestJudgment(TestCase):
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
         self.assertIn("<p>This is a judgment in HTML.</p>", decoded_response)
-        self.assertIn(
-            '<meta name="robots" content="noindex,nofollow" />', decoded_response
-        )
+        self.assertIn('<meta name="robots" content="noindex,nofollow" />', decoded_response)
 
         self.assertEqual(response.status_code, 200)
 
@@ -112,17 +104,13 @@ class TestJudgmentPdfLinkText(TestCase):
     @patch.dict(environ, {"ASSETS_CDN_BASE_URL": "https://example.com"})
     def test_pdf_link_with_size(self, mock_get_document_by_uri, mock_pdf):
         mock_get_document_by_uri.return_value = JudgmentFactory.build(is_published=True)
-        mock_pdf.return_value.uri = (
-            "https://example.com/test/2023/123/test_2023_123.pdf"
-        )
+        mock_pdf.return_value.uri = "https://example.com/test/2023/123/test_2023_123.pdf"
         mock_pdf.return_value.size = 1234
 
         response = self.client.get("/test/2023/123")
         decoded_response = response.content.decode("utf-8")
 
-        self.assertIn(
-            "https://example.com/test/2023/123/test_2023_123.pdf", decoded_response
-        )
+        self.assertIn("https://example.com/test/2023/123/test_2023_123.pdf", decoded_response)
         self.assertNotIn("data.pdf", decoded_response)
         self.assertIn(f"({filesizeformat(1234)})", decoded_response)
 
@@ -196,9 +184,7 @@ class TestDocumentDownloadOptions:
 class TestDocumentURIRedirects(TestCase):
     @patch("judgments.views.detail.get_document_by_uri")
     def test_non_canonical_uri_redirects(self, mock_get_document_by_uri):
-        mock_get_document_by_uri.return_value = JudgmentFactory.build(
-            uri="test/1234/567", is_published=True
-        )
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(uri="test/1234/567", is_published=True)
         response = self.client.get("/test/1234/567/")
         assert isinstance(response, HttpResponseRedirect)
         assert response.status_code == 302
@@ -215,12 +201,8 @@ class TestPressSummaryLabel(TestCase):
         THEN response should contain the press summary label
         """
 
-        mock_get_document_by_uri.return_value = JudgmentFactory.build(
-            document_noun="press summary", is_published=True
-        )
-        response = self.client.get(
-            "/test/2023/123"
-        )  # has to match factory to avoid redirect.
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(document_noun="press summary", is_published=True)
+        response = self.client.get("/test/2023/123")  # has to match factory to avoid redirect.
         self.assertContains(
             response,
             '<p class="judgment-toolbar__press-summary-title">Press Summary</p>',
@@ -229,17 +211,13 @@ class TestPressSummaryLabel(TestCase):
 
     @patch("judgments.views.detail.DocumentPdf", autospec=True)
     @patch("judgments.views.detail.get_document_by_uri")
-    def test_no_press_summary_label_when_on_judgment(
-        self, mock_get_document_by_uri, mock_pdf
-    ):
+    def test_no_press_summary_label_when_on_judgment(self, mock_get_document_by_uri, mock_pdf):
         """
         GIVEN judgment
         WHEN request is made with judgment uri
         THEN response should NOT contain the press summary label
         """
-        mock_get_document_by_uri.return_value = JudgmentFactory.build(
-            uri="eat/2023/1", is_published=True
-        )
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(uri="eat/2023/1", is_published=True)
         response = self.client.get("/eat/2023/1")
         self.assertNotContains(
             response,
@@ -285,13 +263,9 @@ class TestViewRelatedDocumentButton:
 
         def get_document_by_uri_side_effect(document_uri):
             if document_uri == uri:
-                return JudgmentFactory.build(
-                    uri=uri, is_published=True, document_noun=document_noun
-                )
+                return JudgmentFactory.build(uri=uri, is_published=True, document_noun=document_noun)
             elif document_uri == expected_href:
-                return JudgmentFactory.build(
-                    uri=expected_href, is_published=True, document_noun=document_noun
-                )
+                return JudgmentFactory.build(uri=expected_href, is_published=True, document_noun=document_noun)
             else:
                 raise DocumentNotFoundError()
 
@@ -346,13 +320,9 @@ class TestViewRelatedDocumentButton:
 
         def get_document_by_uri_side_effect(document_uri):
             if document_uri == uri:
-                return JudgmentFactory.build(
-                    uri=uri, is_published=True, document_noun=document_noun
-                )
+                return JudgmentFactory.build(uri=uri, is_published=True, document_noun=document_noun)
             elif document_uri == expected_href:
-                return JudgmentFactory.build(
-                    uri=expected_href, is_published=True, document_noun=document_noun
-                )
+                return JudgmentFactory.build(uri=expected_href, is_published=True, document_noun=document_noun)
             else:
                 raise DocumentNotFoundError()
 
@@ -396,9 +366,7 @@ class TestViewRelatedDocumentButton:
 
         def get_document_by_uri_side_effect(document_uri):
             if document_uri == uri:
-                return JudgmentFactory.build(
-                    uri=document_uri, is_published=True, document_noun="press summary"
-                )
+                return JudgmentFactory.build(uri=document_uri, is_published=True, document_noun="press summary")
             else:
                 raise DocumentNotFoundError()
 
@@ -541,9 +509,7 @@ class TestBreadcrumbs:
 class TestDocumentHeadings(TestCase):
     @patch("judgments.views.detail.DocumentPdf", autospec=True)
     @patch("judgments.views.detail.get_document_by_uri")
-    def test_document_headings_when_press_summary(
-        self, mock_get_document_by_uri, mock_pdf
-    ):
+    def test_document_headings_when_press_summary(self, mock_get_document_by_uri, mock_pdf):
         """
         GIVEN that the document returned will be a press summary
         WHEN a request is made with to a document detail page

--- a/judgments/tests/test_factories.py
+++ b/judgments/tests/test_factories.py
@@ -39,9 +39,7 @@ class TestJudgmentFactory:
     def test_html(self):
         judgment = JudgmentFactory.build(html="<h1>Testing HTML</h1>")
 
-        assert (
-            judgment.content_as_html(DocumentURIString("")) == "<h1>Testing HTML</h1>"
-        )
+        assert judgment.content_as_html(DocumentURIString("")) == "<h1>Testing HTML</h1>"
 
     def test_xml(self):
         judgment = JudgmentFactory.build(xml="<h1>Testing XML</h1>")

--- a/judgments/tests/test_forms.py
+++ b/judgments/tests/test_forms.py
@@ -29,9 +29,7 @@ class TestAdvancedSearchForm(TestCase):
         self.assertFalse(form.is_valid())
         # Since this validation is done at a form level, rather than a field level,
         # the errors will be at the __all__ key.
-        self.assertEqual(
-            form.errors, {"__all__": ["Please enter a 'to' date after the 'from' date"]}
-        )
+        self.assertEqual(form.errors, {"__all__": ["Please enter a 'to' date after the 'from' date"]})
 
     def test_advanced_search_form_date_limit(self):
         """

--- a/judgments/tests/test_homepage.py
+++ b/judgments/tests/test_homepage.py
@@ -12,7 +12,5 @@ class TestHomepage(TestCase):
     def test_homepage(self, mock_search_judgments_and_parse_response, mock_api_client):
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
         response = self.client.get("/")
-        mock_search_judgments_and_parse_response.assert_called_with(
-            mock_api_client, SearchParameters(order="-date")
-        )
+        mock_search_judgments_and_parse_response.assert_called_with(mock_api_client, SearchParameters(order="-date"))
         self.assertContains(response, "A SearchResult name!", html=True)

--- a/judgments/tests/test_pdf.py
+++ b/judgments/tests/test_pdf.py
@@ -18,9 +18,7 @@ class TestDocumentPdf:
 
         assert document_pdf.size == 100
 
-        requests_mock.head.assert_called_once_with(
-            document_pdf.generate_uri(), headers={"Accept-Encoding": None}
-        )
+        requests_mock.head.assert_called_once_with(document_pdf.generate_uri(), headers={"Accept-Encoding": None})
 
     @patch("judgments.models.document_pdf.requests")
     def test_get_pdf_size_returns_blank_string_if_404(self, requests_mock):
@@ -73,7 +71,4 @@ class TestDocumentPdf:
     def test_generate_uri_generates_the_correct_uri_with_base_url(self):
         document_pdf = DocumentPdf("foo/bar/baz")
 
-        assert (
-            document_pdf.generate_uri()
-            == "https://bucket.s3.region.amazonaws.com/foo/bar/baz/foo_bar_baz.pdf"
-        )
+        assert document_pdf.generate_uri() == "https://bucket.s3.region.amazonaws.com/foo/bar/baz/foo_bar_baz.pdf"

--- a/judgments/tests/test_press_summaries.py
+++ b/judgments/tests/test_press_summaries.py
@@ -22,9 +22,7 @@ class TestPressSummaries(TestCase):
             press_summary_2,
         ]
 
-        mock_get_press_summaries_for_document_uri.return_value = (
-            excepted_press_summaries
-        )
+        mock_get_press_summaries_for_document_uri.return_value = excepted_press_summaries
 
         request = Mock()
         document_uri = "foo/bar/baz"
@@ -43,9 +41,7 @@ class TestPressSummaries(TestCase):
         )
 
     @patch("judgments.views.press_summaries.get_press_summaries_for_document_uri")
-    def test_redirects_to_press_summaries_when_one_present(
-        self, mock_get_press_summaries_for_document_uri
-    ):
+    def test_redirects_to_press_summaries_when_one_present(self, mock_get_press_summaries_for_document_uri):
         press_summary = PressSummaryFactory.build()
         mock_get_press_summaries_for_document_uri.return_value = [press_summary]
 
@@ -61,9 +57,7 @@ class TestPressSummaries(TestCase):
         )
 
     @patch("judgments.views.press_summaries.get_press_summaries_for_document_uri")
-    def test_shows_multiple_when_multiple_present(
-        self, mock_get_press_summaries_for_document_uri
-    ):
+    def test_shows_multiple_when_multiple_present(self, mock_get_press_summaries_for_document_uri):
         press_summary_1 = PressSummaryFactory.build()
         press_summary_2 = PressSummaryFactory.build()
 
@@ -89,9 +83,7 @@ class TestPressSummaries(TestCase):
         )
 
     @patch("judgments.views.press_summaries.get_press_summaries_for_document_uri")
-    def test_throws_404_when_no_summaries_present(
-        self, mock_get_press_summaries_for_document_uri
-    ):
+    def test_throws_404_when_no_summaries_present(self, mock_get_press_summaries_for_document_uri):
         mock_get_press_summaries_for_document_uri.return_value = []
 
         response = self.client.get("/uksc/2023/35/press-summary")

--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -16,9 +16,7 @@ from judgments.tests.utils.assertions import assert_contains_html
 class TestBrowseResults(TestCase):
     @patch("judgments.views.browse.api_client")
     @patch("judgments.views.browse.search_judgments_and_parse_response")
-    def test_browse_results(
-        self, mock_search_judgments_and_parse_response, mock_api_client
-    ):
+    def test_browse_results(self, mock_search_judgments_and_parse_response, mock_api_client):
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
         response = self.client.get("/ewhc/ch/2022")
         mock_search_judgments_and_parse_response.assert_called_with(
@@ -57,9 +55,7 @@ class TestSearchResults(TestCase):
         CourtDateFactory()
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
 
-        response = self.client.get(
-            "/judgments/search?query=waltham+forest", {"query": "waltham forest"}
-        )
+        response = self.client.get("/judgments/search?query=waltham+forest", {"query": "waltham forest"})
 
         self.assertContains(
             response,
@@ -101,9 +97,7 @@ class TestSearchResults(TestCase):
         """
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
 
-        response = self.client.get(
-            "/judgments/search?query=waltham+forest", {"query": "waltham forest"}
-        )
+        response = self.client.get("/judgments/search?query=waltham+forest", {"query": "waltham forest"})
 
         self.assertContains(
             response,
@@ -152,9 +146,7 @@ class TestSearchResults(TestCase):
         </div>
     """
 
-        response = self.client.get(
-            "/judgments/search?from_date_0=1&from_date_1=1&from_date_2=1444"
-        )
+        response = self.client.get("/judgments/search?from_date_0=1&from_date_1=1&from_date_2=1444")
 
         assert_contains_html(response, expected_html)
 
@@ -184,9 +176,7 @@ class TestSearchResults(TestCase):
         </div>
 """
 
-        response = self.client.get(
-            "/judgments/search?from_date_0=1&from_date_1=1&from_date_2=2011"
-        )
+        response = self.client.get("/judgments/search?from_date_0=1&from_date_1=1&from_date_2=2011")
 
         self.assertNotContains(response, expected_html)
 
@@ -205,9 +195,7 @@ class TestSearchResults(TestCase):
         The expected applied filters HTML:
         - Includes a div with class `advice-message`
         """
-        mock_search_judgments_and_parse_response.return_value = (
-            FakeSearchResponseNoResults()
-        )
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponseNoResults()
         expected_html = """
         <div class="govuk-warning-text">
             <span class="govuk-warning-text__icon" aria-hidden="true">i</span>
@@ -219,9 +207,7 @@ class TestSearchResults(TestCase):
         </div>
 """
 
-        response = self.client.get(
-            "/judgments/search?from_date_0=1&from_date_1=1&from_date_2=1444"
-        )
+        response = self.client.get("/judgments/search?from_date_0=1&from_date_1=1&from_date_2=1444")
 
         self.assertNotContains(response, expected_html)
 
@@ -390,32 +376,24 @@ class TestSearchResults(TestCase):
 class TestSearchBreadcrumbs(TestCase):
     @patch("judgments.views.advanced_search.api_client")
     @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
-    def test_search_breadcrumbs_without_query_string(
-        self, mock_search_judgments_and_parse_response, mock_api_client
-    ):
+    def test_search_breadcrumbs_without_query_string(self, mock_search_judgments_and_parse_response, mock_api_client):
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
         response = self.client.get("/judgments/search")
         assert response.context["breadcrumbs"] == [{"text": "Search results"}]
 
     @patch("judgments.views.advanced_search.api_client")
     @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
-    def test_search_breadcrumbs_with_query_string(
-        self, mock_search_judgments_and_parse_response, mock_api_client
-    ):
+    def test_search_breadcrumbs_with_query_string(self, mock_search_judgments_and_parse_response, mock_api_client):
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
         response = self.client.get("/judgments/search?query=waltham+forest")
 
-        assert response.context["breadcrumbs"] == [
-            {"text": 'Search results for "waltham forest"'}
-        ]
+        assert response.context["breadcrumbs"] == [{"text": 'Search results for "waltham forest"'}]
 
 
 class TestSearchFacets(TestCase):
     @patch("judgments.views.advanced_search.api_client")
     @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
-    def test_populated_court_facets(
-        self, mock_search_judgments_and_parse_response, mock_api_client
-    ):
+    def test_populated_court_facets(self, mock_search_judgments_and_parse_response, mock_api_client):
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
         court_code = all_courts.get_by_code("EWHC-KBD-TCC")
         response = self.client.get("/judgments/search?query=example+query")
@@ -429,9 +407,7 @@ class TestSearchFacets(TestCase):
 
     @patch("judgments.views.advanced_search.api_client")
     @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
-    def test_populated_tribunal_facets(
-        self, mock_search_judgments_and_parse_response, mock_api_client
-    ):
+    def test_populated_tribunal_facets(self, mock_search_judgments_and_parse_response, mock_api_client):
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
         tribunal_code = all_courts.get_by_code("EAT")
         response = self.client.get("/judgments/search?query=example+query")
@@ -445,15 +421,11 @@ class TestSearchFacets(TestCase):
 
     @patch("judgments.views.advanced_search.api_client")
     @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
-    def test_unpopulated_court_facet_keys(
-        self, mock_search_judgments_and_parse_response, mock_api_client
-    ):
+    def test_unpopulated_court_facet_keys(self, mock_search_judgments_and_parse_response, mock_api_client):
         """
         Advanced search only populates court_facets if they are available
         """
-        mock_search_judgments_and_parse_response.return_value = (
-            FakeSearchResponseNoFacets()
-        )
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponseNoFacets()
         response = self.client.get("/judgments/search?query=example+query")
 
         assert response.context["court_facets"] == {}
@@ -461,9 +433,7 @@ class TestSearchFacets(TestCase):
 
     @patch("judgments.views.advanced_search.api_client")
     @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
-    def test_populated_year_facets(
-        self, mock_search_judgments_and_parse_response, mock_api_client
-    ):
+    def test_populated_year_facets(self, mock_search_judgments_and_parse_response, mock_api_client):
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
         response = self.client.get("/judgments/search?query=example+query")
 
@@ -474,15 +444,11 @@ class TestSearchFacets(TestCase):
 
     @patch("judgments.views.advanced_search.api_client")
     @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
-    def test_unpopulated_year_facet_keys(
-        self, mock_search_judgments_and_parse_response, mock_api_client
-    ):
+    def test_unpopulated_year_facet_keys(self, mock_search_judgments_and_parse_response, mock_api_client):
         """
         Advanced search only populates year_facets if they are available
         """
-        mock_search_judgments_and_parse_response.return_value = (
-            FakeSearchResponseNoFacets()
-        )
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponseNoFacets()
         response = self.client.get("/judgments/search?query=example+query")
 
         assert response.context["year_facets"] == {}

--- a/judgments/tests/test_utils.py
+++ b/judgments/tests/test_utils.py
@@ -97,9 +97,7 @@ class TestUtils(unittest.TestCase):
 
         query_text = "[2014] EWHC 4122 (Fam)"
         page = "1"
-        search_results = [
-            mock_judgment(ncn) for ncn in ["[2013] EWSC 123", "[2022] EWHC 54321 (Fam)"]
-        ]
+        search_results = [mock_judgment(ncn) for ncn in ["[2013] EWSC 123", "[2022] EWHC 54321 (Fam)"]]
         result = show_no_exact_ncn_warning(search_results, query_text, page)
         self.assertTrue(result)
 
@@ -113,9 +111,7 @@ class TestUtils(unittest.TestCase):
 
         query_text = "[2014] EWHC 4122 (Fam)"
         page = "2"
-        search_results = [
-            mock_judgment(ncn) for ncn in ["[2013] EWSC 123", "[2022] EWHC 54321 (Fam)"]
-        ]
+        search_results = [mock_judgment(ncn) for ncn in ["[2013] EWSC 123", "[2022] EWHC 54321 (Fam)"]]
         result = show_no_exact_ncn_warning(search_results, query_text, page)
         self.assertFalse(result)
 
@@ -129,9 +125,7 @@ class TestUtils(unittest.TestCase):
 
         query_text = "[2014] EWHC 4122 (Fam)"
         page = "1"
-        search_results = [
-            mock_judgment(ncn) for ncn in ["[2013] EWSC 123", "[2014] EWHC 4122 (Fam)"]
-        ]
+        search_results = [mock_judgment(ncn) for ncn in ["[2013] EWSC 123", "[2014] EWHC 4122 (Fam)"]]
         result = show_no_exact_ncn_warning(search_results, query_text, page)
         self.assertFalse(result)
 
@@ -143,9 +137,7 @@ class TestUtils(unittest.TestCase):
 
         query_text = "walrus"
         page = "1"
-        search_results = [
-            mock_judgment(ncn) for ncn in ["[2013] EWSC 123", "[2014] EWHC 4122 (Fam)"]
-        ]
+        search_results = [mock_judgment(ncn) for ncn in ["[2013] EWSC 123", "[2014] EWHC 4122 (Fam)"]]
         result = show_no_exact_ncn_warning(search_results, query_text, page)
         self.assertFalse(result)
 
@@ -159,9 +151,7 @@ class TestSearchUtils(unittest.TestCase):
         court_code = all_courts.get_by_code("EWHC-KBD-TCC")
         tribunal_code = all_courts.get_by_code("EAT")
 
-        remaining_facets, court_facets, tribunal_facets = process_court_facets(
-            raw_facets
-        )
+        remaining_facets, court_facets, tribunal_facets = process_court_facets(raw_facets)
 
         self.assertEqual(remaining_facets, {"INVALID": "5", "": "1"})
         self.assertEqual(court_facets, {court_code: "20"})

--- a/judgments/tests/test_validators.py
+++ b/judgments/tests/test_validators.py
@@ -18,7 +18,5 @@ class TestValidators(TestCase):
 
         validator = ValidateYearRange("from")
 
-        with self.assertRaisesMessage(
-            ValidationError, f"Year must be after {settings.MINIMUM_ALLOWED_YEAR}"
-        ):
+        with self.assertRaisesMessage(ValidationError, f"Year must be after {settings.MINIMUM_ALLOWED_YEAR}"):
             validator(year)

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -13,12 +13,8 @@ from judgments.views.detail import PdfDetailView
 
 class TestCourtDates(TestCase):
     def setUp(self):
-        CourtDates.objects.create(
-            param="earliest_starting_court", start_year=2001, end_year=2020
-        )
-        CourtDates.objects.create(
-            param="last_ending_court", start_year=2005, end_year=2023
-        )
+        CourtDates.objects.create(param="earliest_starting_court", start_year=2001, end_year=2020)
+        CourtDates.objects.create(param="last_ending_court", start_year=2005, end_year=2023)
 
     def test_min_year(self):
         self.assertEqual(CourtDates.min_year(), 2001)
@@ -125,9 +121,7 @@ class TestRobotsDirectives(TestCase):
         # The homepage should not have a robots meta tag with nofollow,noindex
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
         response = self.client.get("/")
-        self.assertNotContains(
-            response, '<meta name="robots" content="noindex,nofollow" />'
-        )
+        self.assertNotContains(response, '<meta name="robots" content="noindex,nofollow" />')
         self.assertNotEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
     @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
@@ -136,9 +130,7 @@ class TestRobotsDirectives(TestCase):
         # The judgment search results page should have a robots meta tag
         # with nofollow,noindex
         response = self.client.get("/judgments/search?query=waltham+forest")
-        self.assertContains(
-            response, '<meta name="robots" content="noindex,nofollow" />', html=True
-        )
+        self.assertContains(response, '<meta name="robots" content="noindex,nofollow" />', html=True)
 
     @patch("judgments.views.detail.DocumentPdf")
     @patch("judgments.views.detail.requests.get")
@@ -239,17 +231,13 @@ class TestBackLink(TestCase):
     def test_referrer_is_search_page_with_query(self):
         # When there is a referrer, and it is a results page,
         # the back link is displayed:
-        assert search_context_from_url(
-            "https://example.com/judgments/search?query=test+query"
-        ) == {
+        assert search_context_from_url("https://example.com/judgments/search?query=test+query") == {
             "search_url": "https://example.com/judgments/search?query=test+query",
             "query": "test query",
         }
 
     def test_referrer_not_results_or_advanced_search_page(self):
-        self.assertIs(
-            search_context_from_url("https://example.com/any/other/path"), None
-        )
+        self.assertIs(search_context_from_url("https://example.com/any/other/path"), None)
 
     def test_no_referrer(self):
         self.assertIs(search_context_from_url(None), None)
@@ -268,9 +256,7 @@ def test_preprocess_query():
     # Stopwords are removed
     assert utils.preprocess_query("weight of evidence") == "weight evidence"
     # Quotes are normalised
-    assert (
-        utils.preprocess_query("“excessively difficult”") == '"excessively difficult"'
-    )
+    assert utils.preprocess_query("“excessively difficult”") == '"excessively difficult"'
     # Quote normalisation happens before stopwords are removed, so curly quoted # strings retain stopwords:
     assert utils.preprocess_query("“weight of evidence”") == '"weight of evidence"'
     # "vs", "- v -", etc are stopwords,
@@ -290,19 +276,14 @@ def test_preprocess_query():
 
 def test_normalise_quotes():
     # Curly double quotes are replaced by straight ones
-    assert (
-        utils.normalise_quotes("“excessively difficult”") == '"excessively difficult"'
-    )
+    assert utils.normalise_quotes("“excessively difficult”") == '"excessively difficult"'
 
 
 def test_remove_unquoted_stop_words():
     # Stopwords outside quoted strings are removed.
     assert utils.remove_unquoted_stop_words("weight of evidence") == "weight evidence"
     # Stopwords inside quoted strings are removed
-    assert (
-        utils.remove_unquoted_stop_words('"weight of evidence"')
-        == '"weight of evidence"'
-    )
+    assert utils.remove_unquoted_stop_words('"weight of evidence"') == '"weight of evidence"'
 
     assert utils.remove_unquoted_stop_words("the") == "the"
     assert utils.remove_unquoted_stop_words('"the"') == '"the"'

--- a/judgments/tests/utils/assertions.py
+++ b/judgments/tests/utils/assertions.py
@@ -10,9 +10,7 @@ def assert_contains_html(response, html):
     Raises:
         AssertionError: If the HTML is not found in the response content.
     """
-    assert html.replace(" ", "").replace("\n", "") in response.content.decode().replace(
-        " ", ""
-    ).replace("\n", "")
+    assert html.replace(" ", "").replace("\n", "") in response.content.decode().replace(" ", "").replace("\n", "")
 
 
 def assert_not_contains_html(response, html):
@@ -22,6 +20,4 @@ def assert_not_contains_html(response, html):
     Raises:
         AssertionError: If the HTML is found in the response content.
     """
-    assert html.replace(" ", "").replace(
-        "\n", ""
-    ) not in response.content.decode().replace(" ", "").replace("\n", "")
+    assert html.replace(" ", "").replace("\n", "") not in response.content.decode().replace(" ", "").replace("\n", "")

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -20,9 +20,7 @@ urlpatterns = [
     path("<court:court>", BrowseView.as_view(), name="browse"),
     path("<yyyy:year>", BrowseView.as_view(), name="browse"),
     path("<court:court>/<yyyy:year>", BrowseView.as_view(), name="browse"),
-    path(
-        "<court:court>/<subdivision:subdivision>", BrowseView.as_view(), name="browse"
-    ),
+    path("<court:court>/<subdivision:subdivision>", BrowseView.as_view(), name="browse"),
     path(
         "<court:court>/<subdivision:subdivision>/<yyyy:year>",
         BrowseView.as_view(),
@@ -31,9 +29,7 @@ urlpatterns = [
     path("atom.xml", feeds.LatestJudgmentsFeed(), name="feed"),
     path("<court:court>/atom.xml", feeds.LatestJudgmentsFeed(), name="feed"),
     path("<yyyy:year>/atom.xml", feeds.LatestJudgmentsFeed(), name="feed"),
-    path(
-        "<court:court>/<yyyy:year>/atom.xml", feeds.LatestJudgmentsFeed(), name="feed"
-    ),
+    path("<court:court>/<yyyy:year>/atom.xml", feeds.LatestJudgmentsFeed(), name="feed"),
     path(
         "transactional-licence-form",
         lambda request: HttpResponseRedirect("/computational-licence-form"),

--- a/judgments/utils/search_utils.py
+++ b/judgments/utils/search_utils.py
@@ -8,9 +8,7 @@ from judgments.models.court_dates import CourtDates
 ALL_COURT_CODES = [court.code for court in all_courts.get_all()]
 
 ALL_LISTABLE_COURT_NAMES = [court.name for court in all_courts.get_listable_courts()]
-ALL_LISTABLE_TRIBUNAL_NAMES = [
-    tribunal.name for tribunal in all_courts.get_listable_tribunals()
-]
+ALL_LISTABLE_TRIBUNAL_NAMES = [tribunal.name for tribunal in all_courts.get_listable_tribunals()]
 
 
 def _valid_years():
@@ -59,9 +57,7 @@ def process_court_facets(facets: dict, current_courts: dict = {}):
         and all_courts.get_by_code(facet_key).name in ALL_LISTABLE_TRIBUNAL_NAMES
     }
     unprocessed_facets = {
-        facet_key: facet_value
-        for facet_key, facet_value in facets.items()
-        if facet_key not in ALL_COURT_CODES
+        facet_key: facet_value for facet_key, facet_value in facets.items() if facet_key not in ALL_COURT_CODES
     }
 
     sorted_court_facets = _sort_by_number_in_value(court_facets)
@@ -75,15 +71,9 @@ def process_year_facets(facets: dict):
     Separates facets dict into non-year facets,
     and year facets
     """
-    year_facets = {
-        facet_key: facet_value
-        for facet_key, facet_value in facets.items()
-        if facet_key in _valid_years()
-    }
+    year_facets = {facet_key: facet_value for facet_key, facet_value in facets.items() if facet_key in _valid_years()}
     unprocessed_facets = {
-        facet_key: facet_value
-        for facet_key, facet_value in facets.items()
-        if facet_key not in _valid_years()
+        facet_key: facet_value for facet_key, facet_value in facets.items() if facet_key not in _valid_years()
     }
 
     return unprocessed_facets, year_facets

--- a/judgments/utils/utils.py
+++ b/judgments/utils/utils.py
@@ -67,9 +67,7 @@ def remove_unquoted_stop_words(query):
         and re.match(r"\"$|\'$", query) is None
         and re.match(solo_stop_word_regex(stop_words), query) is None
     ):
-        without_stop_words = re.sub(
-            without_stop_words_regex(stop_words), "", query, re.IGNORECASE
-        )
+        without_stop_words = re.sub(without_stop_words_regex(stop_words), "", query, re.IGNORECASE)
         return re.sub(r"\s+", " ", without_stop_words)
     return query
 
@@ -117,9 +115,7 @@ def paginator(current_page: int, total, size_per_page: int = RESULTS_PER_PAGE):
         maximum=MAX_RESULTS_PER_PAGE,
     )
     number_of_pages = math.ceil(int(total) / size_per_page)
-    next_pages = list(
-        range(current_page + 1, min(current_page + 10, number_of_pages) + 1)
-    )
+    next_pages = list(range(current_page + 1, min(current_page + 10, number_of_pages) + 1))
 
     return {
         "current_page": current_page,
@@ -176,9 +172,7 @@ def get_document_by_uri(document_uri: str) -> Document:
 
 
 def get_press_summaries_for_document_uri(document_uri: str) -> list[PressSummary]:
-    return api_client.get_press_summaries_for_document_uri(
-        DocumentURIString(document_uri)
-    )
+    return api_client.get_press_summaries_for_document_uri(DocumentURIString(document_uri))
 
 
 def formatted_document_uri(document_uri: str, format: Optional[str] = None) -> str:

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -69,9 +69,7 @@ def advanced_search(request):
         """
         if not form.is_valid():
             # If the form has errors, return it for rendering!
-            return TemplateResponse(
-                request, "pages/structured_search.html", {"form": form}
-            )
+            return TemplateResponse(request, "pages/structured_search.html", {"form": form})
         else:
             context: dict = {}
             court_facets: dict = {}
@@ -79,9 +77,7 @@ def advanced_search(request):
             year_facets: dict = {}
             query_params: dict = {}
             query_text: str = form.cleaned_data.get("query", "")
-            page: int = clamp(
-                sanitise_input_to_integer(params.get("page"), 1), minimum=1
-            )
+            page: int = clamp(sanitise_input_to_integer(params.get("page"), 1), minimum=1)
             per_page: int = clamp(
                 sanitise_input_to_integer(params.get("per_page"), RESULTS_PER_PAGE),
                 minimum=1,
@@ -124,9 +120,7 @@ def advanced_search(request):
                 "page": page,
             }
             # Merge the courts and tribunals as they are treated as the same in MarkLogic.
-            courts_and_tribunals = form.cleaned_data.get(
-                "court", []
-            ) + form.cleaned_data.get("tribunal", [])
+            courts_and_tribunals = form.cleaned_data.get("court", []) + form.cleaned_data.get("tribunal", [])
             # `SearchParameters` takes an optional string for dates
             if not to_date:
                 to_date_as_search_param = None
@@ -152,29 +146,21 @@ def advanced_search(request):
 
             # Get the response from Marklogic
             try:
-                search_response: SearchResponse = search_judgments_and_parse_response(
-                    api_client, search_parameters
-                )
+                search_response: SearchResponse = search_judgments_and_parse_response(api_client, search_parameters)
             except MarklogicResourceNotFoundError:
                 return HttpResponseServerError("Search failed")
 
             # If a query was provided, get relevant search facets to display to the user
             if search_parameters.query:
-                unprocessed_facets, court_facets, tribunal_facets = (
-                    process_court_facets(search_response.facets, courts_and_tribunals)
-                )
-                unprocessed_facets, year_facets = process_year_facets(
-                    unprocessed_facets
-                )
+                (
+                    unprocessed_facets,
+                    court_facets,
+                    tribunal_facets,
+                ) = process_court_facets(search_response.facets, courts_and_tribunals)
+                unprocessed_facets, year_facets = process_year_facets(unprocessed_facets)
 
-            changed_queries = {
-                key: value
-                for key, value in params.items()
-                if value is not None and not key == "page"
-            }
-            requires_warning, warning = _do_dates_require_warnings(
-                from_date, int(search_response.total)
-            )
+            changed_queries = {key: value for key, value in params.items() if value is not None and not key == "page"}
+            requires_warning, warning = _do_dates_require_warnings(from_date, int(search_response.total))
             # Populate context to provide feedback about filters etc. back to user
             context = context | {
                 "query": query_text,
@@ -193,9 +179,7 @@ def advanced_search(request):
                 "page": page,
                 "filtered": has_filters(params),
                 "page_title": _("results.search.title"),
-                "show_no_exact_ncn_warning": show_no_exact_ncn_warning(
-                    search_response.results, query_text, page
-                ),
+                "show_no_exact_ncn_warning": show_no_exact_ncn_warning(search_response.results, query_text, page),
                 "query_params": query_params,
             }
 

--- a/judgments/views/browse.py
+++ b/judgments/views/browse.py
@@ -27,13 +27,9 @@ class BrowseView(TemplateView):
 
         # All non-None values of court and subdivision should be truthy
         court_query = "/".join(filter(None, [court, subdivision]))
-        page = clamp(
-            sanitise_input_to_integer(self.request.GET.get("page"), 1), minimum=1
-        )
+        page = clamp(sanitise_input_to_integer(self.request.GET.get("page"), 1), minimum=1)
         per_page = clamp(
-            sanitise_input_to_integer(
-                self.request.GET.get("per_page"), RESULTS_PER_PAGE
-            ),
+            sanitise_input_to_integer(self.request.GET.get("per_page"), RESULTS_PER_PAGE),
             minimum=1,
             maximum=MAX_RESULTS_PER_PAGE,
         )
@@ -41,23 +37,13 @@ class BrowseView(TemplateView):
         try:
             search_parameters = SearchParameters(
                 court=court_query if court_query else None,
-                date_from=(
-                    datetime.date(year=year, month=1, day=1).strftime("%Y-%m-%d")
-                    if year
-                    else None
-                ),
-                date_to=(
-                    datetime.date(year=year, month=12, day=31).strftime("%Y-%m-%d")
-                    if year
-                    else None
-                ),
+                date_from=(datetime.date(year=year, month=1, day=1).strftime("%Y-%m-%d") if year else None),
+                date_to=(datetime.date(year=year, month=12, day=31).strftime("%Y-%m-%d") if year else None),
                 order="-date",
                 page=page,
                 page_size=per_page,
             )
-            search_response = search_judgments_and_parse_response(
-                api_client, search_parameters
-            )
+            search_response = search_judgments_and_parse_response(api_client, search_parameters)
 
             context["search_results"] = search_response.results
             context["total"] = search_response.total

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -82,9 +82,7 @@ def get_best_pdf(request, document_uri):
         return HttpResponse(response.content, content_type="application/pdf")
 
     if response.status_code != 404:
-        logging.warn(
-            f"Unexpected {response.status_code} error on {document_uri} whilst trying to get_best_pdf"
-        )
+        logging.warn(f"Unexpected {response.status_code} error on {document_uri} whilst trying to get_best_pdf")
     # fall back to weasy_pdf
 
     return redirect(
@@ -115,9 +113,7 @@ def detail(request, document_uri):
         context["query"] = query
 
     try:
-        context["linked_document_uri"] = get_published_document_by_uri(
-            linked_doc_url(document)
-        ).uri
+        context["linked_document_uri"] = get_published_document_by_uri(linked_doc_url(document)).uri
     except Http404:
         context["linked_document_uri"] = ""
 
@@ -127,9 +123,7 @@ def detail(request, document_uri):
     )  # "" is most recent version
     context["document_uri"] = document.uri
     context["page_title"] = document.name
-    context["pdf_size"] = (
-        f" ({filesizeformat(pdf.size)})" if pdf.size else " (unknown size)"
-    )
+    context["pdf_size"] = f" ({filesizeformat(pdf.size)})" if pdf.size else " (unknown size)"
     context["pdf_uri"] = pdf.uri
 
     if document.document_noun == "press summary":
@@ -148,14 +142,10 @@ def detail(request, document_uri):
         ]
 
     context["breadcrumbs"] = breadcrumbs
-    context["feedback_survey_type"] = (
-        "judgment"  # TODO: update the survey to allow for generalisation to `document`
-    )
+    context["feedback_survey_type"] = "judgment"  # TODO: update the survey to allow for generalisation to `document`
     # https://trello.com/c/l0iBFM1e/1151-update-survey-to-account-for-judgment-the-fact-that-we-have-press-summaries-as-well-as-judgments-now
     context["feedback_survey_document_uri"] = document.uri
-    context["search_context"] = search_context_from_url(
-        request.META.get("HTTP_REFERER")
-    )
+    context["search_context"] = search_context_from_url(request.META.get("HTTP_REFERER"))
 
     return TemplateResponse(request, "judgment/detail.html", context=context)
 

--- a/judgments/views/index.py
+++ b/judgments/views/index.py
@@ -18,16 +18,12 @@ class IndexView(TemplateView):
         context = super().get_context_data(**kwargs)
 
         try:
-            search_response = search_judgments_and_parse_response(
-                api_client, SearchParameters(order="-date")
-            )
+            search_response = search_judgments_and_parse_response(api_client, SearchParameters(order="-date"))
             search_results = search_response.results
             context["recent_judgments"] = search_results
 
         except MarklogicResourceNotFoundError:
-            raise Http404(
-                "Search results not found"
-            )  # TODO: This should be something else!
+            raise Http404("Search results not found")  # TODO: This should be something else!
 
         context["courts"] = all_courts.get_listable_courts()
         context["tribunals"] = all_courts.get_listable_tribunals()

--- a/merge_production_dotenvs_in_dotenv.py
+++ b/merge_production_dotenvs_in_dotenv.py
@@ -13,9 +13,7 @@ PRODUCTION_DOTENV_FILE_PATHS = [
 DOTENV_FILE_PATH = ROOT_DIR_PATH / ".env"
 
 
-def merge(
-    output_file_path: str, merged_file_paths: Sequence[str], append_linesep: bool = True
-) -> None:
+def merge(output_file_path: str, merged_file_paths: Sequence[str], append_linesep: bool = True) -> None:
     with open(output_file_path, "w") as output_file:
         for merged_file_path in merged_file_paths:
             with open(merged_file_path, "r") as merged_file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ ignore="H021,H023,H030,H031"
 profile="django"
 indent=2
 custom_blocks="flag"
+
+[tool.ruff]
+line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,22 +1,3 @@
-[flake8]
-max-line-length = 120
-exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
-
-[pycodestyle]
-max-line-length = 120
-exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules,venv
-
-[isort]
-line_length = 88
-known_first_party = ds_judgements_public_ui,config
-multi_line_output = 3
-default_section = THIRDPARTY
-skip = venv/
-skip_glob = **/migrations/*.py
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-
 [mypy]
 python_version = 3.9
 check_untyped_defs = True

--- a/transactional_licence_form/fields.py
+++ b/transactional_licence_form/fields.py
@@ -35,9 +35,7 @@ class FCLCheckboxWidgetWithOthers(forms.MultiWidget):
         super(FCLCheckboxWidgetWithOthers, self).__init__(widgets, attrs)
 
     def get_context(self, name, value, attrs):
-        context = super(FCLCheckboxWidgetWithOthers, self).get_context(
-            name, value, attrs
-        )
+        context = super(FCLCheckboxWidgetWithOthers, self).get_context(name, value, attrs)
         context["field"] = self.choices_field
         context["other_fields"] = self.other_fields
         context["other_field_subwidgets"] = {}
@@ -78,22 +76,16 @@ class FCLMultipleChoiceFieldWithOthers(FCLFieldMixin, forms.MultiValueField):
     def __init__(self, **kwargs):
         choices = kwargs.pop("choices")
         self.other_fields = {}
-        for field_index, (opt_index, name) in enumerate(
-            kwargs.pop("other_fields", {}).items()
-        ):
+        for field_index, (opt_index, name) in enumerate(kwargs.pop("other_fields", {}).items()):
             self.other_fields[opt_index] = {
                 "name": name,
                 "field": FCLCharField(max_length=50, required=False),
                 "field_index": field_index,
             }
-        self.choices_field = FCLMultipleChoiceField(
-            choices=choices, required=True, label=False
-        )
+        self.choices_field = FCLMultipleChoiceField(choices=choices, required=True, label=False)
         self.widget = FCLCheckboxWidgetWithOthers(self.choices_field, self.other_fields)
         fields = [self.choices_field] + [d["field"] for d in self.other_fields.values()]
-        super(FCLMultipleChoiceFieldWithOthers, self).__init__(
-            fields, **kwargs, require_all_fields=False
-        )
+        super(FCLMultipleChoiceFieldWithOthers, self).__init__(fields, **kwargs, require_all_fields=False)
 
     def compress(self, values=[[]]):
         if len(values) == 0:

--- a/transactional_licence_form/forms.py
+++ b/transactional_licence_form/forms.py
@@ -7,7 +7,6 @@ from .utils import countries_and_territories_choices, list_to_choices
 
 
 class FCLForm(forms.Form):
-
     display_in_review = True
 
     def __init__(self, *args, **kwargs):
@@ -55,7 +54,6 @@ class ContactForm(FCLForm):
 
 
 class OrganizationForm(FCLForm):
-
     def __init__(self, *args, **kwargs):
         super(OrganizationForm, self).__init__(*args, **kwargs)
         self.initial["agent_country"] = "country:GB"
@@ -133,7 +131,6 @@ class ProjectPurposeForm(FCLForm):
 
 
 class PublicStatementForm(FCLForm):
-
     title = "Step 5 - Public Statement"
 
     def layout(self):
@@ -147,7 +144,6 @@ class PublicStatementForm(FCLForm):
 
 
 class WorkingPractices1Form(FCLForm):
-
     title = "Step 6 - Working Practices"
 
     focus_on_specific = fields.FCLChoiceField(
@@ -174,7 +170,6 @@ class WorkingPractices1Form(FCLForm):
 
 
 class WorkingPractices2Form(FCLForm):
-
     title = "Step 7 - Working Practices"
 
     entire_record_available = fields.FCLChoiceField(

--- a/transactional_licence_form/templatetags/transactional_licence_utils.py
+++ b/transactional_licence_form/templatetags/transactional_licence_utils.py
@@ -56,12 +56,6 @@ def format_value_for_review(value, key):
     elif isinstance(value, list):
         return ", ".join(value)
     elif isinstance(value, dict):
-        return ", ".join(
-            [
-                format_value_for_review(value2, key)
-                for value2 in value.values()
-                if len(value2) > 0
-            ]
-        )
+        return ", ".join([format_value_for_review(value2, key) for value2 in value.values() if len(value2) > 0])
     else:
         return f"{value}"

--- a/transactional_licence_form/tests/test_tlf_utils.py
+++ b/transactional_licence_form/tests/test_tlf_utils.py
@@ -39,14 +39,10 @@ class TestTLFUtils(unittest.TestCase):
         # Assert that the form data is sanitized
         mock_sanitize.assert_called_with(form_data)
         # Assert that the email sender is instantiated correctly.
-        mock_email_sender.assert_called_with(
-            utils.EmailSender, ses_server, ses_port, ses_username, ses_password
-        )
+        mock_email_sender.assert_called_with(utils.EmailSender, ses_server, ses_port, ses_username, ses_password)
         # Assert that the email is sent.
         mock_email_sender.__enter__.assert_called()
-        mock_email_sender.send_mail.assert_called_with(
-            from_email, delivery_email, email_subject, sanitized_text
-        )
+        mock_email_sender.send_mail.assert_called_with(from_email, delivery_email, email_subject, sanitized_text)
         # Assert that the sender is torn down correctly
         mock_email_sender.__exit__.assert_called()
 

--- a/transactional_licence_form/utils.py
+++ b/transactional_licence_form/utils.py
@@ -10,9 +10,7 @@ from django.utils.safestring import mark_safe
 
 DISALLOWED_CHARACTERS = {"<": "&lt;", ">": "&gt;"}
 
-COUNTRIES_AND_TERRITORIES_JSON_PATH = (
-    "ds_judgements_public_ui/static/js/location-autocomplete-canonical-list.json"
-)
+COUNTRIES_AND_TERRITORIES_JSON_PATH = "ds_judgements_public_ui/static/js/location-autocomplete-canonical-list.json"
 
 EMAIL_TEMPLATE_PATH = "dynamics_email_template.txt"
 

--- a/transactional_licence_form/views.py
+++ b/transactional_licence_form/views.py
@@ -21,7 +21,6 @@ REVIEWING_SESSION_KEY = "transactional_licence_form_reviewing"
 
 
 class FormWizardView(NamedUrlSessionWizardView):
-
     def get_template_names(self):
         return [TEMPLATE_OVERRIDES.get(self.steps.current, "form.html")]
 
@@ -36,15 +35,10 @@ class FormWizardView(NamedUrlSessionWizardView):
     def post(self, *args, **kwargs):
         management_form = ManagementForm(self.request.POST, prefix=self.prefix)
         if not management_form.is_valid():
-            raise SuspiciousOperation(
-                "ManagementForm data is missing or has been tampered."
-            )
+            raise SuspiciousOperation("ManagementForm data is missing or has been tampered.")
 
         form_current_step = management_form.cleaned_data["current_step"]
-        if (
-            form_current_step != self.steps.current
-            and self.storage.current_step is not None
-        ):
+        if form_current_step != self.steps.current and self.storage.current_step is not None:
             self.storage.current_step = form_current_step
 
         form = self.get_form(data=self.request.POST, files=self.request.FILES)
@@ -75,8 +69,7 @@ class FormWizardView(NamedUrlSessionWizardView):
 
     def in_review(self):
         has_review_parameter = bool(
-            self.request.session.get(REVIEWING_SESSION_KEY, False)
-            or self.request.POST.get("reviewing", False)
+            self.request.session.get(REVIEWING_SESSION_KEY, False) or self.request.POST.get("reviewing", False)
         )
         return has_review_parameter and self.steps.current != "review"
 
@@ -93,9 +86,7 @@ class FormWizardView(NamedUrlSessionWizardView):
             cleaned_data[form_key] = {}
             form_obj = self.get_form_object(form_key)
             if form_obj.is_valid() and isinstance(form_obj.cleaned_data, (tuple, list)):
-                cleaned_data[form_key].update(
-                    {"formset-%s" % form_key: form_obj.cleaned_data}
-                )
+                cleaned_data[form_key].update({"formset-%s" % form_key: form_obj.cleaned_data})
             elif form_obj.is_valid():
                 cleaned_data[form_key].update(form_obj.cleaned_data)
         return cleaned_data


### PR DESCRIPTION
A series of commits which together make all of FCL's repositories behave more consistently with regard to tooling.

## Jira

FCL-176

## What?

- [x] `.pre-commit-config.yaml` does not exclude directories which don't exist, doesn't set default hooks where they aren't needed, and doesn't specify auto-update behaviour
- [x] The `pre-commit-hooks` repo includes the new, broader set of recommended checks
- [x] Python formatting is done using [ruff](https://docs.astral.sh/ruff/)
- [x] `detect-secrets` is removed (deprecated in favour of GitHub's more comprehensive approach)
- [x] prettier config has been harmonised