### PR TITLE
Fix | show the H2 on no no no message when there are some results at …

### DIFF
--- a/ds_judgements_public_ui/templates/judgment/results.html
+++ b/ds_judgements_public_ui/templates/judgment/results.html
@@ -30,11 +30,13 @@
 
           <div class="results__result-list-container">
             {% include "includes/results_list.html" %}
-            {% if not paginator.has_next_page %}
-              {% include "includes/no_results_message.html" with title="End of results" %}
-            {% endif %}
-            {% include "includes/pagination.html" %}
           </div>
+
+          {% if not paginator.has_next_page %}
+            {% include "includes/no_results_message.html" with title="End of results" %}
+          {% endif %}
+
+          {% include "includes/pagination.html" %}
         {% else %}
           {% include "includes/no_results_message.html" %}
         {% endif %}


### PR DESCRIPTION
## Changes in this PR:

If we move the markup around, the hidden h2 styling doesn't get applied to this H2

## JIRA

https://national-archives.atlassian.net/browse/FCL-185


## Screenshots of UI changes:

![localhost_3000_judgments_search_query=Nebahat](https://github.com/user-attachments/assets/247dad85-6791-4a54-8e42-2311a62dd12e)
