### PR TITLE
Spike: Add stub document details box behind feature flag

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_catalogue_card.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_catalogue_card.scss
@@ -1,0 +1,17 @@
+.catalogue-card {
+  &__table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: $space-4 0;
+
+    th,
+    td {
+      padding: $space-2;
+      border: 1px solid $color-dark-grey;
+    }
+
+    th {
+      text-align: left;
+    }
+  }
+}

--- a/ds_judgements_public_ui/sass/main.scss
+++ b/ds_judgements_public_ui/sass/main.scss
@@ -61,6 +61,7 @@ $govuk-focus-colour: $color-focus-blue-outline;
 // Judgments
 @import "includes/judgment_document_paragraph_anchors";
 @import "includes/judgment_text_download_options";
+@import "includes/judgment_catalogue_card";
 @import "includes/judgment_text_end_document_marker";
 @import "includes/judgment_text_service_introduction";
 @import "includes/judgment_text_source";

--- a/ds_judgements_public_ui/templates/includes/judgment_catalogue_card.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_catalogue_card.html
@@ -1,0 +1,14 @@
+{% load court_utils %}
+<div class="container catalogue-card">
+    <h2>Document details</h2>
+
+    <table class="catalogue-card__table">
+        <tr><th>Title</th><td>{{ document.body.name }}</td></tr>
+        <tr><th>Document type</th><td>{{ document.document_noun|capfirst }}</td></tr>
+        <tr><th>Court</th><td>{{ document.body.court|get_court_name }}</td></tr>
+        <tr><th>Handed down</th><td>{{ document.body.document_date_as_string }}</td></tr>
+        {% if document.neutral_citation %}<tr><th>Neutral Citation Number</th><td>{{ document.neutral_citation }}</td></tr>{% endif %}
+        <tr><th>Citable URL</th><td>{{ document.public_uri }}</td></tr>
+    </table>
+
+</div>

--- a/ds_judgements_public_ui/templates/judgment/detail.html
+++ b/ds_judgements_public_ui/templates/judgment/detail.html
@@ -24,4 +24,5 @@
 {% endblock content %}
 {% block postcontent %}
   {% include "includes/judgment_text_download_options.html" %}
+  {% flag "document_catalogue_card" %}{% include "includes/judgment_catalogue_card.html" %}{% endflag %}
 {% endblock postcontent %}


### PR DESCRIPTION
This is a very simple table providing some document information which isn't immediately available on the document page without digging into the XML, such as court name and hand-down date. It is hidden behind the `document_catalogue_card` flag.

## Screenshots

![Capture-2024-11-13-161337](https://github.com/user-attachments/assets/326aa605-3ad8-4ed2-b432-22d53a9f36da)
![Capture-2024-11-13-161316](https://github.com/user-attachments/assets/84ed7620-8158-42fa-a87e-a6e1f4f73cb6)
![Capture-2024-11-13-161258](https://github.com/user-attachments/assets/f28ff905-44a0-4514-8a3c-40ca0936b486)
