### PR TITLE
[FCL-262] increase cache TTL for WhiteNoise-served assets

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -258,7 +258,7 @@ LOGGING = {
 # Your stuff...
 # ------------------------------------------------------------------------------
 APPEND_SLASH = False
-WHITENOISE_MAX_AGE = 900  # set Cache-Control header on static-served images
+WHITENOISE_MAX_AGE = 3600  # set Cache-Control header on static-served images
 
 MARKLOGIC_HOST = env("MARKLOGIC_HOST", default=None)
 MARKLOGIC_USER = env("MARKLOGIC_USER", default=None)


### PR DESCRIPTION
These static assets are currently being cached for 900 seconds (15 minutes). Increase to 1 hour to improve cache hit rates for these.