### PR TITLE
FCL-228 | put document paragraph anchors behind feature flag

### DIFF
--- a/ds_judgements_public_ui/static/js/src/modules/document_paragraph_anchors.js
+++ b/ds_judgements_public_ui/static/js/src/modules/document_paragraph_anchors.js
@@ -76,6 +76,9 @@ const addDocumentParagraphAnchorLinkToSection = function (section) {
 };
 
 const setupDocumentParagraphAnchors = function () {
+    if (!window.waffleFlags || !window.waffleFlags.document_paragraph_anchors)
+        return;
+
     const sections = document.querySelectorAll(".judgment-body__section");
 
     sections.forEach(function (section) {


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Puts the document anchor functionality behind a feature flag

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-228
