### PR TITLE
Set max-requests and max-requests-jitter

### DIFF
--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -8,4 +8,4 @@ set -o nounset
 npm run build
 python /app/manage.py collectstatic --noinput
 cd /app
-/usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app --access-logfile - -w 5 --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s "%({x-forwarded-for}i)s" "%({cloudfront-viewer-address}i)s" "%({x-amz-cf-id}i)s" "%({x-amzn-trace-id}i)s"'
+/usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app --access-logfile - -w 5 --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s "%({x-forwarded-for}i)s" "%({cloudfront-viewer-address}i)s" "%({x-amz-cf-id}i)s" "%({x-amzn-trace-id}i)s"' --max-requests 2000 --max-requests-jitter 200


### PR DESCRIPTION
We think we have a memory leak and setting max-requests will hopefully    mitigate
this. Also set max-requests-jitter so that the workers don't all restart  at the
same time.

2000 and 200 are numbers picked from looking at production traffic.


<!-- Amend as appropriate -->

## Changes in this PR:

## Jira card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated