### PR TITLE
Allow short court codes (e.g. ewhc)

### DIFF
--- a/judgments/forms/search_forms.py
+++ b/judgments/forms/search_forms.py
@@ -10,6 +10,8 @@ from judgments.utils import preprocess_query
 from .fields import DateRangeInputField
 from .widgets import CheckBoxSelectCourtWithYearRange
 
+court_choices_dict = dict[Union[Optional[str], CourtParam], Union[str, dict[CourtParam, str]]]
+
 
 def _get_choices_by_group(courts: list[CourtGroup]):
     """
@@ -24,20 +26,20 @@ def _get_choices_by_group(courts: list[CourtGroup]):
         "key2": "value2"
     }
     """
-    options: dict[Union[Optional[str], CourtParam], Union[str, dict[CourtParam, str]]] = {}
+    options: court_choices_dict = {}
     for group in courts:
         if group.display_heading:
-            option_a: dict[Union[Optional[str], CourtParam], Union[str, dict[CourtParam, str]]] = {
+            court_group: court_choices_dict = {
                 group.name: {
                     court.canonical_param: court.grouped_name for court in group.courts if court.canonical_param
                 }
             }
-            options = options | option_a
+            options = options | court_group
         else:
-            option_b: dict[Union[Optional[str], CourtParam], Union[str, dict[CourtParam, str]]] = {
+            isolated_court: court_choices_dict = {
                 court.canonical_param: court.grouped_name for court in group.courts if court.canonical_param
             }
-            options = options | option_b
+            options = options | isolated_court
     return options
 
 

--- a/judgments/forms/search_forms.py
+++ b/judgments/forms/search_forms.py
@@ -45,7 +45,7 @@ COURT_CHOICES = _get_choices_by_group(all_courts.get_grouped_selectable_courts()
 TRIBUNAL_CHOICES = _get_choices_by_group(all_courts.get_grouped_selectable_tribunals())
 
 
-class CourtTribunalField(forms.MultipleChoiceField):
+class CourtOrTribunalField(forms.MultipleChoiceField):
     def _get_short_identifiers(self) -> set[str]:
         all_shorts: set[str] = set()
         for key, value in self.choices:
@@ -92,14 +92,14 @@ class AdvancedSearchForm(forms.Form):
     )
     # Courts and tribunals are split here because it's easier to render
     # them and then recombine in the view for querying MarkLogic
-    court = CourtTribunalField(
+    court = CourtOrTribunalField(
         choices=COURT_CHOICES,
         widget=CheckBoxSelectCourtWithYearRange(),
         label="From specific courts or tribunals",
         required=False,
     )
 
-    tribunal = CourtTribunalField(
+    tribunal = CourtOrTribunalField(
         choices=TRIBUNAL_CHOICES,
         widget=CheckBoxSelectCourtWithYearRange(),
         required=False,


### PR DESCRIPTION
Short court codes which have subcourts such as ewhc haven't been valid, and this is a problem for the atom feed. 

Fixes #1520 