### PR TITLE
FCL-170 | Fix focus outline offset

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_header.scss
+++ b/ds_judgements_public_ui/sass/includes/_header.scss
@@ -73,6 +73,7 @@
 
     a:focus {
       outline-color: $color-white;
+      outline-offset: 0;
     }
 
     @media only screen and (max-width: $grid-breakpoint-medium) {

--- a/ds_judgements_public_ui/sass/includes/_mixins.scss
+++ b/ds_judgements_public_ui/sass/includes/_mixins.scss
@@ -98,7 +98,7 @@
 
 @mixin focus-default {
   outline: 5px solid $color-focus-blue-outline;
-  outline-offset: 0;
+  outline-offset: 2px;
   z-index: 999;
 }
 


### PR DESCRIPTION
## Changes in this PR:

Increase the offset outline to improve accessibility.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-170

## Screenshots of UI changes:

Before

<img width="179" alt="image" src="https://github.com/user-attachments/assets/9a195f14-dac4-4ce1-9142-27689d312379">

After

<img width="187" alt="image" src="https://github.com/user-attachments/assets/630c96cd-0ab4-4a55-ac9f-37e0b4753566">

Before

<img width="478" alt="image" src="https://github.com/user-attachments/assets/14b0eafa-b073-451c-87f0-90578c80b74a">

After

<img width="466" alt="image" src="https://github.com/user-attachments/assets/f41f2f69-1c5f-4495-9301-a65a9ed753bf">

Before

<img width="277" alt="image" src="https://github.com/user-attachments/assets/303df27a-c70d-48a7-83ea-a4921f779cfb">

After

<img width="333" alt="image" src="https://github.com/user-attachments/assets/014d23c8-c5e4-4f82-bf13-91decb5988e7">

Kept the 0 offset on the header logo so it stays like this (it woud cover the text above otherwise):

<img width="310" alt="image" src="https://github.com/user-attachments/assets/ded5dffb-910e-430d-b133-b9fdc3acd91d">
