### PR TITLE
[FCL-278] Allow homepage in robots.txt

### DIFF
--- a/ds_judgements_public_ui/templates/pages/home.html
+++ b/ds_judgements_public_ui/templates/pages/home.html
@@ -5,6 +5,7 @@
         content="Judgments and decisions from 2003 onwards." />
 {% endblock meta_description %}
 {% block robots %}
+  <meta name="robots" content="nosnippet" />
 {% endblock robots %}
 {% block title %}
   Find case law

--- a/ds_judgements_public_ui/templates/robots.txt
+++ b/ds_judgements_public_ui/templates/robots.txt
@@ -5,4 +5,5 @@ Allow: /how-to-use-this-service
 Allow: /accessibility-statement
 Allow: /open-justice-licence
 Allow: /terms-of-use
+Allow: /$
 Disallow: /


### PR DESCRIPTION
At the moment, we disallow all URLs starting with / with a few exceptions for static pages. This includes disallowing the homepage. However, most search engines have decided that despite the disallow directive the page is important enough to list in the index anyway – but because of the disallow directive they can't scrape it to get anything like description snippets. This means although search engines reveal the existence of the site, they can't tell users anything useful about it. Change this behaviour to explicitly allow scraping of only the root page.

To make sure search engines don't inadvertently use case names in snippets, also add a `nosnippet` directive.

## Jira
[FCL-278](https://national-archives.atlassian.net/browse/FCL-278)

[FCL-278]: https://national-archives.atlassian.net/browse/FCL-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ