### PR TITLE
FCL-171 | fix footer focus color

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_footer.scss
+++ b/ds_judgements_public_ui/sass/includes/_footer.scss
@@ -61,6 +61,10 @@
 
   a {
     @include link-on-dark-bg;
+
+    &:focus {
+      color: $color-white;
+    }
   }
 
   &__base-paragraph {


### PR DESCRIPTION
## Changes in this PR:

Makes the footer link focus colour white.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-171

## Screenshots of UI changes:

### Before

<img width="268" alt="image" src="https://github.com/user-attachments/assets/91db013a-70aa-4b61-a3ca-eadef7b1bb82">


### After

<img width="238" alt="image" src="https://github.com/user-attachments/assets/df6f14b4-9a75-48c9-b87f-12e6c3770751">
