### PR TITLE
FCL-228 | add document paragraph anchors links when they are on the page

### DIFF
--- a/ds_judgements_public_ui/static/js/src/app.js
+++ b/ds_judgements_public_ui/static/js/src/app.js
@@ -4,4 +4,5 @@ import "./modules/manage_aria_buttons";
 import "./modules/document_navigation_links";
 import "./modules/location_picker";
 import "./modules/transactional_licence_form";
+import "./modules/document_paragraph_anchors";
 initAll();

--- a/ds_judgements_public_ui/static/js/src/modules/document_paragraph_anchors.js
+++ b/ds_judgements_public_ui/static/js/src/modules/document_paragraph_anchors.js
@@ -1,0 +1,27 @@
+const setupDocumentParagraphAnchors = function () {
+    const sections = document.querySelectorAll(".judgment-body__section");
+
+    sections.forEach(function (section) {
+        if (!section.hasAttribute("id")) return;
+
+        const sectionId = section.id;
+
+        const numberElement = section.querySelector(".judgment-body__number");
+
+        if (!numberElement) return;
+
+        const numberContent = numberElement.textContent;
+
+        const anchorElement = document.createElement("a");
+        const anchorText = document.createTextNode(numberContent);
+
+        anchorElement.href = "#" + sectionId;
+
+        anchorElement.appendChild(anchorText);
+
+        numberElement.innerHTML = "";
+        numberElement.appendChild(anchorElement);
+    });
+};
+
+document.addEventListener("DOMContentLoaded", setupDocumentParagraphAnchors);


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Adds a script that sets all the paragraph sections that have paragraph numbers with IDs to have their number turned into a link that links to that section.

I'm not sure if there are some reports where this may cause issues? If anyone knows of any I can bake that into the script.

Are we happy with how the paragraph numbers look like links? We could style this as text but still have them as links so those who know are able to get the links easily.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-228

## Screenshots of UI changes:

Makes the paragraph numbers look like this:

<img width="786" alt="image" src="https://github.com/user-attachments/assets/564b3009-7960-427d-9d1b-4f016cdc6cff">