### PR TITLE
Tidy up inconsistent/missing page metadata in HTML headers

### DIFF
--- a/config/views/static.py
+++ b/config/views/static.py
@@ -6,7 +6,7 @@ from .template_view_with_context import TemplateViewWithContext
 
 class AboutThisServiceView(TemplateViewWithContext):
     template_name = "pages/about_this_service.html"
-    page_title = "About this service"
+    page_title = "About Find Case Law"
     page_canonical_url_name = "about_this_service"
     page_allow_index = True
 
@@ -14,6 +14,9 @@ class AboutThisServiceView(TemplateViewWithContext):
         context = super().get_context_data(**kwargs)
         context["courts"] = courts.get_listable_groups()
         context["feedback_survey_type"] = "support"
+        context["breadcrumbs"] = [
+            {"text": self.page_title},
+        ]
         return context
 
 
@@ -31,7 +34,7 @@ class AccessibilityStatementView(TemplateViewWithContext):
         )
         context["breadcrumbs"] = [
             {"url": reverse("terms_and_policies"), "text": "Terms and policies"},
-            {"text": "Accessibility statement"},
+            {"text": self.page_title},
         ]
         return context
 
@@ -68,6 +71,10 @@ class CourtsAndTribunalsInFclView(TemplateViewWithContext):
         context["page_description"] = (
             "Find out which courts and tribunals publish judgments and decisions on the Find Case Law service."
         )
+        context["breadcrumbs"] = [
+            {"url": reverse("about_this_service"), "text": "About Find Case Law"},
+            {"text": "Courts and tribunals in Find Case Law"},
+        ]
         return context
 
 
@@ -83,6 +90,9 @@ class HelpAndGuidanceView(TemplateViewWithContext):
         context["page_description"] = (
             "A list of help and guidance available on the Find Case Law service. We do not offer legal advice or research services."
         )
+        context["breadcrumbs"] = [
+            {"text": self.page_title},
+        ]
         return context
 
 
@@ -114,6 +124,9 @@ class HowToUseThisService(TemplateViewWithContext):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["feedback_survey_type"] = "support"
+        context["breadcrumbs"] = [
+            {"text": self.page_title},
+        ]
         return context
 
 
@@ -126,6 +139,9 @@ class OpenJusticeLicenceView(TemplateViewWithContext):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["feedback_survey_type"] = "license"
+        context["breadcrumbs"] = [
+            {"text": self.page_title},
+        ]
         return context
 
 
@@ -141,6 +157,9 @@ class PrivacyNotice(TemplateViewWithContext):
         context["page_description"] = (
             "Read our privacy notice to understand more about personal data in judgments and decisions on the Find Case Law service."
         )
+        context["breadcrumbs"] = [
+            {"text": self.page_title},
+        ]
         return context
 
 
@@ -175,6 +194,9 @@ class TermsAndPoliciesView(TemplateViewWithContext):
         context["page_description"] = (
             "A list of the Find Case Law service’s terms and policies including the accessibility statement, publishing policy and terms of use."
         )
+        context["breadcrumbs"] = [
+            {"text": self.page_title},
+        ]
         return context
 
 

--- a/ds_judgements_public_ui/templates/judgment/press_summaries/list.html
+++ b/ds_judgements_public_ui/templates/judgment/press_summaries/list.html
@@ -1,9 +1,5 @@
 {% extends "layouts/base.html" %}
 {% load document_utils waffle_tags %}
-{% block title %}
-  {% if page_title %}{{ page_title }} -{% endif %}
-  Find Case Law
-{% endblock title %}
 {% block precontent %}
   <div class="judgment-toolbar">
     <div class="judgment-toolbar__container">

--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -19,9 +19,7 @@
       <link rel="canonical" href="{{ page_canonical_url }}" />
     {% endif %}
     <title>
-      {% block title %}
-      {% endblock title %}
-      - The National Archives
+      {% block title %}{% if page_title %}{{ page_title }} - {% endif %}Find Case Law{% endblock title %} - The National Archives
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="{% static 'images/favicons/favicon.png' %}" />

--- a/ds_judgements_public_ui/templates/layouts/static_content.html
+++ b/ds_judgements_public_ui/templates/layouts/static_content.html
@@ -1,7 +1,4 @@
 {% extends "layouts/base.html" %}
-{% block title %}
-  {% if page_title %}{{ page_title }} -{% endif %} Find Case Law
-{% endblock title %}
 {% block content %}
   <div class="standard-text-template container py-3">
     <div id="start-of-document" class="entry-content clearfix">

--- a/ds_judgements_public_ui/templates/pages/court_or_tribunal.html
+++ b/ds_judgements_public_ui/templates/pages/court_or_tribunal.html
@@ -1,10 +1,5 @@
 {% extends "layouts/base.html" %}
 {% load court_utils %}
-{% block title %}
-  {% if page_title %}
-    {{ page_title }}
-  {% endif %}
-{% endblock title %}
 {% block content %}
   <div class="container court-or-tribunal">
     <div class="court-or-tribunal__crest">

--- a/ds_judgements_public_ui/templates/pages/courts_and_tribunals.html
+++ b/ds_judgements_public_ui/templates/pages/courts_and_tribunals.html
@@ -1,8 +1,4 @@
 {% extends "layouts/base.html" %}
-{% block title %}
-  {% if page_title %}{{ page_title }} -{% endif %}
-  Judgements and decisions by court or tribunal
-{% endblock title %}
 {% block content %}
   <div class="courts-and-tribunals container">
     <div>

--- a/ds_judgements_public_ui/templates/pages/home.html
+++ b/ds_judgements_public_ui/templates/pages/home.html
@@ -7,9 +7,6 @@
 {% block robots %}
   <meta name="robots" content="nosnippet" />
 {% endblock robots %}
-{% block title %}
-  Find Case Law
-{% endblock title %}
 {% block header %}
 
   {% if variant_homepage %}

--- a/e2e_tests/test_about_page.py
+++ b/e2e_tests/test_about_page.py
@@ -9,4 +9,4 @@ def test_about_page(page: Page):
     """
     page.goto("/about-this-service")
 
-    expect(page).to_have_title("About this service - Find Case Law - The National Archives")
+    expect(page).to_have_title("About Find Case Law - Find Case Law - The National Archives")

--- a/transactional_licence_form/views.py
+++ b/transactional_licence_form/views.py
@@ -129,6 +129,7 @@ class StartView1(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["page_title"] = "Re-use Find Case Law records"
         context["page_description"] = (
             "Find out about the Open Justice licensing framework and how to apply for a license to do computational analysis across judgments and decisions on the Find Case Law service."
         )

--- a/transactional_licence_form/views.py
+++ b/transactional_licence_form/views.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import SuspiciousOperation
 from django.shortcuts import redirect, render
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
@@ -111,10 +112,19 @@ class FormWizardView(NamedUrlSessionWizardView):
 
     def get_context_data(self, form, **kwargs):
         context = super(FormWizardView, self).get_context_data(form)
+
+        context["page_title"] = "Apply for a licence"
+        context["breadcrumbs"] = [
+            {"url": reverse("about_this_service"), "text": "About Find Case Law"},
+            {"url": reverse("transactional-licence-form"), "text": "Re-use Find Case Law records"},
+            {"text": "Apply for a licence"},
+        ]
+
         context["all_data"] = self.get_all_cleaned_data_by_form()
         context["all_field_names"] = self.get_all_field_names()
         context["all_forms"] = self.get_all_forms()
         context["reviewing"] = self.in_review()
+
         return context
 
     def done(self, form_list, **kwargs):
@@ -133,19 +143,56 @@ class StartView1(TemplateView):
         context["page_description"] = (
             "Find out about the Open Justice licensing framework and how to apply for a license to do computational analysis across judgments and decisions on the Find Case Law service."
         )
+        context["page_allow_index"] = True
+        context["breadcrumbs"] = [
+            {"url": reverse("about_this_service"), "text": "About Find Case Law"},
+            {"text": "Re-use Find Case Law records"},
+        ]
         return context
 
 
 class StartView2(TemplateView):
     template_name = "start2.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Licence application process"
+        context["page_allow_index"] = True
+        context["breadcrumbs"] = [
+            {"url": reverse("about_this_service"), "text": "About Find Case Law"},
+            {"url": reverse("transactional-licence-form"), "text": "Re-use Find Case Law records"},
+            {"text": "Licence application process"},
+        ]
+        return context
+
 
 class StartView3(TemplateView):
     template_name = "start3.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "What you need to apply for a licence"
+        context["page_allow_index"] = True
+        context["breadcrumbs"] = [
+            {"url": reverse("about_this_service"), "text": "About Find Case Law"},
+            {"url": reverse("transactional-licence-form"), "text": "Re-use Find Case Law records"},
+            {"text": "What you need to apply for a licence"},
+        ]
+        return context
+
 
 class ConfirmationView(TemplateView):
     template_name = "confirmation.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["page_title"] = "Apply for a licence"
+        context["breadcrumbs"] = [
+            {"url": reverse("about_this_service"), "text": "About Find Case Law"},
+            {"url": reverse("transactional-licence-form"), "text": "Re-use Find Case Law records"},
+            {"text": "Apply for a licence"},
+        ]
+        return context
 
 
 def wizard_view(url_name):


### PR DESCRIPTION
This PR brushes up some inconsistencies and missing behaviours in page (particularly static page) metadata.