### PR TITLE
Trailing slash on document 404s rather than 500

### DIFF
--- a/judgments/resolvers/document_resolver_engine.py
+++ b/judgments/resolvers/document_resolver_engine.py
@@ -1,5 +1,8 @@
 from typing import Optional
 
+from caselawclient.models.documents import DocumentURIString
+from caselawclient.models.documents.exceptions import InvalidDocumentURIException
+from django.http import Http404
 from django.http.request import HttpRequest
 from django.views.generic import View
 
@@ -24,6 +27,12 @@ class DocumentResolverEngine(View):
         component_lookup = {
             "press-summary": press_summaries,
         }
+
+        try:
+            document_uri = DocumentURIString(document_uri)
+        except InvalidDocumentURIException:
+            raise Http404("Document Resolver recieved an invalid DocumentURIString")
+
         if file_format:
             return fileformat_lookup[file_format](request, document_uri)
 

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -6,7 +6,7 @@ import pytest
 from caselawclient.errors import DocumentNotFoundError
 from caselawclient.factories import DocumentBodyFactory, JudgmentFactory, PressSummaryFactory
 from caselawclient.models.documents import DocumentURIString
-from django.http import Http404, HttpResponseRedirect
+from django.http import Http404
 from django.template.defaultfilters import filesizeformat
 from django.test import Client, TestCase
 
@@ -162,18 +162,6 @@ class TestDocumentDownloadOptions:
         </div>
         """
         assert_contains_html(response, download_options_html)
-
-
-class TestDocumentURIRedirects(TestCase):
-    @patch("judgments.views.detail.detail_html.get_published_document_by_uri")
-    def test_non_canonical_uri_redirects(self, mock_get_document_by_uri):
-        mock_get_document_by_uri.return_value = JudgmentFactory.build(
-            uri=DocumentURIString("test/1234/567"), is_published=True
-        )
-        response = self.client.get("/test/1234/567/")
-        assert isinstance(response, HttpResponseRedirect)
-        assert response.status_code == 302
-        assert response.url == "/test/1234/567"
 
 
 class TestPressSummaryLabel(TestCase):

--- a/judgments/tests/test_url_resolution.py
+++ b/judgments/tests/test_url_resolution.py
@@ -1,0 +1,7 @@
+from django.test import TestCase
+
+
+class TestURLResolution(TestCase):
+    def test_trailing_slash(self):
+        response = self.client.get("/test/2023/123/")
+        assert response.status_code == 404


### PR DESCRIPTION
Previously we redirected URLs ending in /, but currently they're 500ing. 404ing is at least a better approach.