### PR TITLE
FCL-373 | add and style atom feed button to search results

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_result_controls.scss
+++ b/ds_judgements_public_ui/sass/includes/_result_controls.scss
@@ -10,8 +10,12 @@
 
   form {
     display: flex;
-    flex-direction: row;
-    gap: $space-4;
+    flex-direction: column;
+
+    @media (min-width: $grid-breakpoint-extra-large) {
+      flex-direction: row;
+      gap: $space-4;
+    }
 
     > div {
       display: flex;
@@ -37,11 +41,15 @@
 
   &__button {
     @include call-to-action-button;
-    margin: $space-9 0 $space-4 0;
     font-size: $typography-sm-text-size;
     outline-color: $color-dark-blue;
     padding: $space-2 $space-3;
     font-weight: $typography-normal-font-weight;
     vertical-align: 1px;
+    margin: 0;
+
+    @media (min-width: $grid-breakpoint-extra-large) {
+      margin: $space-9 0 $space-4 0;
+    }
   }
 }

--- a/ds_judgements_public_ui/sass/includes/_results.scss
+++ b/ds_judgements_public_ui/sass/includes/_results.scss
@@ -11,7 +11,18 @@
 
   &__result-header {
     @media (min-width: $grid-breakpoint-large) {
+      flex: 1;
       margin-bottom: $space-4;
+    }
+  }
+
+  &__result-atom-feed-button {
+    display: flex;
+    gap: $space-3;
+    align-items: center;
+
+    @media (min-width: $grid-breakpoint-large) {
+      margin-bottom: $space-6;
     }
   }
 
@@ -26,10 +37,14 @@
   &__result-header-container {
     border-bottom: 1px solid $color-yellow;
 
+    display: flex;
+    flex-direction: column;
+    gap: $space-4;
+
     @media (min-width: $grid-breakpoint-extra-large) {
-      display: flex;
       align-items: flex-end;
-      justify-content: space-between;
+      flex-direction: row;
+      gap: $space-6;
     }
   }
 

--- a/ds_judgements_public_ui/templates/includes/result_atom_feed_button.html
+++ b/ds_judgements_public_ui/templates/includes/result_atom_feed_button.html
@@ -1,0 +1,5 @@
+{% load static %}
+<div class="results__result-atom-feed-button">
+  <img src="{% static "fontawesome-svgs/rss.svg" %}" width="20" height="20" alt=""/>
+  <a href="{% url 'search-feed' %}?{{ query_param_string }}" >Subscribe to these results</a>
+</div>

--- a/ds_judgements_public_ui/templates/judgment/results.html
+++ b/ds_judgements_public_ui/templates/judgment/results.html
@@ -24,6 +24,7 @@
         {% if search_results %}
           <div class="results__result-header-container">
             {% include "includes/result_header.html" %}
+            {% include "includes/result_atom_feed_button.html" %}
             {% include "includes/result_controls.html" %}
           </div>
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Add the feed button to search results

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-373

## Screenshots of UI changes:

Desktop:

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/c090ed62-75bd-4b2b-9ebf-1128aef175c8">

Mobile:

<img width="345" alt="image" src="https://github.com/user-attachments/assets/8b6aefc6-aecc-4c57-a307-0e5d31106671">

Mobile use to look like this without the atom feed, which isn't very tidy:

<img width="344" alt="image" src="https://github.com/user-attachments/assets/4280da8e-ff25-460b-8a72-3127a3c261f6">

