### PR TITLE
Use court name as author in atom feed not submitter

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -119,7 +119,7 @@ class LatestJudgmentsFeed(Feed):
         return reverse("detail", kwargs={"document_uri": item.uri})
 
     def item_author_name(self, item) -> Optional[str]:
-        return item.metadata.author
+        return item.court
 
     def item_extra_kwargs(self, item):
         extra_kwargs = super().item_extra_kwargs(item)

--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -41,6 +41,8 @@ class TestAtomFeed(TestCase):
         self.assertIn("<entry>", decoded_response)
         # and it contains actual content - neither neutral citation or court appear in the feed to test.
         self.assertIn("A SearchResult name!", decoded_response)
+        # and that the author is listed as the court, not the submitter.
+        self.assertIn("<author><name>court</name></author>", decoded_response)
 
     @patch("judgments.feeds.search_judgments_and_parse_response")
     def test_bad_page_404(self, mock_search_judgments_and_parse_response):


### PR DESCRIPTION
Sample `<author>` tag contents:

```
<name>High Court (Business and Property Courts)</name>
<name>Court of Appeal (Civil Division)</name>
<name>High Court (Planning Court)</name>
<name>Court of Appeal (Criminal Division)</name>
<name>High Court (Property, Trusts and Probate List)</name>
```

Discussion: https://my.slack.com/archives/C02TP2L2Z0F/p1726042175209909