### PR TITLE
Use --quiet-deps on sass to hide deprecations from govuk-frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start-sass": "npx sass --watch  --load-path=node_modules ds_judgements_public_ui/sass:ds_judgements_public_ui/static/css",
     "start-scripts": "npx webpack --watch",
-    "build": "npx webpack && npx sass --load-path=node_modules ds_judgements_public_ui/sass:ds_judgements_public_ui/static/css --style=compressed",
+    "build": "npx webpack && npx sass --quiet-deps --load-path=node_modules ds_judgements_public_ui/sass:ds_judgements_public_ui/static/css --style=compressed",
     "watch": "npx nodemon --watch './ds_judgements_public_ui/sass/*' --watch './ds_judgements_public_ui/static/js/*' --exec 'npm run start-sass && npm run start-scripts'",
     "lint:scss": "npx stylelint '**/*.scss'",
     "test": "npx jest"


### PR DESCRIPTION
There are nearly 900 omitted warnings, of which 700 come from govuk-frontend; we should hide them as they make it difficult to see the actual issues and increase log spam.

https://sass-lang.com/documentation/breaking-changes/import/