### PR TITLE
[FCL-278] Allow homepage in robots.txt

### DIFF
--- a/ds_judgements_public_ui/templates/robots.txt
+++ b/ds_judgements_public_ui/templates/robots.txt
@@ -5,4 +5,5 @@ Allow: /how-to-use-this-service
 Allow: /accessibility-statement
 Allow: /open-justice-licence
 Allow: /terms-of-use
+Allow: /$
 Disallow: /


### PR DESCRIPTION
At the moment, we disallow all URLs starting with `/` with a few exceptions for static pages. This includes disallowing the homepage. However, most search engines have decided that despite the disallow directive the page is important enough to list in the index anyway – but because of the disallow directive they can't scrape it to get anything like description snippets. This means although search engines reveal the existence of the site, they can't tell users anything useful about it. Change this behaviour to explicitly allow scraping of _only_ the root page.

## Jira

FCL-278