### PR TITLE
[FCL-311] Correctly root document URLs in sitemaps

### DIFF
--- a/config/views/sitemaps.py
+++ b/config/views/sitemaps.py
@@ -117,7 +117,7 @@ class SitemapCourtView(TemplateView, TemplateResponseMixin):
 
             context["items"] = [
                 {
-                    "url": self.request.build_absolute_uri(result.uri),
+                    "url": self.request.build_absolute_uri("/" + result.uri),
                     "lastmod": datetime.datetime.strptime(result.transformation_date, "%Y-%m-%dT%H:%M:%S")
                     .date()
                     .isoformat(),


### PR DESCRIPTION
Where a court param included a slash, `build_absolute_uri` was incorrectly finding the root of a document URL because they don't by default include a leading slash. Adding this makes sure all documents are correctly placed at the site root.

## Jira

FCL-311