### PR TITLE
[FCL-255] Disable global cache behaviours

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -29,27 +29,6 @@ class RobotsTagMiddleware:
         return response
 
 
-class CacheHeaderMiddleware:
-    # via https://docs.djangoproject.com/en/4.1/topics/http/middleware/
-
-    def __init__(self, get_response):
-        self.get_response = get_response
-        # One-time configuration and initialization.
-
-    def __call__(self, request):
-        # Code to be executed for each request before
-        # the view (and later middleware) are called.
-
-        response = self.get_response(request)
-
-        patch_cache_control(response, max_age=15 * 60, public=True)
-
-        # Code to be executed for each request/response after
-        # the view is called.
-
-        return response
-
-
 class FeedbackLinkMiddleware:
     BASE_FEEDBACK_URL: str = "https://corexmsnp4n42lf2kht3.qualtrics.com/jfe/form/SV_0lyyYAzfv9bGcyW"
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -131,7 +131,6 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
-    "config.middleware.CacheHeaderMiddleware",
     "config.middleware.RobotsTagMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",

--- a/config/tests.py
+++ b/config/tests.py
@@ -8,20 +8,10 @@ from config.views.schema import schema
 
 
 class TestCacheHeaders(TestCase):
-    def test_static_headers(self):
-        url = "/static/images/tna_logo.svg"
-        response = self.client.get(url)
-        assert response.headers["Cache-Control"] == "max-age=900, public"
-
-    def test_view_headers(self):
-        url = "/about-this-service"
-        response = self.client.get(url)
-        assert response.headers["Cache-Control"] == "max-age=900, public"
-
     def test_no_cache_transactional_steps(self):
         url = "/re-use-find-case-law-records/steps/organization"
         response = self.client.get(url)
-        assert response.headers["Cache-Control"] == "max-age=0, no-cache, no-store, must-revalidate, public"
+        assert response.headers["Cache-Control"] == "max-age=0, no-cache, no-store, must-revalidate, private"
 
 
 class TestSchemas(TestCase):


### PR DESCRIPTION
This PR disables global caching behaviours to allow for serving different responses on a request-by-request basis. This is necessary for allowing A/B testing of the homepage and the header variations.

The intent is that this will be rolled out to identify if/where any actual improved caching is needed, with a rapid rollback in case of resource issues.

## Jira

FCL-255