### PR TITLE
fix: put js feature flags back

### DIFF
--- a/ds_judgements_public_ui/templates/includes/waffle_flags_javascript.html
+++ b/ds_judgements_public_ui/templates/includes/waffle_flags_javascript.html
@@ -1,0 +1,7 @@
+<script id="waffle-flags" type="text/javascript">
+  window.waffleFlags = [
+    {% for flag, is_active in waffle_flags.items %}
+      {"{{ flag }}": {% if is_active %}true{% else %}false{% endif %}},
+    {% endfor %}
+  ]
+</script>

--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -100,6 +100,7 @@
     {% block javascript %}
       <script type="module" defer src="{% static 'js/dist/app.js' %}"></script>
       <script defer src="{% static 'js/dist/cookie_consent.js' %}"></script>
+      {% include "includes/waffle_flags_javascript.html" %}
     {% endblock javascript %}
   </body>
 </html>


### PR DESCRIPTION
## Changes in this PR:

These are being used by paragraph linking, but also handy to have for any further JS flag related stuff we want to do.
