### PR TITLE
[FCL-219] Add very minimal ruff configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,8 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.5
     hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/Riverside-Healthcare/djLint

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -1,7 +1,6 @@
 from urllib.parse import urlencode
 
 from django.urls import resolve
-from django.utils.cache import patch_cache_control
 
 # these should match the names in config/urls.py
 INDEXABLE_VIEWS = [

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,29 +7,27 @@ from django.views import defaults as default_views
 from django.views.decorators.cache import cache_page
 from django.views.generic.base import TemplateView
 
-from .views.style_guide import StyleGuideView
-from .views.errors import NotFoundView, ServerErrorView, PermissionDeniedView
-from .views.courts import CourtsTribunalsListView, CourtOrTribunalView
+from .converters import SchemaFileConverter
 from .views.about import AboutThisServiceView
 from .views.accessibility_statement import AccessibilityStatementView
-from .views.open_justice_license import OpenJusticeLicenceView
-from .views.terms_of_use import TermsOfUseView
-from .views.publishing_policy import PublishingPolicyView
-from .views.structured_search import StructuredSearchView
-from .views.terms_and_policies import TermsAndPoliciesView
-from .views.contact_us import ContactUsView
-from .views.courts_and_tribunals_in_fcl import CourtsAndTribunalsInFclView
-from .views.help_and_guidance import HelpAndGuidanceView
-from .views.how_to_search_find_case_law import HowToSearchFindCaseLawView
-from .views.understanding_judgements_and_decisions import UnderstandingJudgmentsAndDecisionsView
-from .views.the_find_case_law_api import TheFindCaseLawApiView
-
-
 from .views.check import status
+from .views.contact_us import ContactUsView
+from .views.courts import CourtOrTribunalView, CourtsTribunalsListView
+from .views.courts_and_tribunals_in_fcl import CourtsAndTribunalsInFclView
+from .views.errors import NotFoundView, PermissionDeniedView, ServerErrorView
+from .views.help_and_guidance import HelpAndGuidanceView
 from .views.how_to import HowToUseThisService
+from .views.how_to_search_find_case_law import HowToSearchFindCaseLawView
+from .views.open_justice_license import OpenJusticeLicenceView
 from .views.privacy_notice import PrivacyNotice
+from .views.publishing_policy import PublishingPolicyView
 from .views.schema import schema
-from .converters import SchemaFileConverter
+from .views.structured_search import StructuredSearchView
+from .views.style_guide import StyleGuideView
+from .views.terms_and_policies import TermsAndPoliciesView
+from .views.terms_of_use import TermsOfUseView
+from .views.the_find_case_law_api import TheFindCaseLawApiView
+from .views.understanding_judgements_and_decisions import UnderstandingJudgmentsAndDecisionsView
 
 register_converter(SchemaFileConverter, "schemafile")
 

--- a/config/views/about.py
+++ b/config/views/about.py
@@ -1,5 +1,6 @@
-from .template_view_with_context import TemplateViewWithContext
 from ds_caselaw_utils import courts
+
+from .template_view_with_context import TemplateViewWithContext
 
 
 class AboutThisServiceView(TemplateViewWithContext):

--- a/config/views/courts.py
+++ b/config/views/courts.py
@@ -1,12 +1,13 @@
-from ds_caselaw_utils import courts
-from .template_view_with_context import TemplateViewWithContext
 from caselawclient.client_helpers.search_helpers import (
     search_judgments_and_parse_response,
 )
 from caselawclient.search_parameters import RESULTS_PER_PAGE, SearchParameters
+from ds_caselaw_utils import courts
 
 from judgments.utils import api_client, clamp, paginator
 from judgments.utils.utils import sanitise_input_to_integer
+
+from .template_view_with_context import TemplateViewWithContext
 
 
 class CourtsTribunalsListView(TemplateViewWithContext):

--- a/config/views/courts.py
+++ b/config/views/courts.py
@@ -4,7 +4,6 @@ from caselawclient.client_helpers.search_helpers import (
     search_judgments_and_parse_response,
 )
 from caselawclient.search_parameters import RESULTS_PER_PAGE, SearchParameters
-from ds_caselaw_utils import courts
 
 from judgments.utils import api_client, clamp, paginator
 from judgments.utils.utils import sanitise_input_to_integer

--- a/config/views/courts_and_tribunals_in_fcl.py
+++ b/config/views/courts_and_tribunals_in_fcl.py
@@ -1,5 +1,6 @@
-from .template_view_with_context import TemplateViewWithContext
 from ds_caselaw_utils import courts
+
+from .template_view_with_context import TemplateViewWithContext
 
 
 class CourtsAndTribunalsInFclView(TemplateViewWithContext):

--- a/config/views/errors.py
+++ b/config/views/errors.py
@@ -1,6 +1,6 @@
-from django.views.generic import TemplateView
-from django.views import defaults as default_views
 from django.shortcuts import render
+from django.views import defaults as default_views
+from django.views.generic import TemplateView
 
 
 class BaseErrorView(TemplateView):

--- a/config/views/structured_search.py
+++ b/config/views/structured_search.py
@@ -1,6 +1,8 @@
-from .template_view_with_context import TemplateViewWithContext
 from ds_caselaw_utils import courts
+
 from judgments.forms import AdvancedSearchForm
+
+from .template_view_with_context import TemplateViewWithContext
 
 
 class StructuredSearchView(TemplateViewWithContext):

--- a/config/views/style_guide.py
+++ b/config/views/style_guide.py
@@ -1,11 +1,12 @@
-from .template_view_with_context import TemplateViewWithContext
 from caselawclient.client_helpers.search_helpers import (
     search_judgments_and_parse_response,
 )
 from caselawclient.search_parameters import SearchParameters
 
-from judgments.utils import api_client
 from judgments.forms import AdvancedSearchForm
+from judgments.utils import api_client
+
+from .template_view_with_context import TemplateViewWithContext
 
 
 class StyleGuideView(TemplateViewWithContext):

--- a/config/views/template_view_with_context.py
+++ b/config/views/template_view_with_context.py
@@ -1,5 +1,5 @@
-from django.views.generic import TemplateView
 from django.utils.translation import gettext
+from django.views.generic import TemplateView
 
 
 class TemplateViewWithContext(TemplateView):

--- a/judgments/context_processors.py
+++ b/judgments/context_processors.py
@@ -1,12 +1,12 @@
 import json
+from typing import Union
 from urllib.parse import unquote
 
 from django.core.exceptions import SuspiciousOperation
-
-from config.settings.base import env
 from waffle import flag_is_active
 from waffle.models import Flag
-from typing import Union
+
+from config.settings.base import env
 
 
 def waffle_flags(request):

--- a/judgments/templatetags/navigation_tags.py
+++ b/judgments/templatetags/navigation_tags.py
@@ -1,5 +1,4 @@
 from django import template
-
 from django.urls import resolve
 
 register = template.Library()

--- a/judgments/tests/template_tags/test_navigation_tags.py
+++ b/judgments/tests/template_tags/test_navigation_tags.py
@@ -1,5 +1,4 @@
 import unittest
-
 from unittest.mock import Mock
 
 from judgments.templatetags.navigation_tags import navigation_item_class

--- a/judgments/tests/test_assertions.py
+++ b/judgments/tests/test_assertions.py
@@ -1,5 +1,6 @@
 import pytest
 from django.test import TestCase
+
 from judgments.tests.utils.assertions import (
     assert_contains_html,
     assert_not_contains_html,

--- a/judgments/tests/test_context_processors.py
+++ b/judgments/tests/test_context_processors.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
-from django.test import TestCase
+
 import lxml.html
+from django.test import TestCase
 from waffle.testutils import override_flag
 
 

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -10,8 +10,8 @@ from factories import JudgmentFactory, PressSummaryFactory
 
 from judgments.tests.utils.assertions import (
     assert_contains_html,
-    assert_response_not_contains_text,
     assert_response_contains_text,
+    assert_response_not_contains_text,
 )
 from judgments.views.detail import (
     NoNeutralCitationError,

--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import lxml
 from caselawclient.search_parameters import SearchParameters
 from django.test import TestCase
 from ds_caselaw_utils import courts as all_courts
@@ -15,7 +16,6 @@ from judgments.tests.utils.assertions import (
     assert_response_contains_text,
     assert_response_not_contains_text,
 )
-import lxml
 
 
 class TestBrowseResults(TestCase):

--- a/judgments/tests/test_utils.py
+++ b/judgments/tests/test_utils.py
@@ -17,7 +17,6 @@ from judgments.utils import (
     process_year_facets,
     show_no_exact_ncn_warning,
 )
-
 from judgments.utils.utils import get_document_by_uri_from_cache
 
 

--- a/judgments/utils/utils.py
+++ b/judgments/utils/utils.py
@@ -1,18 +1,20 @@
 import math
 import re
-from typing import Any, Optional, TypedDict, Literal, overload
-from urllib.parse import parse_qs, urlparse
 from functools import lru_cache
+from time import time
+from typing import Any, Literal, Optional, TypedDict, overload
+from urllib.parse import parse_qs, urlparse
+
 from caselawclient.Client import DEFAULT_USER_AGENT, MarklogicApiClient
+from caselawclient.errors import DocumentNotFoundError
 from caselawclient.models.documents import Document, DocumentURIString
 from caselawclient.models.press_summaries import PressSummary
 from caselawclient.search_parameters import RESULTS_PER_PAGE
-from caselawclient.errors import DocumentNotFoundError
 from django.conf import settings
 from django.urls import reverse
 from ds_caselaw_utils.neutral import neutral_url
+
 from judgments.fixtures.stop_words import stop_words
-from time import time
 
 MAX_RESULTS_PER_PAGE = 50
 

--- a/judgments/views/index.py
+++ b/judgments/views/index.py
@@ -1,14 +1,15 @@
+from functools import lru_cache
+from time import time
+
 from caselawclient.Client import MarklogicResourceNotFoundError
 from caselawclient.client_helpers.search_helpers import (
     search_judgments_and_parse_response,
 )
-from caselawclient.search_parameters import SearchParameters
 from caselawclient.responses.search_response import SearchResponse
+from caselawclient.search_parameters import SearchParameters
 from django.http import Http404
 from django.views.generic import TemplateView
 from ds_caselaw_utils import courts as all_courts
-from time import time
-from functools import lru_cache
 
 from judgments.forms import AdvancedSearchForm
 from judgments.utils import api_client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [tool.djlint]
 ignore="H021,H023,H030,H031"
 profile="django"
@@ -7,3 +6,14 @@ custom_blocks="flag"
 
 [tool.ruff]
 line-length = 120
+
+[tool.ruff.lint]
+ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # long lines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
+extend-select = ["W", "I"]
+# extend-select = [ "B", "Q", "C90", "I", "UP", "YTT", "ASYNC", "S", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+#                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLF", "SLOT", "SIM", "TID", "TCH", "INT", "PTH",
+#                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
+unfixable = ["ERA"]
+
+[tool.ruff.lint.extend-per-file-ignores]
+"tests/*" = ["S101"]  # `assert` is fine in tests

--- a/transactional_licence_form/views.py
+++ b/transactional_licence_form/views.py
@@ -1,10 +1,10 @@
 from django.core.exceptions import SuspiciousOperation
 from django.shortcuts import redirect, render
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
 from formtools.wizard.forms import ManagementForm
 from formtools.wizard.views import NamedUrlSessionWizardView
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import never_cache
 
 from .forms import FORMS
 from .utils import send_form_response_to_dynamics


### PR DESCRIPTION
This switches on ruff with a very minimal set of rules to start and enforce code consistency. We can incrementally switch on rules over time to bring the codebase into stylistic alignment with everything else.

## Jira

FCL-219
