### PR TITLE
Fcl 185 fix no matching results on last page

### DIFF
--- a/ds_judgements_public_ui/templates/judgment/results.html
+++ b/ds_judgements_public_ui/templates/judgment/results.html
@@ -30,11 +30,13 @@
 
           <div class="results__result-list-container">
             {% include "includes/results_list.html" %}
-            {% if not paginator.has_next_page %}
-              {% include "includes/no_results_message.html" with title="End of results" %}
-            {% endif %}
-            {% include "includes/pagination.html" %}
           </div>
+
+          {% if not paginator.has_next_page %}
+            {% include "includes/no_results_message.html" with title="End of results" %}
+          {% endif %}
+
+          {% include "includes/pagination.html" %}
         {% else %}
           {% include "includes/no_results_message.html" %}
         {% endif %}

--- a/ds_judgements_public_ui/templates/judgment/results.html
+++ b/ds_judgements_public_ui/templates/judgment/results.html
@@ -21,7 +21,7 @@
           {% url "about_this_service" as url_value %}
           {% include "includes/advice_message.html" with message=date_warning url_text="Find out what records are available on this service." url_value=url_value url_anchor="section-coverage" %}
         {% endif %}
-        {% if search_results %}
+        {% if total > 0 %}
           <div class="results__result-header-container">
             {% include "includes/result_header.html" %}
             {% include "includes/result_atom_feed_button.html" %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

* Ensure that the logic selecting the title operates on "there are no results", not "there are no results for this page"
* Move the class so the h2 tag isn't hidden.

<img width="1202" alt="image" src="https://github.com/user-attachments/assets/e3d3f4be-a5f3-49ac-9238-0e11236752cb">

Based on 

https://github.com/nationalarchives/ds-caselaw-public-ui/pull/1598

## Jira card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
