### PR TITLE
fix service header text breakage and link hover

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_header.scss
+++ b/ds_judgements_public_ui/sass/includes/_header.scss
@@ -34,4 +34,15 @@
       margin-right: 11rem;
     }
   }
+
+  &__tna-logo-link {
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+
+    @media only screen and (max-width: $grid-breakpoint-medium) {
+      width: 70px;
+      height: 70px;
+    }
+  }
 }

--- a/ds_judgements_public_ui/sass/includes/_service_introduction.scss
+++ b/ds_judgements_public_ui/sass/includes/_service_introduction.scss
@@ -19,6 +19,11 @@
     font-weight: normal;
     line-height: $typography-md-line-height;
     color: colour-var("contrast-font-base");
+    text-wrap: nowrap;
+
+    @media only screen and (max-width: $grid-breakpoint-small) {
+      font-size: $typography-xl-text-size;
+    }
   }
 
   &__helper-text {

--- a/ds_judgements_public_ui/templates/includes/logo.html
+++ b/ds_judgements_public_ui/templates/includes/logo.html
@@ -1,5 +1,5 @@
 {% load static %}
-<a href="https://www.nationalarchives.gov.uk">
+<a class="page-header__tna-logo-link" href="https://www.nationalarchives.gov.uk">
   <img class="page-header__tna-logo"
        src="{% static 'images/logo.svg' %}"
        alt="The National Archives home page"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Fix service text in header and logo and menu hover links
## Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136?selectedIssue=FCL-488
## Screenshots of UI changes:

### Before
Service text
[before-service-text.webm](https://github.com/user-attachments/assets/aa901324-53cb-4d2d-a960-82b5838da819)
Links hover menu and logo
[before-link-hover.webm](https://github.com/user-attachments/assets/5f9c1c51-77ac-43db-9949-6b99fa1fc342)

### After
Service text
[after-service-text-break.webm](https://github.com/user-attachments/assets/5d51862d-a980-4ff2-b5f2-bb12d87a2b9f)
Links hover menu and logo
[after-link-hover.webm](https://github.com/user-attachments/assets/36fc3656-d58b-4889-b8dc-1c1598a1a1c3)

- [ ] Requires env variable(s) to be updated

