### PR TITLE
fix(Search): Fix 'no exact match' regression (so it appears)

### DIFF
--- a/judgments/tests/fixtures.py
+++ b/judgments/tests/fixtures.py
@@ -64,3 +64,4 @@ class FakeSearchResponseNoFacets(FakeSearchResponseBaseClass):
 
 class FakeSearchResponseNoResults(FakeSearchResponseBaseClass):
     total = 0
+    results = []

--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -38,6 +38,17 @@ class TestBrowseResults(TestCase):
         self.assertContains(response, "A SearchResult name!", html=True)
 
 
+class TestNoNCN(TestCase):
+    @patch("judgments.views.browse.api_client")
+    @patch("judgments.views.advanced_search.search_judgments_and_parse_response")
+    def test_browse_results(self, mock_search_judgments_and_parse_response, mock_api_client):
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponseNoResults()
+        response = self.client.get(r"/judgments/search?query=[2024]%20EAT%209999")
+        self.assertContains(
+            response, "There is no judgment with the Neutral Citation of [2024] EAT 9999 in our database.", html=True
+        )
+
+
 class TestSearchResults(TestCase):
     @patch("judgments.views.advanced_search.api_client")
     @patch("judgments.views.advanced_search.search_judgments_and_parse_response")

--- a/judgments/tests/test_utils.py
+++ b/judgments/tests/test_utils.py
@@ -96,7 +96,7 @@ class TestUtils(unittest.TestCase):
             return mock
 
         query_text = "[2014] EWHC 4122 (Fam)"
-        page = "1"
+        page = 1
         search_results = [mock_judgment(ncn) for ncn in ["[2013] EWSC 123", "[2022] EWHC 54321 (Fam)"]]
         result = show_no_exact_ncn_warning(search_results, query_text, page)
         self.assertTrue(result)
@@ -110,7 +110,7 @@ class TestUtils(unittest.TestCase):
             return mock
 
         query_text = "[2014] EWHC 4122 (Fam)"
-        page = "2"
+        page = 2
         search_results = [mock_judgment(ncn) for ncn in ["[2013] EWSC 123", "[2022] EWHC 54321 (Fam)"]]
         result = show_no_exact_ncn_warning(search_results, query_text, page)
         self.assertFalse(result)
@@ -124,7 +124,7 @@ class TestUtils(unittest.TestCase):
             return mock
 
         query_text = "[2014] EWHC 4122 (Fam)"
-        page = "1"
+        page = 1
         search_results = [mock_judgment(ncn) for ncn in ["[2013] EWSC 123", "[2014] EWHC 4122 (Fam)"]]
         result = show_no_exact_ncn_warning(search_results, query_text, page)
         self.assertFalse(result)
@@ -136,7 +136,7 @@ class TestUtils(unittest.TestCase):
             return mock
 
         query_text = "walrus"
-        page = "1"
+        page = 1
         search_results = [mock_judgment(ncn) for ncn in ["[2013] EWSC 123", "[2014] EWHC 4122 (Fam)"]]
         result = show_no_exact_ncn_warning(search_results, query_text, page)
         self.assertFalse(result)

--- a/judgments/utils/utils.py
+++ b/judgments/utils/utils.py
@@ -243,9 +243,7 @@ def search_results_have_exact_ncn(search_results, query):
     return False
 
 
-def show_no_exact_ncn_warning(search_results, query_text, page):
+def show_no_exact_ncn_warning(search_results, query_text: str, page: int):
     return (
-        not (search_results_have_exact_ncn(search_results, query_text))
-        and bool(neutral_url(query_text))
-        and page == "1"
+        not (search_results_have_exact_ncn(search_results, query_text)) and bool(neutral_url(query_text)) and page == 1
     )


### PR DESCRIPTION
Pages are no longer strings. Have searched for `page.*'/d` (and `"` variant) to try to catch all other occurances (mostly tests)

Not sure if it's the right behaviour that the no-no-no box still appears... probably.

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/0ad501d8-e790-4843-90d1-fd6206d7ea98">
