### PR TITLE
[FCL-322] Fix for court years being off by one in the sitemap

### DIFF
--- a/config/views/sitemaps.py
+++ b/config/views/sitemaps.py
@@ -9,8 +9,8 @@ from caselawclient.search_parameters import SearchParameters
 from django.http import Http404
 from django.urls import reverse
 from django.views.generic.base import TemplateResponseMixin, TemplateView
-from ds_caselaw_utils import courts
 
+from judgments.models.court_dates import CourtDates
 from judgments.utils import api_client
 
 
@@ -31,11 +31,11 @@ class SitemapIndexView(TemplateView, TemplateResponseMixin):
         context["maps"] = [self.request.build_absolute_uri(reverse(map)) for map in map_url_names]
 
         # Dynamically append a sitemap for each court
-        for court in courts.get_listable_courts():
+        for court in CourtDates.objects.all():
             for year in range(court.start_year, court.end_year):
                 context["maps"].append(
                     self.request.build_absolute_uri(
-                        reverse("sitemap_court", kwargs={"code": court.canonical_param, "year": year})
+                        reverse("sitemap_court", kwargs={"code": court.param, "year": year})
                     )
                 )
 
@@ -83,12 +83,8 @@ class SitemapCourtsView(TemplateView, TemplateResponseMixin):
         context = super().get_context_data(**kwargs)
 
         context["items"] = [
-            {
-                "url": self.request.build_absolute_uri(
-                    reverse("court_or_tribunal", kwargs={"param": court.canonical_param})
-                )
-            }
-            for court in courts.get_listable_courts()
+            {"url": self.request.build_absolute_uri(reverse("court_or_tribunal", kwargs={"param": court.param}))}
+            for court in CourtDates.objects.all()
         ]
 
         return context

--- a/config/views/sitemaps.py
+++ b/config/views/sitemaps.py
@@ -32,7 +32,7 @@ class SitemapIndexView(TemplateView, TemplateResponseMixin):
 
         # Dynamically append a sitemap for each court
         for court in CourtDates.objects.all():
-            for year in range(court.start_year, court.end_year):
+            for year in range(court.start_year, court.end_year + 1):
                 context["maps"].append(
                     self.request.build_absolute_uri(
                         reverse("sitemap_court", kwargs={"code": court.param, "year": year})

--- a/judgments/management/commands/recalculate_court_dates.py
+++ b/judgments/management/commands/recalculate_court_dates.py
@@ -81,6 +81,15 @@ falling back to config value of {fallback_end_year}"
             api_client, SearchParameters(court=canonical_court_param, order=order)
         )
 
+        if len(search_response.results) == 0:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Could not find document for court {canonical_court_param}, \
+falling back to config value of {fallback}"
+                )
+            )
+            return fallback
+
         first_document = search_response.results[0]
 
         if first_document.date:


### PR DESCRIPTION
We were using `range()` to output all the years we consider to be valid for a court, but this is _exclusive_ of the last value.

Fix this, and also swap to using our from-database `CourtDates` model as the original source of the courts and their date ranges. This means that when years roll over we aren't inadvertently publicising a non-existent range of values for a court.

## Jira

FCL-322