### PR TITLE
FCL-387 | fix warning text becoming bold from govuk update

### DIFF
--- a/ds_judgements_public_ui/sass/includes/govuk_overrides/_warning_text.scss
+++ b/ds_judgements_public_ui/sass/includes/govuk_overrides/_warning_text.scss
@@ -24,6 +24,7 @@
 }
 
 .govuk-warning-text {
+  font-weight: $typography-normal-font-weight;
   margin-bottom: 0;
   border: transparent;
   border-left: 0.5rem $color-yellow solid;


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Fixes the unexpected bolding of our warning text when govuk upgrade happened

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-387


## Screenshots of UI changes:

### Before

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/d5ebbca5-1431-45be-9b63-e8f4b7a0a6c0">


### After

<img width="1201" alt="image" src="https://github.com/user-attachments/assets/6d283b69-f253-4e70-9242-94390623dc27">
