### PR TITLE
FCL-163 | remove document_noun from context

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
@@ -7,7 +7,7 @@
         <a href="{{ pdf_uri }}"
            aria-label="Download this document as a PDF"
            download="">
-          {% if document_noun == 'press summary' %}
+          {% if document.document_noun == 'press summary' %}
             Download this press summary as a PDF
           {% else %}
             Download this judgment as a PDF
@@ -16,7 +16,7 @@
         </a>
       </h3>
       <p>
-        {% if document_noun == 'press summary' %}
+        {% if document.document_noun == 'press summary' %}
           The original format of the press summary as handed down by the court, for printing and downloading.
         {% else %}
           The original format of the judgment as handed down by the court, for printing and downloading.
@@ -27,7 +27,7 @@
       <h3>
         <a href="{% formatted_document_uri document_uri 'xml' %}"
            aria-label="Download this document as XML">
-          {% if document_noun == 'press summary' %}
+          {% if document.document_noun == 'press summary' %}
             Download this press summary as XML
           {% else %}
             Download this judgment as XML
@@ -35,7 +35,7 @@
         </a>
       </h3>
       <p>
-        {% if document_noun == 'press summary' %}
+        {% if document.document_noun == 'press summary' %}
           The press summary in machine-readable LegalDocML format for developers, data scientists and researchers.
         {% else %}
           The judgment in machine-readable LegalDocML format for developers, data scientists and researchers.

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -2,10 +2,10 @@
 
 <div class="judgment-toolbar">
   <div class="judgment-toolbar__container">
-    {% if document_noun == "press summary" %}
+    {% if document.document_noun == "press summary" %}
       <p class="judgment-toolbar__press-summary-title">Press Summary</p>
     {% endif %}
-    <h1 class="judgment-toolbar__title">{{ page_title|get_title_to_display_in_html:document_noun }}</h1>
+    <h1 class="judgment-toolbar__title">{{ document|get_title_to_display_in_html }}</h1>
     <p class="judgment-toolbar__reference">{{ judgment_ncn }}</p>
     <div class="judgment-toolbar__buttons judgment-toolbar-buttons">
       {% if linked_document_uri %}
@@ -14,7 +14,7 @@
              role="button"
              draggable="false"
              href="{% url 'detail' document_uri=linked_document_uri %}{% if query %}?query={{ query | urlencode }}{% endif %}">
-            {% if document_noun == "judgment" %}
+            {% if document.document_noun == "judgment" %}
               View Press Summary
             {% else %}
               View Judgment
@@ -27,7 +27,7 @@
          role="button"
          draggable="false"
          href="{{ pdf_uri }}"
-         aria-label="{{ page_title|get_title_to_display_in_html:document_noun }} - Download as PDF">Download as PDF
+         aria-label="{{ document|get_title_to_display_in_html }} - Download as PDF">Download as PDF
         <span class="judgment-toolbar-buttons__pdf-size">{{ pdf_size }}</span></a>
       <p class="judgment-toolbar-buttons__option--download-options"
          role="note">

--- a/ds_judgements_public_ui/templates/judgment/detail.html
+++ b/ds_judgements_public_ui/templates/judgment/detail.html
@@ -12,9 +12,9 @@
 {% endblock precontent %}
 {% block content %}
   <div id="start-of-document"></div>
-  {% if document %}
+  {% if document_html %}
     {% autoescape off %}
-      {{ document }}
+      {{ document_html }}
     {% endautoescape %}
   {% else %}
     {{ content }}

--- a/judgments/templatetags/document_utils.py
+++ b/judgments/templatetags/document_utils.py
@@ -8,14 +8,14 @@ register = template.Library()
 
 
 @register.filter
-def get_title_to_display_in_html(document_title, document_noun):
-    if not document_title:
+def get_title_to_display_in_html(document):
+    if not document.name:
         return
 
-    if document_noun == "press summary":
-        return document_title.removeprefix("Press Summary of ")
+    if document.document_noun == "press summary":
+        return document.name.removeprefix("Press Summary of ")
 
-    return document_title
+    return document.name
 
 
 @register.simple_tag

--- a/judgments/views/detail.py
+++ b/judgments/views/detail.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import urllib
-from typing import Any
+from typing import Any, Union
 
 import requests
 from caselawclient.errors import DocumentNotFoundError, MarklogicNotPermittedError
@@ -37,7 +37,7 @@ if os.environ.get("SHOW_WEASYPRINT_LOGS") != "True":
     logging.getLogger("weasyprint").handlers = []
 
 
-def get_published_document_by_uri(document_uri: str | None, cache_if_not_found: bool = False) -> Document:
+def get_published_document_by_uri(document_uri: Union[str, None], cache_if_not_found: bool = False) -> Document:
     if not document_uri:
         raise Http404("Missing document uri")
     try:
@@ -110,7 +110,7 @@ def detail(request, document_uri):
         return HttpResponseRedirect(redirect_uri)
 
     context: dict[str, Any] = {}
-    context["document_noun"] = document.document_noun
+
     if document.best_human_identifier is None:
         raise NoNeutralCitationError(document.uri)
     context["judgment_ncn"] = document.best_human_identifier
@@ -124,7 +124,8 @@ def detail(request, document_uri):
     except Http404:
         context["linked_document_uri"] = None
 
-    context["document"] = document.content_as_html(
+    context["document"] = document
+    context["document_html"] = document.content_as_html(
         MOST_RECENT_VERSION,
         query=preprocess_query(query) if query is not None else None,
     )  # "" is most recent version


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Removing explicit document_noun value from context in favour of accessing the document directly

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-163