### PR TITLE
[FCL-386] Migrate to using in-app XSLT rather than MarkLogic

### DIFF
--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -1,6 +1,6 @@
 from os import environ
 from typing import Optional
-from unittest.mock import Mock, patch
+from unittest.mock import call, patch
 
 import pytest
 from caselawclient.errors import DocumentNotFoundError
@@ -51,15 +51,15 @@ class TestJudgment(TestCase):
     @patch("judgments.views.detail.detail_html.DocumentPdf")
     @patch("judgments.views.detail.detail_html.get_published_document_by_uri")
     def test_query_passed_to_api_client(self, mock_get_document_by_uri, mock_pdf):
-        judgment = Mock()
-        judgment.is_published = True
-        judgment.uri = "test/2023/123"
+        judgment = JudgmentFactory.build()
 
         mock_get_document_by_uri.return_value = judgment
-        mock_pdf.return_value.size = 1234
 
         response = self.client.get("/test/2023/123?query=Query")
-        judgment.content_as_html.assert_called_with("", query="Query")
+
+        assert mock_get_document_by_uri.mock_calls[0] == call(
+            "test/2023/123", search_query="Query"
+        )  # We do make subsequent calls as part of getting related documents, but they're not relevant here
 
         self.assertEqual(response.status_code, 200)
 

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -1,4 +1,5 @@
 from os import environ
+from typing import Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -236,7 +237,7 @@ class TestViewRelatedDocumentButton:
         THEN the response should contain a button linking to the related document
         """
 
-        def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False):
+        def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False, search_query: Optional[str] = None):
             if document_uri not in [uri, expected_href]:
                 raise DocumentNotFoundError()
             return document_class_factory.build(uri=document_uri, is_published=True)
@@ -283,7 +284,7 @@ class TestViewRelatedDocumentButton:
         THEN the response should contain a button linking to the related document
         """
 
-        def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False):
+        def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False, search_query: Optional[str] = None):
             if document_uri not in [uri, expected_href]:
                 raise DocumentNotFoundError()
             return document_class_factory.build(uri=document_uri, is_published=True)
@@ -318,7 +319,7 @@ class TestViewRelatedDocumentButton:
         THEN the response should not contain a button linking to the related judgment
         """
 
-        def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False):
+        def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False, search_query: Optional[str] = None):
             return JudgmentFactory.build(uri=document_uri, is_published=True, document_noun="press summary")
 
         mock_get_document_by_uri.side_effect = get_document_by_uri_side_effect
@@ -343,7 +344,7 @@ class TestBreadcrumbs:
         AND an additional `Press Summary` breadcrumb
         """
 
-        def pj(uri, cache_if_not_found=False):
+        def get_document_by_uri_side_effect(uri, cache_if_not_found=False, search_query: Optional[str] = None):
             if "press" in uri:
                 return PressSummaryFactory.build(
                     uri="eat/2023/1/press-summary/1",
@@ -361,7 +362,7 @@ class TestBreadcrumbs:
                     ),
                 )
 
-        mock_get_document_by_uri.side_effect = pj
+        mock_get_document_by_uri.side_effect = get_document_by_uri_side_effect
 
         response = self.client.get("/eat/2023/1/press-summary/1")
         judgment_breadcrumb_html = """
@@ -415,7 +416,7 @@ class TestBreadcrumbs:
         THEN the response should contain breadcrumbs including the appropriate error reference
         """
 
-        def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False):
+        def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False, search_query: Optional[str] = None):
             raise http_error()
 
         mock_get_document_by_uri.side_effect = get_document_by_uri_side_effect
@@ -437,7 +438,7 @@ class TestDocumentHeadings(TestCase):
         AND a p tag subheading with the related judgment's NCN
         """
 
-        def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False):
+        def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False, search_query: Optional[str] = None):
             if document_uri == "eat/2023/1/press-summary/1":
                 return PressSummaryFactory.build(
                     uri="eat/2023/1/press-summary/1",
@@ -501,7 +502,7 @@ class TestHTMLTitle(TestCase):
         summary name and "- Find Case Law - The National Archives"
         """
 
-        def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False):
+        def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False, search_query: Optional[str] = None):
             if document_uri == "eat/2023/1/press-summary/1":
                 return JudgmentFactory.build(
                     uri="eat/2023/1/press-summary/1",

--- a/judgments/utils/judgment_utils.py
+++ b/judgments/utils/judgment_utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from caselawclient.errors import DocumentNotFoundError, MarklogicNotPermittedError
 from caselawclient.models.documents import Document, DocumentURIString
 from django.http import Http404
@@ -5,9 +7,11 @@ from django.http import Http404
 from .utils import get_document_by_uri
 
 
-def get_published_document_by_uri(document_uri: DocumentURIString, cache_if_not_found: bool = False) -> Document:
+def get_published_document_by_uri(
+    document_uri: DocumentURIString, cache_if_not_found: bool = False, search_query: Optional[str] = None
+) -> Document:
     try:
-        document = get_document_by_uri(document_uri, cache_if_not_found=cache_if_not_found)
+        document = get_document_by_uri(document_uri, cache_if_not_found=cache_if_not_found, search_query=search_query)
         if not document:
             raise Http404(f"Document {document_uri} was not found")
     except DocumentNotFoundError:

--- a/judgments/views/detail/detail_html.py
+++ b/judgments/views/detail/detail_html.py
@@ -33,7 +33,10 @@ if os.environ.get("SHOW_WEASYPRINT_LOGS") != "True":
 
 def detail_html(request, document_uri):
     query = request.GET.get("query")
-    document = get_published_document_by_uri(document_uri)
+
+    cleaned_search_query = preprocess_query(query) if query is not None else None
+
+    document = get_published_document_by_uri(document_uri, search_query=cleaned_search_query)
     pdf = DocumentPdf(document_uri)
 
     # If the document_uri which was requested isn't the canonical URI of the document, redirect the user

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-environ==0.11.2 # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 requests~=2.32.2
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=27.1.0
+ds-caselaw-marklogic-api-client~=27.3.0
 ds-caselaw-utils==2.0.0
 rollbar
 django-weasyprint==2.3.0


### PR DESCRIPTION
Now that we're able to run the latest version of the API client with the XSLT no longer relying on MarkLogic, change PUI to run XSLT transforms that way.

## Jira

FCL-386
