### PR TITLE
[FCL-306] Remove compilemessage calls

### DIFF
--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -8,5 +8,4 @@ set -o nounset
 npm run build
 python /app/manage.py collectstatic --noinput
 cd /app
-DJANGO_SETTINGS_MODULE= django-admin compilemessages
 /usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app --access-logfile - -w 5

--- a/fabfile.py
+++ b/fabfile.py
@@ -74,7 +74,6 @@ def start(c, container_name=None):
 def pip(c):
     start(c, "django")
     django_exec("pip install -r requirements/local.txt -U")
-    django_exec("DJANGO_SETTINGS_MODULE= django-admin compilemessages")
     django_exec("python manage.py migrate")
     stop(c, "django")
 


### PR DESCRIPTION
Staging was 502/503 ing with the error 

`CommandError: Can't find msgfmt. Make sure you have GNU gettext tools 0.15 or newer installed.`

Investigating, a number of calls to `compilemessage` get called -- removed them.

FCL-306
