### PR TITLE
Add structured breadcrumb markup

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlencode
 
 from django.template.response import TemplateResponse
+from django.urls import reverse
 
 
 class RobotsTagMiddleware:
@@ -49,4 +50,24 @@ class FeedbackLinkMiddleware:
             params["court"] = response.context_data["feedback_survey_court"]
 
         response.context_data["feedback_survey_link"] = self.BASE_FEEDBACK_URL + "?" + urlencode(params)
+        return response
+
+
+class StructuredBreadcrumbsMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_template_response(self, request, response):
+        if "breadcrumbs" in response.context_data:
+            response.context_data["structured_breadcrumbs"] = [
+                {"text": "Find Case Law", "url": request.build_absolute_uri(reverse("home"))}
+            ]
+            for breadcrumb in response.context_data["breadcrumbs"]:
+                response.context_data["structured_breadcrumbs"].append(
+                    {"text": breadcrumb["text"], "url": breadcrumb.get("url")}
+                )
+
         return response

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -132,6 +132,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "rollbar.contrib.django.middleware.RollbarNotifierMiddleware",
     "config.middleware.FeedbackLinkMiddleware",
+    "config.middleware.StructuredBreadcrumbsMiddleware",
     "waffle.middleware.WaffleMiddleware",
 ]
 

--- a/ds_judgements_public_ui/templates/includes/breadcrumbs.html
+++ b/ds_judgements_public_ui/templates/includes/breadcrumbs.html
@@ -1,5 +1,22 @@
 {% load waffle_tags %}
 
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {% for breadcrumb in structured_breadcrumbs %}
+        {
+          "@type": "ListItem",
+          "position": {{ forloop.counter }},
+          "name": "{{ breadcrumb.text }}"{% if breadcrumb.url %},
+            "item": "{{ breadcrumb.url }}"{% endif %}
+        }{% if not forloop.last %},{% endif %}
+      {% endfor %}
+    ]
+  }
+</script>
+
 <div class="breadcrumbs">
   <nav class="breadcrumbs__flex-container"
        aria-label="Breadcrumb">


### PR DESCRIPTION
These changes improve how we structure our breadcrumbs, which in turn means we can provide structured [`BreadcrumbList`](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb) data for search engines to better understand our site structure.