### PR TITLE
FCL-330 | update paragraph copied styling

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_document_paragraph_anchors.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_document_paragraph_anchors.scss
@@ -92,6 +92,8 @@
   &__copy-link-helptext--show,
   &__copy-link-tooltip--show {
     opacity: 1;
+    text-decoration: none;
+    color: $color-black;
   }
 
   &__copy-link-helptext--left {

--- a/ds_judgements_public_ui/static/js/src/modules/document_paragraph_tooltip_anchors.js
+++ b/ds_judgements_public_ui/static/js/src/modules/document_paragraph_tooltip_anchors.js
@@ -37,9 +37,11 @@ const createCopyElement = function (textToCopy) {
     element.addEventListener("click", function (event) {
         copyLinkToClipboard(event, textToCopy);
         element.innerHTML = "Copied!";
+        element.classList.add("judgment-body__copy-link-tooltip--show");
 
         setTimeout(() => {
             element.innerHTML = "Copy link to this paragraph";
+            element.classList.remove("judgment-body__copy-link-tooltip--show");
         }, 3000);
     });
 


### PR DESCRIPTION
## Changes in this PR:

Updating the paragraph copied tooltip to not have an underline

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-330

## Screenshots of UI changes:

<img width="323" alt="image" src="https://github.com/user-attachments/assets/c04d020a-be16-4087-9d03-1c4f8aa1cae5">
