### PR TITLE
FCL-503 | fix atom feed alignment css

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_result_controls.scss
+++ b/ds_judgements_public_ui/sass/includes/_result_controls.scss
@@ -36,14 +36,17 @@
 
     width: auto;
     min-width: auto;
+    max-height: 32px;
     margin: 0;
-    padding-right: $space-6;
+    padding: $space-1 $space-6 $space-1 $space-2;
+
+    font-size: $typography-sm-text-size;
   }
 
   &__button {
     @include call-to-action-button;
 
-    max-height: 34px;
+    max-height: 32px;
     margin: 0;
     padding: $space-2 $space-3;
 


### PR DESCRIPTION
## Changes in this PR:

Adjust styling back to what it was before

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-503

## Screenshots of UI changes:

### Before

<img width="1258" alt="image" src="https://github.com/user-attachments/assets/31667801-541a-4e7b-81a0-d26cafdfa15f" />


### After

<img width="1284" alt="image" src="https://github.com/user-attachments/assets/52a7d001-e656-4c4f-9d91-f786377c7fcb" />

