### PR TITLE
feat(search): add structured search markup

### DIFF
--- a/ds_judgements_public_ui/templates/includes/basic_search_form.html
+++ b/ds_judgements_public_ui/templates/includes/basic_search_form.html
@@ -1,4 +1,19 @@
 {% load waffle_tags %}
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "url": "https://caselaw.nationalarchives.gov.uk/",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://caselaw.nationalarchives.gov.uk/judgments/search?query={search_term}"
+      },
+      "query-input": "required name=search_term"
+    }
+  }
+</script>
 {% if v2_homepage %}
   <div class="search-component">
     <div class="search-component__container-beta">


### PR DESCRIPTION
This data allows search engines to discover our search entrypoint, and potentially offer it as part of their own results.