### PR TITLE
FCL-450 | adjust padding on homepage boxes

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_homepage_cards.scss
+++ b/ds_judgements_public_ui/sass/includes/_homepage_cards.scss
@@ -16,49 +16,40 @@
       }
     }
 
-    @media (max-width: $grid-breakpoint-medium) {
-      margin-top: $space-4;
-      margin-bottom: $space-4;
-      padding: $space-3;
-      padding-bottom: 12.5rem;
-
-      border: 3px solid $color-yellow;
-    }
-
     @include container;
+
+    @media (max-width: $grid-breakpoint-medium) {
+      padding: 0;
+    }
   }
 
   &__inner-container {
     display: flex;
     flex-direction: row;
-    gap: $space-1;
+    gap: $space-4;
 
     margin-left: 0;
     padding-top: $space-8;
 
     @media (max-width: $grid-breakpoint-medium) {
-      float: left;
       flex-direction: column;
-
-      margin-right: $space-4;
-      margin-left: $space-4;
-      padding-top: 0;
+      margin: $space-4;
+      padding: $space-4;
+      border: 3px solid $color-yellow;
     }
   }
 
   &__info-cards-home {
     display: flex;
+    flex: 1;
     flex-direction: row;
-    gap: $space-4;
 
-    max-width: 24rem;
-    margin: $space-2;
+    text-decoration: none;
 
     background-color: colour-var("accent-background-light");
     border-top: 4px solid $color-yellow;
 
     &:hover {
-      text-decoration: none;
       background-color: colour-var("accent-background");
     }
 
@@ -75,9 +66,6 @@
   }
 
   &__image {
-    width: 111px;
-    height: 175px;
-
     @media (max-width: $grid-breakpoint-medium) {
       display: none;
     }
@@ -90,32 +78,24 @@
   &__body {
     display: flex;
     flex-direction: column;
-
-    width: 13rem;
-    height: 11rem;
-    margin-right: $space-4;
-    margin-left: $space-4;
+    gap: $space-2;
+    padding: $space-2 $space-4;
 
     @media (max-width: $grid-breakpoint-medium) {
-      width: 15rem;
-      margin-left: 0;
+      padding: 0;
     }
   }
 
-  &__heading:hover {
-    color: $color-dark-blue;
-    text-decoration: none;
-  }
-
   &__heading {
-    margin-top: $space-1;
-    margin-bottom: 0;
-
+    margin: 0;
     color: colour-var("link");
     text-decoration: underline;
     text-decoration-color: colour-var("link");
-    text-decoration-line: underline;
-    text-wrap: wrap;
+
+    &:hover {
+      color: $color-dark-blue;
+      text-decoration: none;
+    }
 
     @media (max-width: $grid-breakpoint-medium) {
       text-wrap: nowrap;
@@ -134,10 +114,10 @@
   }
 
   &__body-text {
+    margin: 0;
+    font-size: $typography-sm-text-size;
     color: colour-var("accent-font-base");
-    text-decoration: underline;
-    text-decoration-color: colour-var("accent-background-light");
-    text-decoration-line: none;
+    text-decoration: none;
 
     @media (max-width: $grid-breakpoint-medium) {
       display: none;

--- a/ds_judgements_public_ui/sass/includes/_tna_colour_overrides.scss
+++ b/ds_judgements_public_ui/sass/includes/_tna_colour_overrides.scss
@@ -33,7 +33,7 @@
     "contrast-button-background": #fff,
     "contrast-button-hover-text": #fff,
     "contrast-button-hover-background": #010101,
-    "accent-background": #afb6b5,
+    "accent-background": #dee0e2,
     "accent-background-light": #ededed,
     "accent-border": #8c9694,
     "accent-list-marker": rgba(1, 1, 1, 0.58),

--- a/ds_judgements_public_ui/templates/includes/info_cards_homepage.html
+++ b/ds_judgements_public_ui/templates/includes/info_cards_homepage.html
@@ -3,43 +3,37 @@
 <div class="homepage-cards__outer-container">
   <div class="homepage-cards__inner-container">
     <h2>Learn more about Find Case Law</h2>
-    <a href="{% url 'courts_and_tribunals' %}" class="grid-background-link" aria-label="Browse by court or tribunal">
-      <div class="homepage-cards__info-cards-home">
-        <img class="homepage-cards__image"
-             src="{% static 'images/HM-courts-and-tribunal-service-building-sign.jpg' %}"
-             alt="Browse by court or tribunal"
-             width="111px"
-             height="175px"/>
-        <div class="homepage-cards__body">
-          <h3 class="homepage-cards__heading">Browse by court or tribunal</h3>
-          <p class="homepage-cards__body-text">View judgments and decisions from specific courts and tribunals.</p>
-        </div>
+    <a href="{% url 'courts_and_tribunals' %}" aria-label="Browse by court or tribunal"  class="homepage-cards__info-cards-home">
+      <img class="homepage-cards__image"
+           src="{% static 'images/HM-courts-and-tribunal-service-building-sign.jpg' %}"
+           alt="Browse by court or tribunal"
+           width="110px"
+           height="146px"/>
+      <div class="homepage-cards__body">
+        <h3 class="homepage-cards__heading">Browse by court or tribunal</h3>
+        <p class="homepage-cards__body-text">View judgments and decisions from specific courts and tribunals.</p>
       </div>
     </a>
-    <a href="{% url 'how_to_search_find_case_law' %}" class="grid-background-link" aria-label="How to search Find Case Law">
-      <div class="homepage-cards__info-cards-home">
-        <img class="homepage-cards__image"
-             src="{% static 'images/modern-magnifying-glass.jpg' %}"
-             alt="How to search Find Case Law"
-             width="111px"
-             height="175px"/>
-        <div class="homepage-cards__body">
-          <h3 class="homepage-cards__heading">How to search</h3>
-          <p class="homepage-cards__body-text">Learn how to search the full text of every judgment and decision available on Find Case Law.</p>
-        </div>
+    <a href="{% url 'how_to_search_find_case_law' %}" aria-label="How to search Find Case Law"  class="homepage-cards__info-cards-home">
+      <img class="homepage-cards__image"
+           src="{% static 'images/modern-magnifying-glass.jpg' %}"
+           alt="How to search Find Case Law"
+           width="110px"
+           height="146px"/>
+      <div class="homepage-cards__body">
+        <h3 class="homepage-cards__heading">How to search</h3>
+        <p class="homepage-cards__body-text">Learn how to search the full text of every judgment and decision available on Find Case Law.</p>
       </div>
     </a>
-    <a href="{% url 'computational_licence_form' %}" class="grid-background-link" aria-label="Re-use Find Case Law records">
-      <div class="homepage-cards__info-cards-home">
-        <img class="homepage-cards__image"
-             src="{% static 'images/person-working-on-a-laptop.jpg' %}"
-             alt="Re-use Find Case Law records"
-             width="111px"
-             height="175px"/>
-        <div class="homepage-cards__body">
-          <h3 class="homepage-cards__heading">Re-use Find Case Law records</h3>
-          <p class="homepage-cards__body-text">Find out how to gain free access to and re-use of judgments and decisions.</p>
-        </div>
+    <a href="{% url 'computational_licence_form' %}" aria-label="Re-use Find Case Law records" class="homepage-cards__info-cards-home">
+      <img class="homepage-cards__image"
+           src="{% static 'images/person-working-on-a-laptop.jpg' %}"
+           alt="Re-use Find Case Law records"
+           width="110px"
+           height="146px"/>
+      <div class="homepage-cards__body">
+        <h3 class="homepage-cards__heading">Re-use Find Case Law records</h3>
+        <p class="homepage-cards__body-text">Find out how to gain free access to and re-use of judgments and decisions.</p>
       </div>
     </a>
   </div>


### PR DESCRIPTION
## Changes in this PR:

Adjusting the padding on the homepage cards

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-450

## Screenshots of UI changes:

### Before


Desktop:

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/42875d8c-1f81-4e59-be5d-dc200c3a52ec" />

Tablet:

<img width="975" alt="image" src="https://github.com/user-attachments/assets/059d33c4-7b92-4b7d-b6dd-609198ce6803" />

Mobile:

<img width="449" alt="image" src="https://github.com/user-attachments/assets/fecc7a59-453a-4f29-adbb-3546355a7dc4" />



### After

Desktop:

<img width="1187" alt="image" src="https://github.com/user-attachments/assets/a0130676-3445-4565-b1e7-c3249f7c5745" />

Tablet:

<img width="991" alt="image" src="https://github.com/user-attachments/assets/a7db8f9e-84d9-4fc2-933d-c06d0ae48dfd" />

Mobile:

<img width="453" alt="image" src="https://github.com/user-attachments/assets/675679bb-350b-4a83-a2cd-950fb8e60186" />

