### PR TITLE
FCL-163 | remove judgment_ncn from context

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgment_navigation.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_navigation.html
@@ -29,7 +29,7 @@
     {% if page_title %}
       <h2>{{ page_title }}</h2>
     {% endif %}
-    <p>{{ judgment_ncn }}</p>
+    <p>{{ document.best_human_identifier }}</p>
   </div>
 
   <div id="js-document-navigation-links-end"

--- a/ds_judgements_public_ui/templates/includes/judgment_navigation.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_navigation.html
@@ -12,7 +12,7 @@
         (<span class="document-navigation-links__match-count document-navigation-links__link-count">{{ number_of_mentions }}</span> matches)
         <a class="document-navigation-links__remove-query-link"
            title="Remove query highlights"
-           href="{% url 'detail' document_uri %}">Remove query highlights</a>
+           href="{% url 'detail' document.uri %}">Remove query highlights</a>
       </span>
     </span>
   {% endif %}

--- a/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
@@ -25,7 +25,7 @@
     </div>
     <div class="judgment-download-options__download-option">
       <h3>
-        <a href="{% formatted_document_uri document_uri 'xml' %}"
+        <a href="{% formatted_document_uri document.uri 'xml' %}"
            aria-label="Download this document as XML">
           {% if document.document_noun == 'press summary' %}
             Download this press summary as XML

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -6,7 +6,7 @@
       <p class="judgment-toolbar__press-summary-title">Press Summary</p>
     {% endif %}
     <h1 class="judgment-toolbar__title">{{ document|get_title_to_display_in_html }}</h1>
-    <p class="judgment-toolbar__reference">{{ judgment_ncn }}</p>
+    <p class="judgment-toolbar__reference">{{ document.best_human_identifier }}</p>
     <div class="judgment-toolbar__buttons judgment-toolbar-buttons">
       {% if linked_document_uri %}
         {% spaceless %}

--- a/ds_judgements_public_ui/templates/pdf/document.html
+++ b/ds_judgements_public_ui/templates/pdf/document.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="robots" content="noindex,nofollow" />
-    <title>{{ document_uri }}</title>
+    <title>{{ document.uri }}</title>
     {% block css %}
       <link href="{% static 'css/document_pdf.css' %}" rel="stylesheet" />
     {% endblock css %}

--- a/judgments/resolvers/document_resolver_engine.py
+++ b/judgments/resolvers/document_resolver_engine.py
@@ -3,7 +3,7 @@ from typing import Optional
 from django.http.request import HttpRequest
 from django.views.generic import View
 
-from judgments.views.detail import detail, detail_xml, get_best_pdf, get_generated_pdf
+from judgments.views.detail import best_pdf, detail_html, detail_xml, generated_pdf
 from judgments.views.press_summaries import press_summaries
 
 
@@ -16,10 +16,10 @@ class DocumentResolverEngine(View):
         component: Optional[str] = None,
     ):
         fileformat_lookup = {
-            "data.pdf": get_best_pdf,
-            "generated.pdf": get_generated_pdf,
+            "data.pdf": best_pdf,
+            "generated.pdf": generated_pdf,
             "data.xml": detail_xml,
-            "data.html": detail,
+            "data.html": detail_html,
         }
         component_lookup = {
             "press-summary": press_summaries,
@@ -30,4 +30,4 @@ class DocumentResolverEngine(View):
         if component:
             return component_lookup[component](request, document_uri)
 
-        return detail(request, document_uri)
+        return detail_html(request, document_uri)

--- a/judgments/tests/test_document_resolver_engine.py
+++ b/judgments/tests/test_document_resolver_engine.py
@@ -6,23 +6,23 @@ from judgments.resolvers.document_resolver_engine import DocumentResolverEngine
 
 
 class TestDocumentResolverEngine(TestCase):
-    @patch("judgments.resolvers.document_resolver_engine.get_best_pdf")
-    @patch("judgments.resolvers.document_resolver_engine.get_generated_pdf")
+    @patch("judgments.resolvers.document_resolver_engine.best_pdf")
+    @patch("judgments.resolvers.document_resolver_engine.generated_pdf")
     @patch("judgments.resolvers.document_resolver_engine.detail_xml")
-    @patch("judgments.resolvers.document_resolver_engine.detail")
+    @patch("judgments.resolvers.document_resolver_engine.detail_html")
     def test_resolver_engine_with_fileformats(
         self,
-        mock_detail,
+        mock_detail_html,
         mock_detail_xml,
-        mock_get_generated_pdf,
-        mock_get_best_pdf,
+        mock_generated_pdf,
+        mock_best_pdf,
     ):
         document_uri = "ewhc/comm/2024/253"
         test_params = [
-            ("data.pdf", mock_get_best_pdf),
-            ("generated.pdf", mock_get_generated_pdf),
+            ("data.pdf", mock_best_pdf),
+            ("generated.pdf", mock_generated_pdf),
             ("data.xml", mock_detail_xml),
-            ("data.html", mock_detail),
+            ("data.html", mock_detail_html),
         ]
         for file_format, view in test_params:
             with self.subTest(filename=file_format, view=view):

--- a/judgments/tests/test_judgment_utils.py
+++ b/judgments/tests/test_judgment_utils.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+
+import pytest
+from caselawclient.errors import DocumentNotFoundError
+from django.http import Http404
+from factories import JudgmentFactory
+
+from judgments.utils import (
+    get_published_document_by_uri,
+)
+
+
+class TestGetPublishedDocument:
+    @patch("judgments.utils.judgment_utils.get_document_by_uri")
+    def test_judgment_is_published(self, mock_get_document_by_uri):
+        judgment = JudgmentFactory.build(is_published=True)
+        mock_get_document_by_uri.return_value = judgment
+        assert get_published_document_by_uri("2022/eat/1") == judgment
+
+    @patch("judgments.utils.judgment_utils.get_document_by_uri")
+    def test_judgment_is_unpublished(self, mock_get_document_by_uri):
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(is_published=False)
+        with pytest.raises(Http404):
+            get_published_document_by_uri("2099/eat/1")
+
+    @patch("judgments.utils.judgment_utils.get_document_by_uri", side_effect=DocumentNotFoundError)
+    def test_judgment_missing(self, mock_get_document_by_uri):
+        with pytest.raises(Http404):
+            get_published_document_by_uri("not-a-judgment")
+
+    @patch("judgments.utils.judgment_utils.get_document_by_uri")
+    def test_press_summary_is_published(self, mock_get_document_by_uri):
+        judgment = JudgmentFactory.build(is_published=True, uri="2022/eat/1/press-summary/1")
+        mock_get_document_by_uri.return_value = judgment
+        assert get_published_document_by_uri("2022/eat/1/press-summary/1") == judgment

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -144,8 +144,8 @@ class TestRobotsDirectives(TestCase):
         response = self.client.get("/judgments/search?query=waltham+forest")
         self.assertContains(response, '<meta name="robots" content="noindex,nofollow" />', html=True)
 
-    @patch("judgments.views.detail.DocumentPdf")
-    @patch("judgments.views.detail.requests.get")
+    @patch("judgments.views.detail.best_pdf.DocumentPdf")
+    @patch("judgments.views.detail.best_pdf.requests.get")
     def test_aws_pdf(self, mock_get, mock_pdf):
         url = "https://assets.caselaw.nationalarchives.gov.uk/eat/2023/1/eat_2023_1.pdf"
         mock_pdf.return_value.generate_uri.return_value = url
@@ -156,8 +156,8 @@ class TestRobotsDirectives(TestCase):
         self.assertContains(response, "CAT")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
-    @patch("judgments.views.detail.DocumentPdf")
-    @patch("judgments.views.detail.requests.get")
+    @patch("judgments.views.detail.best_pdf.DocumentPdf")
+    @patch("judgments.views.detail.best_pdf.requests.get")
     def test_aws_pdf_press_summary(self, mock_get, mock_pdf):
         url = "https://assets.caselaw.nationalarchives.gov.uk/eat/2023/1/press-summary/1/eat_2023_1_press-summary_1.pdf"
         mock_pdf.return_value.generate_uri.return_value = url
@@ -168,24 +168,24 @@ class TestRobotsDirectives(TestCase):
         self.assertContains(response, "CAT")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
-    @patch("judgments.views.detail.get_document_by_uri")
+    @patch("judgments.views.detail.detail_xml.get_published_document_by_uri")
     def test_xml(self, mock_get_document_by_uri):
         mock_get_document_by_uri.return_value = JudgmentFactory.build(is_published=True)
         response = self.client.get("/eat/2023/1/data.xml")
-        mock_get_document_by_uri.assert_called_with("eat/2023/1", cache_if_not_found=False)
+        mock_get_document_by_uri.assert_called_with("eat/2023/1")
         self.assertContains(response, "This is a judgment in XML.")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
-    @patch("judgments.views.detail.get_document_by_uri")
+    @patch("judgments.views.detail.detail_xml.get_published_document_by_uri")
     def test_xml_press_summary(self, mock_get_document_by_uri):
         mock_get_document_by_uri.return_value = JudgmentFactory.build(is_published=True)
         response = self.client.get("/eat/2023/1/press-summary/1/data.xml")
-        mock_get_document_by_uri.assert_called_with("eat/2023/1/press-summary/1", cache_if_not_found=False)
+        mock_get_document_by_uri.assert_called_with("eat/2023/1/press-summary/1")
         self.assertContains(response, "This is a judgment in XML.")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
     @patch.object(PdfDetailView, "pdf_stylesheets", [])
-    @patch("judgments.views.detail.PdfDetailView.get_context_data")
+    @patch("judgments.views.detail.generated_pdf.PdfDetailView.get_context_data")
     def test_weasy_pdf(self, mock_context):
         mock_context.return_value = {"judgment": "<cat>KITTEN</cat>"}
         response = self.client.get("/eat/2023/1/generated.pdf")
@@ -194,7 +194,7 @@ class TestRobotsDirectives(TestCase):
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow")
 
     @patch.object(PdfDetailView, "pdf_stylesheets", [])
-    @patch("judgments.views.detail.PdfDetailView.get_context_data")
+    @patch("judgments.views.detail.generated_pdf.PdfDetailView.get_context_data")
     def test_weasy_pdf_press_summary(self, mock_context):
         mock_context.return_value = {"judgment": "<cat>KITTEN</cat>"}
         response = self.client.get("/eat/2023/1/press-summary/1/generated.pdf")

--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -1,3 +1,4 @@
+from .judgment_utils import get_published_document_by_uri
 from .search_utils import (
     ALL_COURT_CODES,
     get_minimum_valid_year,
@@ -34,6 +35,7 @@ __all__ = [
     "clamp",
     "formatted_document_uri",
     "get_document_by_uri",
+    "get_published_document_by_uri",
     "get_minimum_valid_year",
     "get_press_summaries_for_document_uri",
     "has_filters",

--- a/judgments/utils/judgment_utils.py
+++ b/judgments/utils/judgment_utils.py
@@ -1,0 +1,20 @@
+from caselawclient.errors import DocumentNotFoundError, MarklogicNotPermittedError
+from caselawclient.models.documents import Document, DocumentURIString
+from django.http import Http404
+
+from .utils import get_document_by_uri
+
+
+def get_published_document_by_uri(document_uri: DocumentURIString, cache_if_not_found: bool = False) -> Document:
+    try:
+        document = get_document_by_uri(document_uri, cache_if_not_found=cache_if_not_found)
+        if not document:
+            raise Http404(f"Document {document_uri} was not found")
+    except DocumentNotFoundError:
+        raise Http404(f"Document {document_uri} was not found")
+    except MarklogicNotPermittedError:
+        raise Http404(f"Document {document_uri} is not available")
+
+    if not document.is_published:
+        raise Http404(f"Document {document_uri} is not available")
+    return document

--- a/judgments/utils/utils.py
+++ b/judgments/utils/utils.py
@@ -244,12 +244,12 @@ def formatted_document_uri(document_uri: str, format: Optional[str] = None) -> s
     return url
 
 
-def linked_doc_url(document: Document):
+def linked_doc_url(document: Document) -> DocumentURIString:
     press_summary_suffix = "/press-summary/1"
     if document.document_noun == "press summary":
-        return document.uri.removesuffix(press_summary_suffix)
+        return DocumentURIString(document.uri.removesuffix(press_summary_suffix))
     else:
-        return document.uri + press_summary_suffix
+        return DocumentURIString(document.uri + press_summary_suffix)
 
 
 def linked_doc_title(document: Document):

--- a/judgments/views/detail/__init__.py
+++ b/judgments/views/detail/__init__.py
@@ -1,0 +1,6 @@
+from .best_pdf import best_pdf
+from .detail_html import NoNeutralCitationError, detail_html
+from .detail_xml import detail_xml
+from .generated_pdf import PdfDetailView, generated_pdf
+
+__all__ = ["best_pdf", "detail_html", "detail_xml", "generated_pdf", "PdfDetailView", "NoNeutralCitationError"]

--- a/judgments/views/detail/best_pdf.py
+++ b/judgments/views/detail/best_pdf.py
@@ -1,0 +1,32 @@
+import logging
+
+import requests
+from django.http import HttpResponse
+from django.shortcuts import redirect
+from django.urls import reverse
+
+from judgments.models.document_pdf import DocumentPdf
+
+
+def best_pdf(request, document_uri):
+    """
+    Response for the legacy data.pdf endpoint, used by data reusers
+
+    If there's a DOCX-derived PDF in the S3 bucket, return that.
+    Otherwise fall back and redirect to the weasyprint version."""
+    pdf = DocumentPdf(document_uri)
+    response = requests.get(pdf.generate_uri())
+    logging.debug("Response %s", response.status_code)
+    if response.status_code == 200:
+        return HttpResponse(response.content, content_type="application/pdf")
+
+    if response.status_code != 404:
+        logging.warn(f"Unexpected {response.status_code} error on {document_uri} whilst trying to get_best_pdf")
+    # fall back to weasy_pdf
+
+    return redirect(
+        reverse(
+            "detail",
+            kwargs={"document_uri": document_uri, "file_format": "generated.pdf"},
+        )
+    )

--- a/judgments/views/detail/detail_html.py
+++ b/judgments/views/detail/detail_html.py
@@ -1,24 +1,18 @@
 import logging
 import os
 import urllib
-from typing import Any, Union
+from typing import Any
 
-import requests
-from caselawclient.errors import DocumentNotFoundError, MarklogicNotPermittedError
-from caselawclient.models.documents import Document, DocumentURIString
-from django.conf import settings
-from django.http import Http404, HttpResponse, HttpResponseRedirect
-from django.shortcuts import redirect
+from caselawclient.models.documents import DocumentURIString
+from django.http import Http404, HttpResponseRedirect
 from django.template.defaultfilters import filesizeformat
 from django.template.response import TemplateResponse
 from django.urls import reverse
-from django.views.generic import TemplateView
-from django_weasyprint import WeasyTemplateResponseMixin
 
 from judgments.forms import AdvancedSearchForm
 from judgments.models.document_pdf import DocumentPdf
 from judgments.utils import (
-    get_document_by_uri,
+    get_published_document_by_uri,
     linked_doc_title,
     linked_doc_url,
     preprocess_query,
@@ -37,69 +31,7 @@ if os.environ.get("SHOW_WEASYPRINT_LOGS") != "True":
     logging.getLogger("weasyprint").handlers = []
 
 
-def get_published_document_by_uri(document_uri: Union[str, None], cache_if_not_found: bool = False) -> Document:
-    if not document_uri:
-        raise Http404("Missing document uri")
-    try:
-        document = get_document_by_uri(document_uri, cache_if_not_found=cache_if_not_found)
-        if not document:
-            raise Http404(f"Document {document_uri} was not found")
-    except DocumentNotFoundError:
-        raise Http404(f"Document {document_uri} was not found")
-    except MarklogicNotPermittedError:
-        raise Http404(f"Document {document_uri} is not available")
-
-    if not document.is_published:
-        raise Http404(f"Document {document_uri} is not available")
-    return document
-
-
-class PdfDetailView(WeasyTemplateResponseMixin, TemplateView):
-    template_name = "pdf/document.html"
-    pdf_stylesheets = [os.path.join(settings.STATIC_ROOT, "css", "documentpdf.css")]
-    pdf_attachment = True
-
-    def get_context_data(self, document_uri=None, **kwargs) -> dict[str, Any]:
-        context = super().get_context_data(**kwargs)
-
-        document = get_published_document_by_uri(document_uri)
-
-        self.pdf_filename = f"{document.uri}.pdf"
-
-        context["document"] = document.content_as_html(MOST_RECENT_VERSION)
-
-        return context
-
-
-def get_generated_pdf(request, document_uri):
-    return PdfDetailView.as_view()(request, document_uri=document_uri)
-
-
-def get_best_pdf(request, document_uri):
-    """
-    Response for the legacy data.pdf endpoint, used by data reusers
-
-    If there's a DOCX-derived PDF in the S3 bucket, return that.
-    Otherwise fall back and redirect to the weasyprint version."""
-    pdf = DocumentPdf(document_uri)
-    response = requests.get(pdf.generate_uri())
-    logging.debug("Response %s", response.status_code)
-    if response.status_code == 200:
-        return HttpResponse(response.content, content_type="application/pdf")
-
-    if response.status_code != 404:
-        logging.warn(f"Unexpected {response.status_code} error on {document_uri} whilst trying to get_best_pdf")
-    # fall back to weasy_pdf
-
-    return redirect(
-        reverse(
-            "detail",
-            kwargs={"document_uri": document_uri, "file_format": "generated.pdf"},
-        )
-    )
-
-
-def detail(request, document_uri):
+def detail_html(request, document_uri):
     query = request.GET.get("query")
     document = get_published_document_by_uri(document_uri)
     pdf = DocumentPdf(document_uri)
@@ -118,7 +50,8 @@ def detail(request, document_uri):
         context["number_of_mentions"] = str(document.number_of_mentions(query))
 
     try:
-        linked_document = get_published_document_by_uri(linked_doc_url(document), cache_if_not_found=True)
+        linked_document_uri = linked_doc_url(document)
+        linked_document = get_published_document_by_uri(linked_document_uri, cache_if_not_found=True)
         context["linked_document_uri"] = linked_document.uri
     except Http404:
         context["linked_document_uri"] = None
@@ -162,18 +95,7 @@ def detail(request, document_uri):
     context["page_canonical_url"] = document.public_uri
     context["document_canonical_url"] = request.build_absolute_uri("/" + document.uri)
     context["feedback_survey_document_uri"] = document.uri  # TODO: Remove this from context
-    context["document_uri"] = document.uri  # TODO: Remove this from context
     context["page_title"] = document.name  # TODO: Remove this from context
     context["pdf_uri"] = pdf.uri  # TODO: Remove this from context
 
     return TemplateResponse(request, "judgment/detail.html", context=context)
-
-
-def detail_xml(_request, document_uri):
-    document = get_published_document_by_uri(document_uri)
-
-    document_xml = document.content_as_xml
-
-    response = HttpResponse(document_xml, content_type="application/xml")
-    response["Content-Disposition"] = f"attachment; filename={document.uri}.xml"
-    return response

--- a/judgments/views/detail/detail_xml.py
+++ b/judgments/views/detail/detail_xml.py
@@ -1,0 +1,15 @@
+from django.http import HttpResponse
+
+from judgments.utils import (
+    get_published_document_by_uri,
+)
+
+
+def detail_xml(_request, document_uri):
+    document = get_published_document_by_uri(document_uri)
+
+    document_xml = document.content_as_xml
+
+    response = HttpResponse(document_xml, content_type="application/xml")
+    response["Content-Disposition"] = f"attachment; filename={document.uri}.xml"
+    return response

--- a/judgments/views/detail/generated_pdf.py
+++ b/judgments/views/detail/generated_pdf.py
@@ -1,0 +1,40 @@
+import logging
+import os
+from typing import Any
+
+from caselawclient.models.documents import DocumentURIString
+from django.conf import settings
+from django.views.generic import TemplateView
+from django_weasyprint import WeasyTemplateResponseMixin
+
+from judgments.utils import (
+    get_published_document_by_uri,
+)
+
+MOST_RECENT_VERSION = DocumentURIString("")
+
+
+# suppress weasyprint log spam
+if os.environ.get("SHOW_WEASYPRINT_LOGS") != "True":
+    logging.getLogger("weasyprint").handlers = []
+
+
+class PdfDetailView(WeasyTemplateResponseMixin, TemplateView):
+    template_name = "pdf/document.html"
+    pdf_stylesheets = [os.path.join(settings.STATIC_ROOT, "css", "documentpdf.css")]
+    pdf_attachment = True
+
+    def get_context_data(self, document_uri=None, **kwargs) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+
+        document = get_published_document_by_uri(document_uri)
+
+        self.pdf_filename = f"{document.uri}.pdf"
+
+        context["document"] = document.content_as_html(MOST_RECENT_VERSION)
+
+        return context
+
+
+def generated_pdf(request, document_uri):
+    return PdfDetailView.as_view()(request, document_uri=document_uri)


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Removing judgment_ncn from the context in favour of accessing the same value directly from the document

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-163