### PR TITLE
[FCL-275] Cache the latest judgments search on the home page

### DIFF
--- a/judgments/tests/test_homepage.py
+++ b/judgments/tests/test_homepage.py
@@ -4,13 +4,21 @@ from caselawclient.search_parameters import SearchParameters
 from django.test import TestCase
 
 from judgments.tests.fixtures import FakeSearchResponse
+from judgments.views.index import cached_recent_judgments
 
 
 class TestHomepage(TestCase):
+    @patch("judgments.views.index.cached_recent_judgments")
+    def test_homepage(self, mock_cached_recent_judgments):
+        mock_cached_recent_judgments.return_value = FakeSearchResponse()
+        response = self.client.get("/")
+        mock_cached_recent_judgments.assert_called_once()
+        self.assertContains(response, "A SearchResult name!", html=True)
+
     @patch("judgments.views.index.api_client")
     @patch("judgments.views.index.search_judgments_and_parse_response")
-    def test_homepage(self, mock_search_judgments_and_parse_response, mock_api_client):
-        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
-        response = self.client.get("/")
-        mock_search_judgments_and_parse_response.assert_called_with(mock_api_client, SearchParameters(order="-date"))
-        self.assertContains(response, "A SearchResult name!", html=True)
+    def test_cached_recent_judgments(self, mock_search_judgments_and_parse_response, mock_api_client):
+        cached_recent_judgments(123)
+        mock_search_judgments_and_parse_response.assert_called_once_with(
+            mock_api_client, SearchParameters(order="-date")
+        )

--- a/judgments/views/index.py
+++ b/judgments/views/index.py
@@ -3,12 +3,24 @@ from caselawclient.client_helpers.search_helpers import (
     search_judgments_and_parse_response,
 )
 from caselawclient.search_parameters import SearchParameters
+from caselawclient.responses.search_response import SearchResponse
 from django.http import Http404
 from django.views.generic import TemplateView
 from ds_caselaw_utils import courts as all_courts
+from time import time
+from functools import lru_cache
 
 from judgments.forms import AdvancedSearchForm
 from judgments.utils import api_client
+
+
+@lru_cache(maxsize=4)
+def cached_recent_judgments(ttl_hash: int) -> SearchResponse:
+    """
+    This is a wrapper for caching homepage search results in memory with a maximum TTL. https://stackoverflow.com/questions/31771286/python-in-memory-cache-with-time-to-live
+    """
+    del ttl_hash  # ttl_hash is used to fake cache expiry with time
+    return search_judgments_and_parse_response(api_client, SearchParameters(order="-date"))
 
 
 class IndexView(TemplateView):
@@ -18,7 +30,7 @@ class IndexView(TemplateView):
         context = super().get_context_data(**kwargs)
 
         try:
-            search_response = search_judgments_and_parse_response(api_client, SearchParameters(order="-date"))
+            search_response = cached_recent_judgments(ttl_hash=round(time() / 900))  # Expire cache in 15 mins
             search_results = search_response.results
             context["recent_judgments"] = search_results
 


### PR DESCRIPTION
This will cache the list of judgments on the home page for up to 15 minutes, reducing database load.

## Jira

FCL-275