### PR TITLE
[FLC-407] Old-style tribunal URLs now redirect with correct query parameter

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -15,6 +15,7 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.feedgenerator import Atom1Feed
 
+from .forms.search_forms import TRIBUNAL_CHOICES
 from .utils import api_client, paginator
 from .utils.search_request_to_parameters import search_request_to_parameters
 
@@ -38,7 +39,10 @@ def redirect_atom_feed(
     new_parameters = {}
     court_query = "/".join(filter(lambda x: x is not None, [court, subdivision]))  # type: ignore[arg-type]
     if court_query:
-        new_parameters["court"] = court_query
+        if court_query in TRIBUNAL_CHOICES.keys():
+            new_parameters["tribunal"] = court_query
+        else:
+            new_parameters["court"] = court_query
     if year:
         new_parameters["from"] = f"{year}-01-01"
         new_parameters["to"] = f"{year}-12-31"

--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -112,6 +112,10 @@ class TestAtomFeed(TestCase):
         response = self.client.get("/ewhc/atom.xml")
         assert response.url == "/atom.xml?court=ewhc"  # type: ignore[attr-defined]
 
+    def test_redirect_tribunal(self):
+        response = self.client.get("/eat/atom.xml")
+        assert response.url == "/atom.xml?tribunal=eat"  # type: ignore[attr-defined]
+
     def test_redirect_year_only(self):
         response = self.client.get("/2024/atom.xml")
         assert response.url == "/atom.xml?from=2024-01-01&to=2024-12-31"  # type: ignore[attr-defined]


### PR DESCRIPTION
We were redirecting all old tribunal URLs to use the `court` parameter instead of the correct `tribunal` parameter.

## Jira

FCL-407
