### PR TITLE
Do not cache transactional licence

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -41,6 +41,7 @@ class CacheHeaderMiddleware:
         # the view (and later middleware) are called.
 
         response = self.get_response(request)
+
         patch_cache_control(response, max_age=15 * 60, public=True)
 
         # Code to be executed for each request/response after

--- a/config/tests.py
+++ b/config/tests.py
@@ -18,6 +18,11 @@ class TestCacheHeaders(TestCase):
         response = self.client.get(url)
         assert response.headers["Cache-Control"] == "max-age=900, public"
 
+    def test_no_cache_transactional_steps(self):
+        url = "/re-use-find-case-law-records/steps/organization"
+        response = self.client.get(url)
+        assert response.headers["Cache-Control"] == "max-age=0, no-cache, no-store, must-revalidate, public"
+
 
 class TestSchemas(TestCase):
     @patch("config.views.schema.requests.get")

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -53,7 +53,7 @@ class PdfDetailView(WeasyTemplateResponseMixin, TemplateView):
     pdf_stylesheets = [os.path.join(settings.STATIC_ROOT, "css", "judgmentpdf.css")]
     pdf_attachment = True
 
-    def get_context_data(self, document_uri, **kwargs):
+    def get_context_data(self, document_uri=None, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
 
         document = get_published_document_by_uri(document_uri)

--- a/transactional_licence_form/views.py
+++ b/transactional_licence_form/views.py
@@ -3,6 +3,8 @@ from django.shortcuts import redirect, render
 from django.views.generic import TemplateView
 from formtools.wizard.forms import ManagementForm
 from formtools.wizard.views import NamedUrlSessionWizardView
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
 
 from .forms import FORMS
 from .utils import send_form_response_to_dynamics
@@ -20,6 +22,7 @@ TEMPLATE_OVERRIDES = {
 REVIEWING_SESSION_KEY = "transactional_licence_form_reviewing"
 
 
+@method_decorator(never_cache, name="dispatch")
 class FormWizardView(NamedUrlSessionWizardView):
     def get_template_names(self):
         return [TEMPLATE_OVERRIDES.get(self.steps.current, "form.html")]


### PR DESCRIPTION
The difficulties we've been with the transactional licence not loading in the data might very well be caused by caching -- only happens remotely (no caching locally), is slightly erratic, **appears fixable by cache-busting query parameters**. Either way, it's not good to cache pages that might emit user data.