### PR TITLE
[FCL-195] Skip pre-commit branch check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: no-commit-to-branch
 
   # With no caching at all the entire ci process takes 4m 30s to complete!
   pytest:


### PR DESCRIPTION
The recent changes to pre-commit introduce checks which make sure users aren’t committing to main. Unfortunately when we run pre-commit in CI on main it complains.

Disable this check in the CI workflow, so it remains in place for local runs but is ignored for CI.

## Jira

FCL-195