### PR TITLE
FCL-228 | add waffle tags to the window so we can toggle features on/…

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_document_paragraph_anchors.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_document_paragraph_anchors.scss
@@ -7,7 +7,8 @@
     }
 
     &:hover {
-      .judgment-body__copy-link {
+      .judgment-body__copy-link,
+      .judgment-body__copy-tooltip {
         opacity: 1;
       }
     }
@@ -29,18 +30,26 @@
     }
 
     &:hover {
-      .judgment-body__copy-link-tooltip {
+      .judgment-body__copy-link-helptext {
         opacity: 1;
       }
     }
   }
 
   &__copy-link-tooltip {
+    right: 30px;
+  }
+
+  &__copy-link-helptext {
+    right: 44px;
+  }
+
+  &__copy-link-tooltip,
+  &__copy-link-helptext {
     position: absolute;
     opacity: 0;
     font-size: 14px;
     top: -8px;
-    right: 44px;
     font-family: Roboto, sans-serif;
     white-space: nowrap;
     border: 1px solid $color-grey;

--- a/ds_judgements_public_ui/static/js/src/app.js
+++ b/ds_judgements_public_ui/static/js/src/app.js
@@ -4,5 +4,6 @@ import "./modules/manage_aria_buttons";
 import "./modules/document_navigation_links";
 import "./modules/location_picker";
 import "./modules/transactional_licence_form";
-import "./modules/document_paragraph_anchors";
+import "./modules/document_paragraph_tooltip_anchors";
+import "./modules/document_paragraph_icon_anchors";
 initAll();

--- a/ds_judgements_public_ui/static/js/src/modules/document_paragraph_icon_anchors.js
+++ b/ds_judgements_public_ui/static/js/src/modules/document_paragraph_icon_anchors.js
@@ -14,10 +14,10 @@ const createAnchorElement = function (id, content) {
     return element;
 };
 
-const createCopyTooltipElement = function () {
+const createCopyHelptextElement = function () {
     const element = document.createElement("span");
 
-    element.classList.add("judgment-body__copy-link-tooltip");
+    element.classList.add("judgment-body__copy-link-helptext");
     element.innerHTML = "Copy link to paragraph";
 
     return element;
@@ -25,20 +25,20 @@ const createCopyTooltipElement = function () {
 
 const createCopyElement = function (textToCopy) {
     const element = document.createElement("span");
-    const tooltip = createCopyTooltipElement();
+    const helptext = createCopyHelptextElement();
 
     element.classList.add("judgment-body__copy-link");
     element.innerHTML = linkSvg;
-    element.appendChild(tooltip);
+    element.appendChild(helptext);
 
     element.addEventListener("click", function (event) {
         event.preventDefault();
         event.stopPropagation();
         navigator.clipboard.writeText(textToCopy);
-        tooltip.innerHTML = "Copied!";
+        helptext.innerHTML = "Copied!";
 
         setTimeout(() => {
-            tooltip.innerHTML = "Copy link to paragraph";
+            helptext.innerHTML = "Copy link to paragraph";
         }, 3000);
     });
 
@@ -75,7 +75,13 @@ const addDocumentParagraphAnchorLinkToSection = function (section) {
     numberElement.appendChild(copyableAnchorElement);
 };
 
-const setupDocumentParagraphAnchors = function () {
+const setupDocumentParagraphIconAnchors = function () {
+    if (
+        !window.waffleFlags ||
+        !window.waffleFlags.document_paragraph_icon_anchors
+    )
+        return;
+
     const sections = document.querySelectorAll(".judgment-body__section");
 
     sections.forEach(function (section) {
@@ -83,4 +89,7 @@ const setupDocumentParagraphAnchors = function () {
     });
 };
 
-document.addEventListener("DOMContentLoaded", setupDocumentParagraphAnchors);
+document.addEventListener(
+    "DOMContentLoaded",
+    setupDocumentParagraphIconAnchors,
+);

--- a/ds_judgements_public_ui/static/js/src/modules/document_paragraph_tooltip_anchors.js
+++ b/ds_judgements_public_ui/static/js/src/modules/document_paragraph_tooltip_anchors.js
@@ -1,0 +1,80 @@
+const createAnchorElement = function (id, content) {
+    const element = document.createElement("a");
+    const text = document.createTextNode(content);
+
+    element.href = "#" + id;
+    element.classList.add("judgment-body__anchor-link");
+
+    element.appendChild(text);
+
+    return element;
+};
+
+const createCopyElement = function (textToCopy) {
+    const element = document.createElement("span");
+
+    element.classList.add("judgment-body__copy-link-tooltip");
+    element.innerHTML = "Copy link to this paragraph";
+
+    element.addEventListener("click", function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        navigator.clipboard.writeText(textToCopy);
+        element.innerHTML = "Copied!";
+
+        setTimeout(() => {
+            element.innerHTML = "Copy link to this paragraph";
+        }, 3000);
+    });
+
+    return element;
+};
+
+const createCopyableAnchorElement = function (id, content) {
+    const anchorElement = createAnchorElement(id, content);
+    const copyElement = createCopyElement(anchorElement.href);
+
+    anchorElement.append(copyElement);
+
+    return anchorElement;
+};
+
+const addDocumentParagraphAnchorLinkToSection = function (section) {
+    if (!section || !(section instanceof HTMLElement)) return;
+    if (!section.hasAttribute("id")) return;
+
+    const sectionId = section.id;
+
+    const numberElement = section.querySelector(".judgment-body__number");
+
+    if (!numberElement) return;
+
+    const numberContent = numberElement.textContent;
+    numberElement.innerHTML = "";
+
+    const copyableAnchorElement = createCopyableAnchorElement(
+        sectionId,
+        numberContent,
+    );
+
+    numberElement.appendChild(copyableAnchorElement);
+};
+
+const setupDocumentParagraphTooltipAnchors = function () {
+    if (
+        !window.waffleFlags ||
+        !window.waffleFlags.document_paragraph_tooltip_anchors
+    )
+        return;
+
+    const sections = document.querySelectorAll(".judgment-body__section");
+
+    sections.forEach(function (section) {
+        addDocumentParagraphAnchorLinkToSection(section);
+    });
+};
+
+document.addEventListener(
+    "DOMContentLoaded",
+    setupDocumentParagraphTooltipAnchors,
+);

--- a/ds_judgements_public_ui/templates/includes/waffle_flags_javascript.html
+++ b/ds_judgements_public_ui/templates/includes/waffle_flags_javascript.html
@@ -1,0 +1,7 @@
+<script id="waffle-flags" type="text/javascript">
+  window.waffleFlags = [
+    {% for flag, is_active in waffle_flags.items %}
+      {"{{ flag }}": {% if is_active %}true{% else %}false{% endif %}},
+    {% endfor %}
+  ]
+</script>

--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -155,9 +155,11 @@
     {% endblock feedback_cta %}
 
     {% include "includes/footer.html" %}
+
     {% block javascript %}
       <script type="module" defer src="{% static 'js/dist/app.js' %}"></script>
       <script defer src="{% static 'js/dist/cookie_consent.js' %}"></script>
+      {% include "includes/waffle_flags_javascript.html" %}
     {% endblock javascript %}
   </body>
 </html>

--- a/judgments/context_processors.py
+++ b/judgments/context_processors.py
@@ -5,6 +5,7 @@ from django.core.exceptions import SuspiciousOperation
 
 from config.settings.base import env
 from waffle import flag_is_active
+from waffle.models import Flag
 
 
 def waffle_flags(request):
@@ -23,6 +24,13 @@ def waffle_flags(request):
         context = {"variant_homepage": True, "v1_homepage": False, "v2_homepage": False, "v3_homepage": True}
     else:
         context = {"variant_homepage": False, "v1_homepage": False, "v2_homepage": False, "v3_homepage": False}
+
+    flags = {}
+    for flag in Flag.objects.all():
+        flags[flag.name] = flag.is_active(request)
+
+    context["waffle_flags"] = flags
+
     return context
 
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

This loops through all the waffle flags and sets them on the window as waffleFlags so we can do javascript based a/b testing.

We have an object explicitly set with some specific flags in this same context preprocessor - as a follow up, it might be worth refactoring that to use this waffle_flags object, but I didn't want to do all that in this PR.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-228
