### PR TITLE
[FCL-253] Fix narrow content on variant 3 homepage

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_recent_judgments.scss
+++ b/ds_judgements_public_ui/sass/includes/_recent_judgments.scss
@@ -6,6 +6,7 @@
   }
 
   &__container-beta-v3 {
+    @include container;
     padding-top: $space-3;
     padding-bottom: $space-8;
     @media (max-width: $grid-breakpoint-medium) {

--- a/ds_judgements_public_ui/sass/includes/govuk_overrides/_grid.scss
+++ b/ds_judgements_public_ui/sass/includes/govuk_overrides/_grid.scss
@@ -4,9 +4,6 @@
   @media (max-width: $grid-breakpoint-medium) {
     flex-direction: column-reverse;
   }
-  @media only screen and (min-width: 530px) {
-    padding: 0 $space-17;
-  }
 }
 
 .govuk-grid-column-one-third {

--- a/ds_judgements_public_ui/templates/pages/home.html
+++ b/ds_judgements_public_ui/templates/pages/home.html
@@ -96,7 +96,7 @@
 {% block content %}
   {% include "includes/basic_search_form.html" %}
   {% if v3_homepage %}
-    <div class="recent-judgments__container-beta-v3 govuk-width-container">
+    <div class="recent-judgments__container-beta-v3">
       <main class="govuk-main-wrapper">
         <div class="govuk-grid-row__beta_v3_homepage">
           <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
This is down to some unnecessary nesting of classes which each add their own padding or margins; remove and simplify.

## Screenshots

### Before

![Find case law - The National Archives · 5 10pm · 08-28](https://github.com/user-attachments/assets/3642bc80-8cff-4679-bd95-af528932788f)

### After

![Find case law - The National Archives](https://github.com/user-attachments/assets/0294d012-2ba0-4243-b417-74f504ccb0a5)
