### PR TITLE
FCL-147 | Extract breadcrumbs out of base.html

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -12,6 +12,10 @@ from .converters import SchemaFileConverter
 
 register_converter(SchemaFileConverter, "schemafile")
 
+handler404 = views.NotFoundView.as_view()
+handler500 = views.ServerErrorView.as_view()
+handler403 = views.PermissionDeniedView.as_view()
+
 urlpatterns = [
     # Django Admin, use {% url 'admin:index' %}
     path(settings.ADMIN_URL, admin.site.urls),

--- a/config/urls.py
+++ b/config/urls.py
@@ -115,15 +115,15 @@ if settings.DEBUG:
         ),
         path(
             "403/",
-            default_views.permission_denied,
+            views.PermissionDeniedView.as_view(),
             kwargs={"exception": Exception("Permission Denied")},
         ),
         path(
             "404/",
-            default_views.page_not_found,
+            views.NotFoundView.as_view(),
             kwargs={"exception": Exception("Page not Found")},
         ),
-        path("500/", default_views.server_error),
+        path("500/", views.ServerErrorView.as_view()),
     ]
     if "debug_toolbar" in settings.INSTALLED_APPS:
         import debug_toolbar

--- a/config/views.py
+++ b/config/views.py
@@ -6,6 +6,8 @@ from caselawclient.search_parameters import RESULTS_PER_PAGE, SearchParameters
 from django.http import Http404, HttpResponse
 from django.utils.translation import gettext
 from django.views.generic import TemplateView
+from django.views import defaults as default_views
+from django.shortcuts import render
 from ds_caselaw_utils import courts
 
 from judgments.forms import AdvancedSearchForm
@@ -210,6 +212,72 @@ class PrivacyNotice(TemplateViewWithContext):
         context = super().get_context_data(**kwargs)
         context["feedback_survey_type"] = "privacy_notice"
         return context
+
+
+class BaseErrorView(TemplateView):
+    template_name = None
+
+    def get_context_data(self, **kwargs):
+        request = self.request
+        exception = kwargs.get("exception")
+
+        response = self.get_response(request, exception)
+
+        context = response.context_data if hasattr(response, "context_data") else {}
+        context["breadcrumbs"] = self.get_breadcrumbs()
+
+        return context
+
+    def get_breadcrumbs(self):
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def dispatch(self, request, *args, **kwargs):
+        exception = kwargs.get("exception")
+        return render(
+            request, self.template_name, self.get_context_data(exception=exception), status=self.get_error_status()
+        )
+
+    def get_error_status(self):
+        raise NotImplementedError("Subclasses must implement this method")
+
+
+class NotFoundView(BaseErrorView):
+    template_name = "404.html"
+
+    def get_response(self, request, exception):
+        return default_views.page_not_found(request, exception, self.template_name)
+
+    def get_breadcrumbs(self):
+        return [{"text": "Page not found"}]
+
+    def get_error_status(self):
+        return 404
+
+
+class ServerErrorView(BaseErrorView):
+    template_name = "500.html"
+
+    def get_response(self, request, exception):
+        return default_views.server_error(request, self.template_name)
+
+    def get_breadcrumbs(self):
+        return [{"text": "Server Error"}]
+
+    def get_error_status(self):
+        return 500
+
+
+class PermissionDeniedView(BaseErrorView):
+    template_name = "403.html"
+
+    def get_response(self, request, exception):
+        return default_views.permission_denied(request, exception, self.template_name)
+
+    def get_breadcrumbs(self):
+        return [{"text": "Forbidden"}]
+
+    def get_error_status(self):
+        return 403
 
 
 def schema(request, schemafile: str):

--- a/ds_judgements_public_ui/templates/403.html
+++ b/ds_judgements_public_ui/templates/403.html
@@ -2,9 +2,6 @@
 {% block title %}
   Forbidden - Find Case Law
 {% endblock title %}
-{% block breadcrumbs %}
-  <li>Forbidden</li>
-{% endblock breadcrumbs %}
 {% block content %}
   <div class="standard-text-template container py-3">
     <h1>Forbidden</h1>

--- a/ds_judgements_public_ui/templates/404.html
+++ b/ds_judgements_public_ui/templates/404.html
@@ -2,9 +2,6 @@
 {% block title %}
   Page not found - Find case law
 {% endblock title %}
-{% block breadcrumbs %}
-  <li>Page not found</li>
-{% endblock breadcrumbs %}
 {% block content %}
   <div class="standard-text-template container py-3">
     <h1>Page not found</h1>

--- a/ds_judgements_public_ui/templates/500.html
+++ b/ds_judgements_public_ui/templates/500.html
@@ -2,9 +2,6 @@
 {% block title %}
   Server Error - Find Case Law
 {% endblock title %}
-{% block breadcrumbs %}
-  <li>Server Error</li>
-{% endblock breadcrumbs %}
 {% block content %}
   <div class="standard-text-template container py-3">
     <h1>Server Error</h1>

--- a/ds_judgements_public_ui/templates/includes/breadcrumbs.html
+++ b/ds_judgements_public_ui/templates/includes/breadcrumbs.html
@@ -1,0 +1,22 @@
+{% load waffle_tags %}
+
+<div class="page-header__breadcrumb">
+  <nav class="page-header__breadcrumb-flex-container"
+       aria-label="Breadcrumb">
+    <ol>
+      <li>
+        <span class="page-header__breadcrumb-you-are-in">You are in:</span>
+        <a href="{% url 'home' %}">Find case law</a>
+      </li>
+      {% for breadcrumb in breadcrumbs %}
+        {% if breadcrumb.url %}
+          <li>
+            <a href="{{ breadcrumb.url }}">{{ breadcrumb.text }}</a>
+          </li>
+        {% else %}
+          <li>{{ breadcrumb.text }}</li>
+        {% endif %}
+      {% endfor %}
+    </ol>
+  </nav>
+</div>

--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -84,28 +84,8 @@
                 <div class="page-header__site-logo">
                   <a href="{% url "home" %}" id="home-link">{% translate "home" %}</a>
                 </div>
-                <div class="page-header__breadcrumb">
-                  <nav class="page-header__breadcrumb-flex-container"
-                       aria-label="Breadcrumb">
-                    <ol>
-                      <li>
-                        <span class="page-header__breadcrumb-you-are-in">You are in:</span>
-                        <a href="{% url 'home' %}">Find case law</a>
-                      </li>
-                      {% block breadcrumbs_v2 %}
-                        {% for breadcrumb in breadcrumbs %}
-                          {% if breadcrumb.url %}
-                            <li>
-                              <a href="{{ breadcrumb.url }}">{{ breadcrumb.text }}</a>
-                            </li>
-                          {% else %}
-                            <li>{{ breadcrumb.text }}</li>
-                          {% endif %}
-                        {% endfor %}
-                      {% endblock breadcrumbs_v2 %}
-                    </ol>
-                  </nav>
-                </div>
+
+                {% include "includes/breadcrumbs.html" %}
               </div>
               {% include "includes/logo.html" %}
             </div>
@@ -120,28 +100,8 @@
               <div class="page-header__site-logo">
                 <a href="{% url "home" %}" id="home-link">{% translate "home" %}</a>
               </div>
-              <div class="page-header__breadcrumb">
-                <nav class="page-header__breadcrumb-flex-container"
-                     aria-label="Breadcrumb">
-                  <ol>
-                    <li>
-                      <span class="page-header__breadcrumb-you-are-in">You are in:</span>
-                      <a href="{% url 'home' %}">Find case law</a>
-                    </li>
-                    {% block breadcrumbs %}
-                      {% for breadcrumb in breadcrumbs %}
-                        {% if breadcrumb.url %}
-                          <li>
-                            <a href="{{ breadcrumb.url }}">{{ breadcrumb.text }}</a>
-                          </li>
-                        {% else %}
-                          <li>{{ breadcrumb.text }}</li>
-                        {% endif %}
-                      {% endfor %}
-                    {% endblock breadcrumbs %}
-                  </ol>
-                </nav>
-              </div>
+
+              {% include "includes/breadcrumbs.html" %}
             </div>
             {% include "includes/logo.html" %}
           </div>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

 - Extracts breadcrumbs out of base.html into it's own include
 - Removes the need for blocks (they don't work with includes in django) within templates that extend the base.html

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-147
