### PR TITLE
[FCL-368] Improve how we flag pages as not being indexable

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -1,17 +1,6 @@
 from urllib.parse import urlencode
 
-from django.urls import resolve
-
-# these should match the names in config/urls.py
-INDEXABLE_VIEWS = [
-    "home",
-    "computational_licence_form",
-    "what_to_expect",
-    "how_to_use_this_service",
-    "accessibility_statement",
-    "open_justice_licence",
-    "terms_of_use",
-]
+from django.template.response import TemplateResponse
 
 
 class RobotsTagMiddleware:
@@ -23,8 +12,10 @@ class RobotsTagMiddleware:
         # Code to be executed for each request before
         # the view (and later middleware) are called.
         response = self.get_response(request)
-        if resolve(request.path).view_name not in INDEXABLE_VIEWS:
-            response.headers["X-Robots-Tag"] = "noindex,nofollow"
+        # If page_allow_index is True, short-circuit adding the X-Robots-Tag
+        if isinstance(response, TemplateResponse) and response.context_data.get("page_allow_index", False):
+            return response
+        response.headers["X-Robots-Tag"] = "noindex,nofollow"
         return response
 
 

--- a/config/views/static.py
+++ b/config/views/static.py
@@ -7,6 +7,7 @@ class AboutThisServiceView(TemplateViewWithContext):
     template_name = "pages/about_this_service.html"
     page_title = "About this service"
     page_canonical_url_name = "about_this_service"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -19,6 +20,7 @@ class AccessibilityStatementView(TemplateViewWithContext):
     template_name = "pages/accessibility_statement.html"
     page_title = "Accessibility statement"
     page_canonical_url_name = "accessibility_statement"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -30,6 +32,7 @@ class ContactUsView(TemplateViewWithContext):
     template_name = "pages/contact_us.html"
     page_title = "Contact Us"
     page_canonical_url_name = "contact_us"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -41,6 +44,7 @@ class CourtsAndTribunalsInFclView(TemplateViewWithContext):
     template_name = "pages/courts_and_tribunals_in_fcl.html"
     page_title = "Courts and tribunals in Find Case Law"
     page_canonical_url_name = "courts_and_tribunals_in_fcl"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -53,6 +57,7 @@ class FindCaseLawApiView(TemplateViewWithContext):
     template_name = "pages/the_find_case_law_api.html"
     page_title = "The Find Case Law API"
     page_canonical_url_name = "the_find_case_law_api"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -64,6 +69,7 @@ class HelpAndGuidanceView(TemplateViewWithContext):
     template_name = "pages/help_and_guidance.html"
     page_title = "Help and guidance"
     page_canonical_url_name = "help_and_guidance"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -75,6 +81,7 @@ class HowToSearchFindCaseLawView(TemplateViewWithContext):
     template_name = "pages/how_to_search_find_case_law.html"
     page_title = "How to search Find Case Law"
     page_canonical_url_name = "how_to_search_find_case_law"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -86,6 +93,7 @@ class HowToUseThisService(TemplateViewWithContext):
     template_name = "pages/how_to_use_this_service.html"
     page_title = "How to use the Find Case Law service"
     page_canonical_url_name = "how_to_use_this_service"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -97,6 +105,7 @@ class OpenJusticeLicenceView(TemplateViewWithContext):
     template_name = "pages/open_justice_licence.html"
     page_title = "Open Justice Licence"
     page_canonical_url_name = "open_justice_licence"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -108,6 +117,7 @@ class PrivacyNotice(TemplateViewWithContext):
     template_name = "pages/privacy_notice.html"
     page_title = "Privacy Notice"
     page_canonical_url_name = "privacy_notice"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -119,6 +129,7 @@ class PublishingPolicyView(TemplateViewWithContext):
     template_name = "pages/publishing_policy.html"
     page_title = "Publishing policy"
     page_canonical_url_name = "publishing_policy"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -130,6 +141,7 @@ class TermsAndPoliciesView(TemplateViewWithContext):
     template_name = "pages/terms_and_policies.html"
     page_title = "Terms and policies"
     page_canonical_url_name = "terms_and_policies"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -141,6 +153,7 @@ class TermsOfUseView(TemplateViewWithContext):
     template_name = "pages/terms_of_use.html"
     page_title = "Terms of Use"
     page_canonical_url_name = "terms_of_use"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -152,6 +165,7 @@ class UnderstandingJudgmentsAndDecisionsView(TemplateViewWithContext):
     template_name = "pages/understanding_judgments_and_decisions.html"
     page_title = "Understanding judgments and decisions"
     page_canonical_url_name = "understanding_judgments_and_decisions"
+    page_allow_index = True
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/config/views/template_view_with_context.py
+++ b/config/views/template_view_with_context.py
@@ -7,10 +7,12 @@ from django.views.generic import TemplateView
 class TemplateViewWithContext(TemplateView):
     page_title: Optional[str] = None
     page_canonical_url_name: Optional[str] = None
+    page_allow_index: bool = False
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["page_title"] = self.page_title
+        context["page_allow_index"] = self.page_allow_index
         if self.page_canonical_url_name:
             context["page_canonical_url"] = self.request.build_absolute_uri(reverse(self.page_canonical_url_name))
         return context

--- a/ds_judgements_public_ui/templates/judgment/detail.html
+++ b/ds_judgements_public_ui/templates/judgment/detail.html
@@ -1,8 +1,8 @@
 {% extends "layouts/base.html" %}
 {% load document_utils waffle_tags %}
-{% block robots %}
-  <meta name="robots" content="noindex,nofollow" />
-{% endblock robots %}
+{% block extra_head_tags %}
+  <link rel="canonical" href="{{ document_canonical_url }}" />
+{% endblock extra_head_tags %}
 {% block title %}
   {% if page_title %}{{ page_title }} -{% endif %}
   Find Case Law

--- a/ds_judgements_public_ui/templates/judgment/press_summaries/list.html
+++ b/ds_judgements_public_ui/templates/judgment/press_summaries/list.html
@@ -1,8 +1,5 @@
 {% extends "layouts/base.html" %}
 {% load document_utils waffle_tags %}
-{% block robots %}
-  <meta name="robots" content="noindex,nofollow" />
-{% endblock robots %}
 {% block title %}
   {% if page_title %}{{ page_title }} -{% endif %}
   Find Case Law

--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -6,7 +6,9 @@
     {% block meta_description %}
     {% endblock meta_description %}
     {% block robots %}
-      <meta name="robots" content="noindex,nofollow" />
+      {% if not page_allow_index %}
+        <meta name="robots" content="noindex,nofollow" />
+      {% endif %}
     {% endblock robots %}
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     {% if page_canonical_url %}

--- a/ds_judgements_public_ui/templates/layouts/static_content.html
+++ b/ds_judgements_public_ui/templates/layouts/static_content.html
@@ -1,6 +1,4 @@
 {% extends "layouts/base.html" %}
-{% block robots %}
-{% endblock robots %}
 {% block title %}
   {% if page_title %}{{ page_title }} -{% endif %} Find Case Law
 {% endblock title %}

--- a/ds_judgements_public_ui/templates/pages/court_or_tribunal.html
+++ b/ds_judgements_public_ui/templates/pages/court_or_tribunal.html
@@ -1,8 +1,5 @@
 {% extends "layouts/base.html" %}
 {% load court_utils %}
-{% block robots %}
-  <meta name="robots" content="noindex,nofollow" />
-{% endblock robots %}
 {% block title %}
   {% if page_title %}
     {{ page_title }}

--- a/ds_judgements_public_ui/templates/pages/courts_and_tribunals.html
+++ b/ds_judgements_public_ui/templates/pages/courts_and_tribunals.html
@@ -1,7 +1,4 @@
 {% extends "layouts/base.html" %}
-{% block robots %}
-  <meta name="robots" content="noindex,nofollow" />
-{% endblock robots %}
 {% block title %}
   {% if page_title %}{{ page_title }} -{% endif %}
   Judgements and decisions by court or tribunal

--- a/judgments/views/index.py
+++ b/judgments/views/index.py
@@ -32,6 +32,7 @@ class IndexView(TemplateView):
         context = super().get_context_data(**kwargs)
 
         context["page_canonical_url"] = self.request.build_absolute_uri(reverse("home"))
+        context["page_allow_index"] = True
 
         try:
             search_response = cached_recent_judgments(ttl_hash=round(time() / 900))  # Expire cache in 15 mins


### PR DESCRIPTION
**This is based on the work in #1493 - review/merge that one first and rebase this!**

This was previously split between an in-template HTML tag, and a HTTP tag which relied on a whitelist. It was possible for these two things to become out of sync. Now, the view decides if a page should be indexable, by explicitly setting `context["page_allow_index"]` to `True`. `TemplateViewWithContext` will simplify this process for pages which use it.

For all instances where `page_allow_index` is not explicitly set to True, the `base.html` template will inject a `noindex,nofollow` meta tag and the `RobotsTagMiddleware` will inject a `noindex,nofollow` `X-Robots-Tag` HTTP header into the `response` object.

This establishes a pattern which can be used in FCL-304 of specifying these page metadata elements once in the view, and then them being reused in various contexts as necessary.

## Jira

FCL-368