### PR TITLE
[FCL-580] Upgrade to API Client v29.1 to resolve best_human_identifier issue

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgment_navigation.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_navigation.html
@@ -29,7 +29,9 @@
     {% if page_title %}
       <h2>{{ page_title }}</h2>
     {% endif %}
-    <p>{{ document.best_human_identifier }}</p>
+    {% if document.best_human_identifier %}
+      <p>{{ document.best_human_identifier.value }}</p>
+    {% endif %}
   </div>
 
   <div id="js-document-navigation-links-end"

--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -6,7 +6,9 @@
       <p class="judgment-toolbar__press-summary-title">Press Summary</p>
     {% endif %}
     <h1 id="judgment-toolbar-title" class="judgment-toolbar__title">{{ document|get_title_to_display_in_html }}</h1>
-    <p class="judgment-toolbar__reference">{{ document.best_human_identifier }}</p>
+    {% if document.best_human_identifier %}
+      <p class="judgment-toolbar__reference">{{ document.best_human_identifier.value }}</p>
+    {% endif %}
     <div class="judgment-toolbar__actions">
       {% if linked_document_uri %}
         {% spaceless %}

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -16,7 +16,6 @@ from judgments.tests.utils.assertions import (
     assert_response_not_contains_text,
 )
 from judgments.views.detail import (
-    NoNeutralCitationError,
     PdfDetailView,
 )
 
@@ -543,17 +542,3 @@ class TestHTMLTitle(TestCase):
         title = "Judgment A - Find Case Law - The National Archives"
         xpath_query = "//title"
         assert_response_contains_text(response, title, xpath_query)
-
-
-class TestNoNeutralCitation(TestCase):
-    @patch("judgments.views.detail.detail_html.get_published_document_by_uri")
-    def test_document_baseclass_raises_error(self, get_document):
-        doc = JudgmentFactory.build(
-            uri=DocumentURIString("eat/2023/1"),
-            is_published=True,
-            name="Judgment A",
-            neutral_citation=None,
-        )
-        get_document.return_value = doc
-        with pytest.raises(NoNeutralCitationError):
-            self.client.get("/eat/2023/1")

--- a/judgments/views/detail/__init__.py
+++ b/judgments/views/detail/__init__.py
@@ -1,6 +1,6 @@
 from .best_pdf import best_pdf
-from .detail_html import NoNeutralCitationError, detail_html
+from .detail_html import detail_html
 from .detail_xml import detail_xml
 from .generated_pdf import PdfDetailView, generated_pdf
 
-__all__ = ["best_pdf", "detail_html", "detail_xml", "generated_pdf", "PdfDetailView", "NoNeutralCitationError"]
+__all__ = ["best_pdf", "detail_html", "detail_xml", "generated_pdf", "PdfDetailView"]

--- a/judgments/views/detail/detail_html.py
+++ b/judgments/views/detail/detail_html.py
@@ -19,11 +19,6 @@ from judgments.utils import (
     search_context_from_url,
 )
 
-
-class NoNeutralCitationError(Exception):
-    pass
-
-
 # suppress weasyprint log spam
 if os.environ.get("SHOW_WEASYPRINT_LOGS") != "True":
     logging.getLogger("weasyprint").handlers = []
@@ -53,9 +48,6 @@ def detail_html(request, document_uri):
     if document_uri != document.uri:
         redirect_uri = reverse("detail", kwargs={"document_uri": document.uri})
         return HttpResponseRedirect(redirect_uri)
-
-    if document.best_human_identifier is None:
-        raise NoNeutralCitationError(document.uri)
 
     try:
         linked_document_uri = linked_doc_url(document)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-environ==0.11.2 # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 requests~=2.32.2
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=28.2.0
+ds-caselaw-marklogic-api-client~=29.1.0
 ds-caselaw-utils==2.0.1
 rollbar
 django-weasyprint==2.3.1


### PR DESCRIPTION
We shouldn't be relying on the old v28 behaviour for getting the best human identifier (ie always using the NCN), instead we should be using the v29 implementation of scored identifiers. This also changes the return type from `str` to `Identifier`, so (although an `Identifier` is castable) we switch to using `.value` so things are all in the proper context.