### PR TITLE
[FCL-283] Reinstate links to API documentation

### DIFF
--- a/ds_judgements_public_ui/templates/pages/how_to_use_this_service.html
+++ b/ds_judgements_public_ui/templates/pages/how_to_use_this_service.html
@@ -21,6 +21,9 @@
         <a href="#section-understanding">Understanding a judgment or decision</a>
       </li>
       <li class="anchor-links__list-option">
+        <a href="#section-case-law-data">Case Law as data</a>
+      </li>
+      <li class="anchor-links__list-option">
         <a href="#section-contact">How to contact us</a>
       </li>
     </ul>
@@ -181,6 +184,21 @@
       You may find that some judgments and decisions have reporting restrictions. In these cases the relevant parts
       of the judgment will be obscured.
     </p>
+    <h2 id="section-case-law-data">Case Law as data</h2>
+    <p>The Find Case Law API allows you to access court judgments and tribunal decisions held by Find Case Law as data.</p>
+    <p>‘API’ stands for ‘Application Programming Interface’, meaning software that allows two computer applications to share information.</p>
+    <p>Our API provides access to judgments and decisions held by Find Case Law that have been converted from Microsoft Word documents into XML, a machine-readable file format. These have been automatically marked up according to <a href="https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=3425f20f-b704-4076-9fab-018dc7d3efbe">the international data standard, LegalDocML</a>, and validated by our legal editorial team. This data includes:</p>
+    <ol>
+      <li>Neutral Citation</li>
+      <li>Court / Chamber</li>
+      <li>Date</li>
+      <li>Case Name</li>
+      <li>Party Names</li>
+      <li>Judges Names</li>
+    </ol>
+    <p>The Find Case Law API makes this LegalDocML data accessible through <a href="https://en.wikipedia.org/wiki/Atom_(web_standard)">Atom feeds</a>, which allow you to keep track of recently published or updated judgments. You can find more details and guidelines in <a href="https://nationalarchives.github.io/ds-find-caselaw-docs/public">our API documentation on GitHub</a>.</p>
+    <p>In most cases ‘Neutral Citation’ is used to uniquely identify judgments and decisions.</p>
+
     <h2 id="section-contact">How to contact us</h2>
     <p>
       You can get in touch by emailing

--- a/transactional_licence_form/templates/start.html
+++ b/transactional_licence_form/templates/start.html
@@ -176,7 +176,7 @@
     </div>
     <h2 class="transactional-licence-form-content__heading">How to access records as data</h2>
     <p>
-      You can access Find Case Law records as data using the <a href="https://github.com/nationalarchives/ds-find-caselaw-docs/blob/main/doc/openapi/public_api.yml">Find Case Law API.</a>
+      You can access Find Case Law records as data using the <a href="https://nationalarchives.github.io/ds-find-caselaw-docs/public">Find Case Law API.</a>
     </p>
     <p>
       We have converted judgments and decisions we hold into XML and automatically mark the records up according to <a href="https://groups.oasis-open.org/communities/tc-community-home2?CommunityKey=3425f20f-b704-4076-9fab-018dc7d3efbe">the international data standard: LegalDocML</a>.


### PR DESCRIPTION
## Changes in this PR:

Temporarily reinstates a documentation section linking to our API docs on GitHub, pending its more permanent new home in PR2 (see FCL-93).

## Jira

FCL-283
