### PR TITLE
Fcl 190 add facet year to date warning

### DIFF
--- a/judgments/tests/fixtures.py
+++ b/judgments/tests/fixtures.py
@@ -66,6 +66,11 @@ class FakeSearchResponseNoFacets(FakeSearchResponseBaseClass):
     facets = {}
 
 
+class FakeSearchResponseWithFacets(FakeSearchResponseBaseClass):
+    total = 9999
+    facets = {"2010": "9", "2011": "99", "EWCOP": "999", "": "1"}
+
+
 class FakeSearchResponseNoResults(FakeSearchResponseBaseClass):
     total = 0
     results = []

--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -11,6 +11,7 @@ from judgments.tests.fixtures import (
     FakeSearchResponse,
     FakeSearchResponseNoFacets,
     FakeSearchResponseNoResults,
+    FakeSearchResponseWithFacets,
 )
 from judgments.tests.utils.assertions import (
     assert_contains_html,
@@ -147,18 +148,21 @@ class TestSearchResults(TestCase):
         AND the from_date is before `settings.MINIMUM_WARNING_YEAR`
         AND there's no search results
         THEN the response should contain the expected warning
+        AND it should contain facet info
 
         The expected applied filters HTML:
         - Includes a div with class `govuk-warning-text` and correct warning text
         """
-        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponseWithFacets()
 
-        response = self.client.get("/judgments/search?from_date_0=1&from_date_1=1&from_date_2=1444")
+        response = self.client.get("/judgments/search?query=cat&from_date_0=1&from_date_1=1&from_date_2=1444")
 
         expected_text = """
                 1444 is before 2003, the date of the oldest record on the Find Case Law service.
+                Showing matching results from 2010.  Find out what records are available on this service.
         """
         xpath_query = "//div[@class='govuk-warning-text__text']"
+
         assert_response_contains_text(response, expected_text, xpath_query)
 
     @patch("judgments.views.advanced_search.api_client")

--- a/judgments/tests/utils/assertions.py
+++ b/judgments/tests/utils/assertions.py
@@ -42,10 +42,16 @@ def is_contained(container_tree, contained_tree):
     )
 
 
-def is_contained_by_xpath(container_tree, xpath_query, contained_text):
+def xpath_contents(container_tree, xpath_query):
     elements = container_tree.xpath(xpath_query)
 
-    return any(normalise_text(contained_text) in normalise_text(element.text_content()) for element in elements)
+    return [normalise_text(element.text_content()) for element in elements]
+
+
+def is_contained_by_xpath(container_tree, xpath_query, contained_text):
+    normalised_elements = xpath_contents(container_tree, xpath_query)
+
+    return any(normalise_text(contained_text) in normalised_element for normalised_element in normalised_elements)
 
 
 def response_contains_html(response, contained_html):
@@ -64,7 +70,10 @@ def assert_not_contains_html(response, contained_html):
 
 def assert_response_contains_text(response, contained_text, xpath_query):
     container_tree = parse_html(response.content.decode())
-    assert is_contained_by_xpath(container_tree, xpath_query, contained_text)
+    if not is_contained_by_xpath(container_tree, xpath_query, contained_text):
+        raise AssertionError(
+            f"{contained_text} not found in xpath results {xpath_contents(container_tree, xpath_query)}"
+        )
 
 
 def assert_response_not_contains_text(response, contained_text, xpath_query):

--- a/judgments/utils/search_utils.py
+++ b/judgments/utils/search_utils.py
@@ -16,7 +16,7 @@ def _valid_years():
     Generate a list of valid years as strings.
     """
     today = datetime.date.today()
-    valid_years = range(2003, today.year)
+    valid_years = range(2003, today.year + 1)
     return [f"{year}" for year in valid_years]
 
 


### PR DESCRIPTION
.
<!-- Amend as appropriate -->

## Changes in this PR:

* Tell the user what year our earliest document matching their search query is.
* Fix an off-by-one error which meant the current year could never be a year facet
* Make an assertion helper raise a useful error message

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136?selectedIssue=FCL-190

## Screenshots of UI changes:

### After

<img width="1212" alt="image" src="https://github.com/user-attachments/assets/68e8b062-059a-4059-aef9-a0601e58a369">
