### PR TITLE
[FCL-295] Add link to canonical form of document pages to HTML header

### DIFF
--- a/ds_judgements_public_ui/templates/judgment/detail.html
+++ b/ds_judgements_public_ui/templates/judgment/detail.html
@@ -3,6 +3,9 @@
 {% block robots %}
   <meta name="robots" content="noindex,nofollow" />
 {% endblock robots %}
+{% block extra_head_tags %}
+  <link rel="canonical" href="{{ document_canonical_url }}" />
+{% endblock extra_head_tags %}
 {% block title %}
   {% if page_title %}{{ page_title }} -{% endif %}
   Find case law

--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -24,6 +24,7 @@
             rel="stylesheet" />
       <link href="{% static 'css/main.css' %}" rel="stylesheet" />
     {% endblock css %}
+    {% block extra_head_tags %}{% endblock extra_head_tags %}
     {% include "includes/gtm/gtm_head.html" %}
   </head>
   <body>

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -127,6 +127,7 @@ def detail(request, document_uri):
         query=preprocess_query(query) if query is not None else None,
     )  # "" is most recent version
     context["document_uri"] = document.uri
+    context["document_canonical_url"] = request.build_absolute_uri("/" + document.uri)
     context["page_title"] = document.name
     context["pdf_size"] = f" ({filesizeformat(pdf.size)})" if pdf.size else " (unknown size)"
     context["pdf_uri"] = pdf.uri


### PR DESCRIPTION
This provides search engines with hints about which variation of a document page should be considered 'correct' in the event they arrive at one which is using query parameters in the URL, eg arriving from a search.

## Jira

FCL-295