### PR TITLE
Resolve base page

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
@@ -25,7 +25,7 @@
     </div>
     <div class="judgment-download-options__download-option">
       <h3>
-        <a href="{% formatted_document_uri document.uri 'xml' %}"
+        <a href="{% formatted_document_uri request.path 'xml' %}"
            aria-label="Download {{ document|get_title_to_display_in_html }} as XML">
           {% if document.document_noun == 'press summary' %}
             Download this press summary as XML

--- a/ds_judgements_public_ui/templates/judgment/disambiguation.html
+++ b/ds_judgements_public_ui/templates/judgment/disambiguation.html
@@ -1,0 +1,16 @@
+{% extends "layouts/base.html" %}
+{% block title %}
+  Multiple matches - Find Case Law
+{% endblock title %}
+{% block content %}
+  <h1>Multiple matches</h1>
+  <p>There were multiple results for an identifier of {{ uri }}.</p>
+  <h3>Choices</h3>
+  (This should all be SQID)
+  <ul>
+    {% for resolution in resolutions %}
+      <li><a href="{{ resolution.identifier_uuid }}{{ file_format }}">{{ resolution.identifier_uuid }}</a></li>
+    {% endfor %}
+  </ul>
+  <p>{{ resolutions }}</p>
+{% endblock content %}

--- a/judgments/resolvers/document_resolver_engine.py
+++ b/judgments/resolvers/document_resolver_engine.py
@@ -37,6 +37,8 @@ class IdentifierResolverEngine(View):
             "press-summary": press_summaries,
         }
 
+        if document_uri[-1] == "/":
+            raise Http404("Paths cannot end with a slash")
         resolutions = api_client.resolve_from_identifier(document_uri)
         if not resolutions:
             msg = f"No resolutions for {document_uri}"

--- a/judgments/resolvers/document_resolver_engine.py
+++ b/judgments/resolvers/document_resolver_engine.py
@@ -11,7 +11,7 @@ from judgments.views.detail import best_pdf, detail_html, detail_xml, generated_
 from judgments.views.press_summaries import press_summaries
 
 
-class MarklogicInDocumentClothing(str):
+class MarklogicInDocumentClothing(DocumentURIString):
     def __new__(self, value):
         return value.strip("/").replace(".xml", "")
 

--- a/judgments/resolvers/document_resolver_engine.py
+++ b/judgments/resolvers/document_resolver_engine.py
@@ -6,8 +6,53 @@ from django.http import Http404
 from django.http.request import HttpRequest
 from django.views.generic import View
 
+from judgments.utils.utils import api_client
 from judgments.views.detail import best_pdf, detail_html, detail_xml, generated_pdf
 from judgments.views.press_summaries import press_summaries
+
+
+class MarklogicInDocumentClothing(str):
+    def __new__(self, value):
+        return value.strip("/").replace(".xml", "")
+
+
+class IdentifierResolverEngine(View):
+    # TODO: make this not just a copy-paste
+
+    def dispatch(
+        self,
+        request: HttpRequest,
+        document_uri: str,
+        file_format: Optional[str] = None,
+        component: Optional[str] = None,
+    ):
+        fileformat_lookup = {
+            "data.pdf": best_pdf,
+            "generated.pdf": generated_pdf,
+            "data.xml": detail_xml,
+            "data.html": detail_html,
+        }
+        component_lookup = {
+            "press-summary": press_summaries,
+        }
+
+        resolutions = api_client.resolve_from_identifier(document_uri)
+        if len(resolutions) == 0:
+            msg = f"No resolutions for {document_uri}"
+            raise Http404(msg)
+        if len(resolutions) > 1:
+            msg = f"Too many resolutions for {document_uri}"
+            raise Http404(msg)
+
+        resolution_uri = MarklogicInDocumentClothing(resolutions[0].document_uri)
+
+        if file_format:
+            return fileformat_lookup[file_format](request, resolution_uri)
+
+        if component:
+            return component_lookup[component](request, resolution_uri)
+
+        return detail_html(request, resolution_uri)
 
 
 class DocumentResolverEngine(View):

--- a/judgments/resolvers/document_resolver_engine.py
+++ b/judgments/resolvers/document_resolver_engine.py
@@ -8,6 +8,7 @@ from django.views.generic import View
 
 from judgments.utils.utils import api_client
 from judgments.views.detail import best_pdf, detail_html, detail_xml, generated_pdf
+from judgments.views.disambiguation import DisambiguationView
 from judgments.views.press_summaries import press_summaries
 
 
@@ -37,12 +38,13 @@ class IdentifierResolverEngine(View):
         }
 
         resolutions = api_client.resolve_from_identifier(document_uri)
-        if len(resolutions) == 0:
+        if not resolutions:
             msg = f"No resolutions for {document_uri}"
             raise Http404(msg)
         if len(resolutions) > 1:
-            msg = f"Too many resolutions for {document_uri}"
-            raise Http404(msg)
+            return DisambiguationView.as_view()(
+                request, uri=document_uri, resolutions=resolutions, file_format=file_format
+            )
 
         resolution_uri = MarklogicInDocumentClothing(resolutions[0].document_uri)
 

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -25,7 +25,7 @@ class IdentifierResolutionsFactory:
         return IdentifierResolutions(
             [
                 IdentifierResolution(
-                    identifier_uuid=f"id-{uuid}",
+                    identifier_uuid=f"id-{identifier_uuid}",
                     document_uri=MarkLogicDocumentURIString(uri),
                     identifier_slug=DocumentURIString(slug),
                     document_published=True,

--- a/judgments/tests/factories.py
+++ b/judgments/tests/factories.py
@@ -1,3 +1,8 @@
+import uuid
+
+from caselawclient.identifier_resolution import IdentifierResolution, IdentifierResolutions
+from caselawclient.models.documents import DocumentURIString
+from caselawclient.xquery_type_dicts import MarkLogicDocumentURIString
 from factory.django import DjangoModelFactory
 
 from judgments.models import CourtDates
@@ -10,3 +15,20 @@ class CourtDateFactory(DjangoModelFactory):
     param = "uksc"
     start_year = 2001
     end_year = 2024
+
+
+class IdentifierResolutionsFactory:
+    @classmethod
+    def build(cls, identifier_uuid=None, uri="/ml_example_url.xml", slug="uksc/1979/999") -> IdentifierResolutions:
+        if not identifier_uuid:
+            identifier_uuid = str(uuid.uuid4())
+        return IdentifierResolutions(
+            [
+                IdentifierResolution(
+                    identifier_uuid=f"id-{uuid}",
+                    document_uri=MarkLogicDocumentURIString(uri),
+                    identifier_slug=DocumentURIString(slug),
+                    document_published=True,
+                )
+            ]
+        )

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -227,6 +227,9 @@ class TestPressSummaryLabel(TestCaseWithMockAPI):
 class TestViewRelatedDocumentButton:
     @patch("judgments.views.detail.detail_html.DocumentPdf", autospec=True)
     @patch("judgments.views.detail.detail_html.get_published_document_by_uri")
+    @patch(
+        "judgments.resolvers.document_resolver_engine.api_client.resolve_from_identifier", side_effect=echo_resolution
+    )
     @pytest.mark.parametrize(
         "uri,expected_text,expected_href,document_class_factory",
         [
@@ -246,6 +249,7 @@ class TestViewRelatedDocumentButton:
     )
     def test_view_related_document_button_when_document_with_related_document(
         self,
+        mock_api_client,
         mock_get_document_by_uri,
         mock_pdf,
         uri,
@@ -261,7 +265,7 @@ class TestViewRelatedDocumentButton:
 
         def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False, search_query: Optional[str] = None):
             if document_uri not in [uri, expected_href]:
-                raise DocumentNotFoundError()
+                raise DocumentNotFoundError(document_uri)
             return document_class_factory.build(uri=document_uri, is_published=True)
 
         mock_get_document_by_uri.side_effect = get_document_by_uri_side_effect
@@ -274,6 +278,9 @@ class TestViewRelatedDocumentButton:
 
     @patch("judgments.views.detail.detail_html.DocumentPdf", autospec=True)
     @patch("judgments.views.detail.detail_html.get_published_document_by_uri")
+    @patch(
+        "judgments.resolvers.document_resolver_engine.api_client.resolve_from_identifier", side_effect=echo_resolution
+    )
     @pytest.mark.parametrize(
         "uri,expected_text,expected_href,document_class_factory",
         [
@@ -293,6 +300,7 @@ class TestViewRelatedDocumentButton:
     )
     def test_view_related_document_button_when_document_with_related_document_and_query_string(
         self,
+        mock_api_client,
         mock_get_document_by_uri,
         mock_pdf,
         uri,
@@ -308,7 +316,7 @@ class TestViewRelatedDocumentButton:
 
         def get_document_by_uri_side_effect(document_uri, cache_if_not_found=False, search_query: Optional[str] = None):
             if document_uri not in [uri, expected_href]:
-                raise DocumentNotFoundError()
+                raise DocumentNotFoundError(document_uri)
             return document_class_factory.build(uri=document_uri, is_published=True)
 
         mock_get_document_by_uri.side_effect = get_document_by_uri_side_effect
@@ -320,6 +328,9 @@ class TestViewRelatedDocumentButton:
 
     @patch("judgments.views.detail.detail_html.DocumentPdf", autospec=True)
     @patch("judgments.views.detail.detail_html.get_published_document_by_uri")
+    @patch(
+        "judgments.resolvers.document_resolver_engine.api_client.resolve_from_identifier", side_effect=echo_resolution
+    )
     @pytest.mark.parametrize(
         "uri,unexpected_text,unexpected_href",
         [
@@ -329,6 +340,7 @@ class TestViewRelatedDocumentButton:
     )
     def test_no_view_related_document_button_when_document_without_related_document(
         self,
+        mock_api_client,
         mock_get_document_by_uri,
         mock_pdf,
         uri,
@@ -345,7 +357,6 @@ class TestViewRelatedDocumentButton:
             return JudgmentFactory.build(uri=document_uri, is_published=True, document_noun="press summary")
 
         mock_get_document_by_uri.side_effect = get_document_by_uri_side_effect
-
         client = Client()
         response = client.get(f"/{uri}")
         xpath_query = f"//a[@href='{unexpected_href}']"

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -488,7 +488,7 @@ class TestDocumentHeadings(TestCase):
                 judgment.identifiers.add(judgment_ncn)
                 return judgment
             else:
-                raise DocumentNotFoundError()
+                raise DocumentNotFoundError(document_uri)
 
         mock_get_document_by_uri.side_effect = get_document_by_uri_side_effect
         response = self.client.get("/eat/2023/1/press-summary/1")

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -12,6 +12,7 @@ from django.http import Http404
 from django.template.defaultfilters import filesizeformat
 from django.test import Client, TestCase
 
+from judgments.tests.factories import IdentifierResolutionsFactory
 from judgments.tests.utils.assertions import (
     assert_contains_html,
     assert_response_contains_text,
@@ -557,7 +558,8 @@ class TestHTMLTitle(TestCase):
 
     @patch("judgments.views.detail.detail_html.DocumentPdf", autospec=True)
     @patch("judgments.views.detail.detail_html.get_published_document_by_uri")
-    def test_html_title_when_judgment(self, mock_get_document_by_uri, mock_pdf):
+    @patch("judgments.resolvers.document_resolver_engine.api_client")
+    def test_html_title_when_judgment(self, mock_api_client, mock_get_document_by_uri, mock_pdf):
         """
         GIVEN a judgment
         WHEN a request is made with the judgment URI
@@ -569,6 +571,10 @@ class TestHTMLTitle(TestCase):
             is_published=True,
             body=DocumentBodyFactory.build(name="Judgment A"),
         )
+        mock_api_client.resolve_from_identifier.return_value = IdentifierResolutionsFactory.build(
+            slug="eat/2023/1", uri="/ml.xml"
+        )
+
         response = self.client.get("/eat/2023/1")
         title = "Judgment A - Find Case Law - The National Archives"
         xpath_query = "//title"

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -5,7 +5,7 @@ from judgments.views.browse import BrowseView
 from judgments.views.index import IndexView
 
 from . import converters, feeds
-from .resolvers.document_resolver_engine import DocumentResolverEngine, IdentifierResolverEngine
+from .resolvers.document_resolver_engine import IdentifierResolverEngine
 from .views.advanced_search import advanced_search
 
 register_converter(converters.YearConverter, "yyyy")
@@ -17,7 +17,9 @@ register_converter(converters.FileFormatConverter, "file_format")
 register_converter(converters.ComponentConverter, "component")
 
 urlpatterns = [
-    path("demo/<document_uri:document_uri>", IdentifierResolverEngine.as_view(), name="resolve-ncn"),
+    path("<document_uri:document_uri>/<component:component>", IdentifierResolverEngine.as_view(), name="detail"),
+    path("<document_uri:document_uri>/<file_format:file_format>", IdentifierResolverEngine.as_view(), name="detail"),
+    path("<document_uri:document_uri>", IdentifierResolverEngine.as_view(), name="detail"),
     path("<court:court>", BrowseView.as_view(), name="browse"),
     path("<yyyy:year>", BrowseView.as_view(), name="browse"),
     path("<court:court>/<yyyy:year>", BrowseView.as_view(), name="browse"),
@@ -62,5 +64,8 @@ urlpatterns = [
         DocumentResolverEngine.as_view(),
         name="detail",
     ),
+    path("judgments/results", advanced_search),
+    path("judgments/advanced_search", advanced_search),
+    path("judgments/search", advanced_search, name="search"),
     path("", IndexView.as_view(), name="home"),
 ]

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -5,7 +5,8 @@ from judgments.views.browse import BrowseView
 from judgments.views.index import IndexView
 
 from . import converters, feeds
-from .resolvers.document_resolver_engine import DocumentResolverEngine
+from .resolvers.document_resolver_engine import DocumentResolverEngine, IdentifierResolverEngine
+from .views.advanced_search import advanced_search
 
 register_converter(converters.YearConverter, "yyyy")
 register_converter(converters.DateConverter, "date")
@@ -16,6 +17,7 @@ register_converter(converters.FileFormatConverter, "file_format")
 register_converter(converters.ComponentConverter, "component")
 
 urlpatterns = [
+    path("demo/<document_uri:document_uri>", IdentifierResolverEngine.as_view(), name="resolve-ncn"),
     path("<court:court>", BrowseView.as_view(), name="browse"),
     path("<yyyy:year>", BrowseView.as_view(), name="browse"),
     path("<court:court>/<yyyy:year>", BrowseView.as_view(), name="browse"),

--- a/judgments/utils/utils.py
+++ b/judgments/utils/utils.py
@@ -242,17 +242,19 @@ def get_press_summaries_for_document_uri(document_uri: str) -> list[PressSummary
 
 
 def formatted_document_uri(document_uri: DocumentURIString, format: Optional[str] = None) -> str:
-    url = reverse("detail", args=[document_uri])
+    url = reverse("detail", args=[document_uri.strip("/")])
     if format == "pdf":
-        url = url + "/data.pdf"
+        return f"{url}/data.pdf"
     elif format == "generated_pdf":
-        url = url + "/generated.pdf"
+        return f"{url}/generated.pdf"
     elif format == "xml":
-        url = url + "/data.xml"
+        return f"{url}/data.xml"
     elif format == "html":
-        url = url + "/data.html"
-
-    return url
+        return f"{url}/data.html"
+    elif not format:
+        return url
+    msg = f"Unexpected format to formatted_document_uri, {format!r}"
+    raise RuntimeError(msg)
 
 
 def linked_doc_url(document: Document) -> DocumentURIString:

--- a/judgments/views/detail/best_pdf.py
+++ b/judgments/views/detail/best_pdf.py
@@ -21,7 +21,7 @@ def best_pdf(request, document_uri):
         return HttpResponse(response.content, content_type="application/pdf")
 
     if response.status_code != 404:
-        logging.warn(f"Unexpected {response.status_code} error on {document_uri} whilst trying to get_best_pdf")
+        logging.warning(f"Unexpected {response.status_code} error on {document_uri} whilst trying to get_best_pdf")
     # fall back to weasy_pdf
 
     return redirect(

--- a/judgments/views/detail/detail_html.py
+++ b/judgments/views/detail/detail_html.py
@@ -4,10 +4,9 @@ import urllib
 from typing import Any
 
 from caselawclient.models.documents import DocumentURIString
-from django.http import Http404, HttpResponseRedirect
+from django.http import Http404
 from django.template.defaultfilters import filesizeformat
 from django.template.response import TemplateResponse
-from django.urls import reverse
 from lxml import html as html_parser
 
 from judgments.forms import AdvancedSearchForm
@@ -49,9 +48,12 @@ def detail_html(request, document_uri: DocumentURIString):
     pdf = DocumentPdf(document_uri)
 
     # If the document_uri which was requested isn't the canonical URI of the document, redirect the user
-    if document_uri != document.uri:
-        redirect_uri = reverse("detail", kwargs={"document_uri": document.uri})
-        return HttpResponseRedirect(redirect_uri)
+    # Except that the DocumentURIString is actually a shortened version of the MarkLogic name, now -- so this code is irrelevant.
+
+    # if document_uri != document.uri:
+    #     raise RuntimeError(f"doc_uri != doc.uri: {document_uri}, {document.uri}")
+    #     redirect_uri = reverse("detail", kwargs={"document_uri": document.uri})
+    #     return HttpResponseRedirect(redirect_uri)
 
     try:
         linked_document_uri = linked_doc_url(document)

--- a/judgments/views/detail/detail_html.py
+++ b/judgments/views/detail/detail_html.py
@@ -29,7 +29,7 @@ def number_of_mentions(content: str, query: str) -> int:
     return len(tree.findall(".//mark"))
 
 
-def detail_html(request, document_uri):
+def detail_html(request, document_uri: str):
     query = request.GET.get("query")
 
     context: dict[str, Any] = {}

--- a/judgments/views/detail/detail_html.py
+++ b/judgments/views/detail/detail_html.py
@@ -3,6 +3,7 @@ import os
 import urllib
 from typing import Any
 
+from caselawclient.models.documents import DocumentURIString
 from django.http import Http404, HttpResponseRedirect
 from django.template.defaultfilters import filesizeformat
 from django.template.response import TemplateResponse
@@ -29,7 +30,7 @@ def number_of_mentions(content: str, query: str) -> int:
     return len(tree.findall(".//mark"))
 
 
-def detail_html(request, document_uri):
+def detail_html(request, document_uri: DocumentURIString):
     query = request.GET.get("query")
 
     context: dict[str, Any] = {}

--- a/judgments/views/detail/detail_html.py
+++ b/judgments/views/detail/detail_html.py
@@ -29,7 +29,7 @@ def number_of_mentions(content: str, query: str) -> int:
     return len(tree.findall(".//mark"))
 
 
-def detail_html(request, document_uri: str):
+def detail_html(request, document_uri):
     query = request.GET.get("query")
 
     context: dict[str, Any] = {}

--- a/judgments/views/detail/detail_xml.py
+++ b/judgments/views/detail/detail_xml.py
@@ -1,16 +1,21 @@
 from caselawclient.models.documents import DocumentURIString
 from django.http import HttpResponse
+from django.urls import resolve
 
 from judgments.utils import (
     get_published_document_by_uri,
 )
 
 
-def detail_xml(_request, document_uri: DocumentURIString) -> HttpResponse:
+def filename(request) -> str:
+    return resolve(request.path).captured_kwargs["document_uri"].replace("/", "_")
+
+
+def detail_xml(request, document_uri: DocumentURIString) -> HttpResponse:
     document = get_published_document_by_uri(document_uri)
 
     document_xml = document.body.content_as_xml
 
     response = HttpResponse(document_xml, content_type="application/xml")
-    response["Content-Disposition"] = f"attachment; filename={document.uri}.xml"
+    response["Content-Disposition"] = f"attachment; filename={filename(request)}.xml"
     return response

--- a/judgments/views/detail/generated_pdf.py
+++ b/judgments/views/detail/generated_pdf.py
@@ -28,7 +28,7 @@ class PdfDetailView(WeasyTemplateResponseMixin, TemplateView):
 
         document = get_published_document_by_uri(document_uri)
 
-        self.pdf_filename = f"{document.uri}.pdf"
+        self.pdf_filename = f"placeholder_{document.uri}.pdf"
 
         context["document"] = document.body.content_as_html()
 

--- a/judgments/views/disambiguation.py
+++ b/judgments/views/disambiguation.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from caselawclient.identifier_resolution import IdentifierResolutions
+from caselawclient.models.documents import DocumentURIString
+from django.views.generic.base import TemplateView
+
+
+class DisambiguationView(TemplateView):
+    template_name = "judgment/disambiguation.html"
+
+    def get_context_data(
+        self, uri: DocumentURIString, resolutions: IdentifierResolutions, file_format: Optional[str], **kwargs
+    ):
+        context = super().get_context_data(**kwargs)
+        context["uri"] = uri
+        context["resolutions"] = resolutions
+        context["file_format"] = f"/{file_format}" or ""
+
+        return context


### PR DESCRIPTION
* Base page loads
* PDF and XML links:

https://assets.caselaw.nationalarchives.gov.uk/[ml]/[ml].pdf -- this seems right
https://assets.caselaw.nationalarchives.gov.uk/[ml]/sample1.png -- this seems fine.
http://localhost:3000/[ml]/data.xml -- this is wrong, that should be [id], as it's resolver based link ***FIXED***

### Important commit message

There are a number of places where we use formatted_document_uri to get the name of a resource -- images, PDFs and XML spring to mind.
But there's now a distinction between these resources. Those at `assets` will share the name of the MarkLogic resource, but
those at `/data.extension` will share the name of the loaded page.

Changing it only here seems correct.
<!-- Amend as appropriate -->

## Changes in this PR:

## Jira card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
