### PR TITLE
FCL-147 | Improve HTML assertion helper

### DIFF
--- a/judgments/tests/test_assertions.py
+++ b/judgments/tests/test_assertions.py
@@ -1,0 +1,54 @@
+import pytest
+from django.test import TestCase
+from judgments.tests.utils.assertions import assert_contains_html, assert_not_contains_html
+
+
+class MockResponse:
+    def __init__(self, content):
+        self.content = content.encode()
+
+
+class TestAssertions(TestCase):
+    contained_html = "<title>Judgment A - Find case law - The National Archives</title>"
+    response_contains = MockResponse("<html>" + contained_html + "</html>")
+    response_not_contains = MockResponse("<html>Something else</html>")
+
+    def test_assert_contains_html(self):
+        try:
+            assert_contains_html(self.response_contains, self.contained_html)
+        except AssertionError:
+            pytest.fail("assert_contains_html raised an AssertionError")
+
+    def test_assert_not_contains_html(self):
+        try:
+            assert_not_contains_html(self.response_not_contains, self.contained_html)
+        except AssertionError:
+            pytest.fail("assert_not_contains_html raised an AssertionError")
+
+    def test_assert_contains_html_fails(self):
+        with pytest.raises(AssertionError):
+            assert_contains_html(self.response_not_contains, self.contained_html)
+
+    def test_assert_not_contains_html_fails(self):
+        with pytest.raises(AssertionError):
+            assert_not_contains_html(self.response_contains, self.contained_html)
+
+    def test_assert_contains_nested_html(self):
+        contained_html = "<li><span>Item 2</span></li>"
+        response = MockResponse(
+            "<html><ul><li><span>Item 1</span></li>" + contained_html + "<li><span>Item 3</span></li></html>"
+        )
+
+        try:
+            assert_contains_html(response, contained_html)
+        except AssertionError:
+            pytest.fail("assert_contains_html raised AssertionError with nested HTML")
+
+    def test_assert_not_contains_nested_html(self):
+        contained_html = "<li><span>Item 2</span></li>"
+        response = MockResponse("<html><ul><li><span>Item 1</span></li><li><span>Item 3</span></li></html>")
+
+        try:
+            assert_not_contains_html(response, contained_html)
+        except AssertionError:
+            pytest.fail("assert_contains_html raised AssertionError with nested HTML")

--- a/judgments/tests/test_assertions.py
+++ b/judgments/tests/test_assertions.py
@@ -1,6 +1,11 @@
 import pytest
 from django.test import TestCase
-from judgments.tests.utils.assertions import assert_contains_html, assert_not_contains_html
+from judgments.tests.utils.assertions import (
+    assert_contains_html,
+    assert_not_contains_html,
+    assert_response_contains_text,
+    assert_response_not_contains_text,
+)
 
 
 class MockResponse:
@@ -17,7 +22,7 @@ class TestAssertions(TestCase):
         try:
             assert_contains_html(self.response_contains, self.contained_html)
         except AssertionError:
-            pytest.fail("assert_contains_html raised an AssertionError")
+            pytest.fail("assert_contains_html raised an AssertionError - html not contained within response")
 
     def test_assert_not_contains_html(self):
         try:
@@ -52,3 +57,25 @@ class TestAssertions(TestCase):
             assert_not_contains_html(response, contained_html)
         except AssertionError:
             pytest.fail("assert_contains_html raised AssertionError with nested HTML")
+
+    def test_assert_response_contains_text(self):
+        contained_text = "Server Error"
+        xpath_query = "//div[@class='breadcrumbs']"
+
+        response = MockResponse("<html><div class='breadcrumbs'><ul><li>Server Error</li></ul></div></html>")
+
+        try:
+            assert_response_contains_text(response, contained_text, xpath_query)
+        except AssertionError:
+            pytest.fail("assert_response_contains_text raised AssertionError")
+
+    def test_assert_response_not_contains_text(self):
+        contained_text = "Not there"
+        xpath_query = "//div[@class='breadcrumbs']"
+
+        response = MockResponse("<html><div class='breadcrumbs'><ul><li>Server Error</li></ul></div></html>")
+
+        try:
+            assert_response_not_contains_text(response, contained_text, xpath_query)
+        except AssertionError:
+            pytest.fail("assert_response_not_contains_text raised AssertionError")

--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -10,7 +10,11 @@ from judgments.tests.fixtures import (
     FakeSearchResponseNoFacets,
     FakeSearchResponseNoResults,
 )
-from judgments.tests.utils.assertions import assert_contains_html
+from judgments.tests.utils.assertions import (
+    assert_contains_html,
+    assert_response_contains_text,
+    assert_response_not_contains_text,
+)
 
 
 class TestBrowseResults(TestCase):
@@ -132,23 +136,18 @@ class TestSearchResults(TestCase):
         THEN the response should contain the expected warning
 
         The expected applied filters HTML:
-        - Includes a div with class `govuk-warning-text`
+        - Includes a div with class `govuk-warning-text` and correct warning text
         """
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
-        expected_html = """
-        <div class="govuk-warning-text">
-            <span class="govuk-warning-text__icon" aria-hidden="true">i</span>
-            <div class="govuk-warning-text__text">
-                1444 is before 2003, the date of the oldest record on the Find Case Law service.
-                Showing results from 2003.
-                <a href="/about-this-service#section-coverage">Read more</a>
-            </div>
-        </div>
-    """
 
         response = self.client.get("/judgments/search?from_date_0=1&from_date_1=1&from_date_2=1444")
 
-        assert_contains_html(response, expected_html)
+        expected_text = """
+                1444 is before 2003, the date of the oldest record on the Find Case Law service.
+                Showing results from 2003.
+        """
+        xpath_query = "//div[@class='govuk-warning-text__text']"
+        assert_response_contains_text(response, expected_text, xpath_query)
 
     @patch("judgments.views.advanced_search.api_client")
     @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
@@ -165,20 +164,15 @@ class TestSearchResults(TestCase):
         - Includes a div with class `advice-message`
         """
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
-        expected_html = """
-        <div class="govuk-warning-text">
-            <span class="govuk-warning-text__icon" aria-hidden="true">i</span>
-            <div class="govuk-warning-text__text">
-                2011 is before 2003, the date of the oldest record on the Find Case Law service.
-                Showing results from 2003.
-                <a href="/about-this-service#section-coverage">Read more</a>
-            </div>
-        </div>
-"""
 
         response = self.client.get("/judgments/search?from_date_0=1&from_date_1=1&from_date_2=2011")
 
-        self.assertNotContains(response, expected_html)
+        expected_text = """
+                2011 is before 2003, the date of the oldest record on the Find Case Law service.
+                Showing results from 2003.
+        """
+        xpath_query = "//div[@class='govuk-warning-text__text']"
+        assert_response_not_contains_text(response, expected_text, xpath_query)
 
     @patch("judgments.views.advanced_search.api_client")
     @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
@@ -196,20 +190,15 @@ class TestSearchResults(TestCase):
         - Includes a div with class `advice-message`
         """
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponseNoResults()
-        expected_html = """
-        <div class="govuk-warning-text">
-            <span class="govuk-warning-text__icon" aria-hidden="true">i</span>
-            <div class="govuk-warning-text__text">
-                1444 is before 2003, the date of the oldest record on the Find Case Law service.
-                Showing results from 2003.
-                <a href="/about-this-service#section-coverage">Read more</a>
-            </div>
-        </div>
-"""
 
         response = self.client.get("/judgments/search?from_date_0=1&from_date_1=1&from_date_2=1444")
 
-        self.assertNotContains(response, expected_html)
+        expected_text = """
+                1444 is before 2003, the date of the oldest record on the Find Case Law service.
+                Showing results from 2003.
+        """
+        xpath_query = "//div[@class='govuk-warning-text__text']"
+        assert_response_not_contains_text(response, expected_text, xpath_query)
 
     @patch("judgments.views.advanced_search.api_client")
     @patch("judgments.views.advanced_search.search_judgments_and_parse_response")

--- a/judgments/tests/utils/assertions.py
+++ b/judgments/tests/utils/assertions.py
@@ -9,7 +9,7 @@ def parse_html(html_string):
     return html.fromstring(html_string)
 
 
-def parse_html_fragment(html_string):
+def parse_html_fragment_as_fragments(html_string):
     return html.fragments_fromstring(html_string)
 
 
@@ -44,7 +44,7 @@ def is_contained(container_tree, contained_tree):
 
 def response_contains_html(response, contained_html):
     container_tree = parse_html(response.content.decode())
-    contained_tree = parse_html_fragment(contained_html)
+    contained_tree = parse_html_fragment_as_fragments(contained_html)
     return is_contained(container_tree, contained_tree)
 
 

--- a/judgments/tests/utils/assertions.py
+++ b/judgments/tests/utils/assertions.py
@@ -2,22 +2,55 @@
 Custom assertion helpers for tests.
 """
 
-
-def assert_contains_html(response, html):
-    """
-    Asserts that the given HTML is contained within the response content.
-
-    Raises:
-        AssertionError: If the HTML is not found in the response content.
-    """
-    assert html.replace(" ", "").replace("\n", "") in response.content.decode().replace(" ", "").replace("\n", "")
+from lxml import html
 
 
-def assert_not_contains_html(response, html):
-    """
-    Asserts that the given HTML is not contained within the response content.
+def parse_html(html_string):
+    return html.fromstring(html_string)
 
-    Raises:
-        AssertionError: If the HTML is found in the response content.
-    """
-    assert html.replace(" ", "").replace("\n", "") not in response.content.decode().replace(" ", "").replace("\n", "")
+
+def parse_html_fragment(html_string):
+    return html.fragments_fromstring(html_string)
+
+
+def normalise_text(text):
+    return " ".join(text.split())
+
+
+def elements_match(element_1, element_2):
+    if element_1.tag != element_2.tag:
+        return False
+
+    if (normalise_text(element_1.text or "")) != normalise_text(element_2.text or ""):
+        return False
+
+    if element_1.attrib != element_2.attrib:
+        return False
+
+    children_1 = list(element_1)
+    children_2 = list(element_2)
+
+    if len(children_1) != len(children_2):
+        return False
+
+    return all(elements_match(c1, c2) for c1, c2 in zip(children_1, children_2))
+
+
+def is_contained(container_tree, contained_tree):
+    return all(
+        any(elements_match(element, fragment) for element in container_tree.iter()) for fragment in contained_tree
+    )
+
+
+def response_contains_html(response, contained_html):
+    container_tree = parse_html(response.content.decode())
+    contained_tree = parse_html_fragment(contained_html)
+    return is_contained(container_tree, contained_tree)
+
+
+def assert_contains_html(response, contained_html):
+    assert response_contains_html(response, contained_html)
+
+
+def assert_not_contains_html(response, contained_html):
+    assert not response_contains_html(response, contained_html)

--- a/judgments/tests/utils/assertions.py
+++ b/judgments/tests/utils/assertions.py
@@ -42,6 +42,12 @@ def is_contained(container_tree, contained_tree):
     )
 
 
+def is_contained_by_xpath(container_tree, xpath_query, contained_text):
+    elements = container_tree.xpath(xpath_query)
+
+    return any(normalise_text(contained_text) in normalise_text(element.text_content()) for element in elements)
+
+
 def response_contains_html(response, contained_html):
     container_tree = parse_html(response.content.decode())
     contained_tree = parse_html_fragment_as_fragments(contained_html)
@@ -54,3 +60,15 @@ def assert_contains_html(response, contained_html):
 
 def assert_not_contains_html(response, contained_html):
     assert not response_contains_html(response, contained_html)
+
+
+def assert_response_contains_text(response, contained_text, xpath_query):
+    container_tree = parse_html(response.content.decode())
+
+    assert is_contained_by_xpath(container_tree, xpath_query, contained_text)
+
+
+def assert_response_not_contains_text(response, contained_text, xpath_query):
+    container_tree = parse_html(response.content.decode())
+
+    assert not is_contained_by_xpath(container_tree, xpath_query, contained_text)


### PR DESCRIPTION
## Changes in this PR:

Changes our html assertion checker for tests to use their actual nodes and check them rather than comparing strings with whitespace removed.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-215

## Screenshots of UI changes:
