### PR TITLE
Ensure 'previous' button not display:none hidden

### DIFF
--- a/transactional_licence_form/templates/layouts/form_step.html
+++ b/transactional_licence_form/templates/layouts/form_step.html
@@ -42,8 +42,7 @@
                   type="button"
                   id="transactional-licence-form-previous-button"
                   class="button-secondary button-inline"
-                  value="{{ wizard.steps.prev }}"
-                  style="display:none">Previous</button>
+                  value="{{ wizard.steps.prev }}">Previous</button>
         {% endif %}
         <input type="submit"
                class="button-inline {% if reviewing %}button-secondary{% else %}button-cta{% endif %}"


### PR DESCRIPTION
Not sure why this happened.

`npm run build` fixed it... is the display:none being overriden with javascript or something?