### PR TITLE
fix(Search): Change copy of date warning

### DIFF
--- a/ds_judgements_public_ui/templates/judgment/results.html
+++ b/ds_judgements_public_ui/templates/judgment/results.html
@@ -16,7 +16,7 @@
         {% endif %}
         {% if requires_from_warning %}
           {% url "about_this_service" as url_value %}
-          {% include "includes/advice_message.html" with message=date_warning url_text="Read more" url_value=url_value url_anchor="section-coverage" %}
+          {% include "includes/advice_message.html" with message=date_warning url_text="Find out what records are available on this service." url_value=url_value url_anchor="section-coverage" %}
         {% endif %}
         {% if search_results %}
           <div class="results__result-controls-container">{% include "includes/result_controls.html" %}</div>

--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -144,7 +144,6 @@ class TestSearchResults(TestCase):
 
         expected_text = """
                 1444 is before 2003, the date of the oldest record on the Find Case Law service.
-                Showing results from 2003.
         """
         xpath_query = "//div[@class='govuk-warning-text__text']"
         assert_response_contains_text(response, expected_text, xpath_query)

--- a/judgments/views/advanced_search.py
+++ b/judgments/views/advanced_search.py
@@ -46,8 +46,7 @@ def _do_dates_require_warnings(from_date: date, total_results: int) -> tuple[boo
             from_warning = True
             warning = f"""
                     {from_date.year} is before {min_year},
-                    the date of the oldest record on the Find Case Law service.
-                    Showing results from {min_year}."""
+                    the date of the oldest record on the Find Case Law service."""
     return from_warning, warning
 
 


### PR DESCRIPTION
Remove "from 2001/3" message and change link text
https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136/backlog?selectedIssue=FCL-188

Would benefit from review of the link text

Before:
<img width="1176" alt="image" src="https://github.com/user-attachments/assets/bf8c4a50-440a-43e1-9d50-d6e549647906">

After:
<img width="1185" alt="image" src="https://github.com/user-attachments/assets/d81fb61f-cf9a-4160-a3ce-d4ebd5859cd3">

(the 2003 will be 2001 on production)

Hold for approval of copy from Rose.
