### PR TITLE
[FCL-285] Make API page point to generated docs instead of OpenAPI spec

### DIFF
--- a/ds_judgements_public_ui/templates/pages/the_find_case_law_api.html
+++ b/ds_judgements_public_ui/templates/pages/the_find_case_law_api.html
@@ -48,43 +48,8 @@
           </p>
           <p>
             The Find Case Law API makes this LegalDocML data accessible through <a href="https://en.wikipedia.org/wiki/Atom_(web_standard)">Atom feeds</a>, which allow you to keep track of recently published or updated judgments.
-            You can find more details and guidelines in <a href="https://github.com/nationalarchives/ds-find-caselaw-docs/blob/main/doc/openapi/public_api.yml">the OpenAPI specification available on GitHub</a> .
+            You can find more details and guidelines in our <a href="https://nationalarchives.github.io/ds-find-caselaw-docs/public">API documentation</a> .
           </p>
-          <p>In most cases ‘Neutral Citation’ is used to uniquely identify judgments and decisions.</p>
-          <h2 id="section-specifications">API specifications</h2>
-          <p>Example root feed URL
-            <ul>
-              <li>https://caselaw.nationalarchives.gov.uk/atom.xml</li>
-            </ul>
-          </p>
-          <p>URL structure for judgment data
-            <ul>
-              <li>https://caselaw.nationalarchives.gov.uk/year/court/subdivision/id/data.xml</li>
-            </ul>
-          </p>
-          <p>API parameters
-            <ul>
-              <li>order = updated: Sort by the last XML database update</li>
-              <li>order = date: Sort by date on the judgment</li>
-              <li>page = 3: Paginated response. Starting at page 1</li>
-            </ul>
-          </p>
-          <p>API example workflow
-            <ol>
-              <li>Poll the recently-published feed</li>
-              <li>Detect a new item using the timestamps in the feed</li>
-              <li>Retrieve the URI of the judgment from the id field of the item</li>
-            </ol>
-          </p>
-          <p>Detecting changes</p>
-          <p>
-            Whenever a judgment gets changed it appears in the recently published list. This includes minor updates such as when we enrich the
-            document with hyperlinks to other legal citations, as well as more significant changes such as revisions we have received from the courts.
-          </p>
-          <p>The atom feed and the judgment xml include a content hash so that you can check if the text of the document has changed.</p>
-          <h2 id="section-feedback">Give us your feedback</h2>
-          <p>We are still actively developing Find Case Law based on user feedback. This includes improving the experience of how data re-users can access the data.</p>
-          <p>You can provide feedback by using <a href="https://corexmsnp4n42lf2kht3.qualtrics.com/jfe/form/SV_0lyyYAzfv9bGcyW?full_url=https%3A%2F%2Fcaselaw.nationalarchives.gov.uk%2Fabout-this-service&type=support">the feedback form</a> linked to at the bottom of every page of this website.</p>
 
         </section>
       </div>


### PR DESCRIPTION
We recently migrated information on consuming the API into our OpenAPI specification, which dramatically enhanced the autogenerated documentation. We should point to this directly instead of trying to maintain documentation in two places.

## Jira

FCL-285
