### PR TITLE
fix(breadcrumbs): properly build absolute URL for breadcrumbs

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -67,7 +67,10 @@ class StructuredBreadcrumbsMiddleware:
             ]
             for breadcrumb in response.context_data["breadcrumbs"]:
                 response.context_data["structured_breadcrumbs"].append(
-                    {"text": breadcrumb["text"], "url": breadcrumb.get("url")}
+                    {
+                        "text": breadcrumb["text"],
+                        "url": request.build_absolute_uri(breadcrumb["url"]) if "url" in breadcrumb else None,
+                    }
                 )
 
         return response


### PR DESCRIPTION
We weren't correctly building absolute URLs for breadcrumb elements which weren't the root - this is now fixed.