### PR TITLE
[FCL-609] Clean up old computational licence form links

### DIFF
--- a/config/views/sitemaps.py
+++ b/config/views/sitemaps.py
@@ -54,7 +54,6 @@ class SitemapStaticView(TemplateView, TemplateResponseMixin):
             "home",
             "advanced_search",
             "about_this_service",
-            "what_to_expect",
             "how_to_use_this_service",
             "courts_and_tribunals",
             "transactional-licence-form",

--- a/config/views/sitemaps.py
+++ b/config/views/sitemaps.py
@@ -57,7 +57,7 @@ class SitemapStaticView(TemplateView, TemplateResponseMixin):
             "what_to_expect",
             "how_to_use_this_service",
             "courts_and_tribunals",
-            "computational_licence_form",
+            "transactional-licence-form",
             "privacy_notice",
             "accessibility_statement",
             "open_justice_licence",

--- a/ds_judgements_public_ui/templates/includes/footer.html
+++ b/ds_judgements_public_ui/templates/includes/footer.html
@@ -59,7 +59,7 @@
         All content is available under the <a class="judgments-footer__link"
                                               href="{% url "open_justice_licence" %}">Open Justice Licence</a>.
         <br/>
-        For re-use that is not covered by the Open Justice Licence, please <a href="{% url "computational_licence_form" %}">apply for licence to do computational analysis.</a>.
+        For re-use that is not covered by the Open Justice Licence, please <a href="{% url "transactional-licence-form" %}">apply for licence to do computational analysis.</a>.
       </p>
     </div>
   </div>

--- a/ds_judgements_public_ui/templates/includes/info_cards_about_find_case_law.html
+++ b/ds_judgements_public_ui/templates/includes/info_cards_about_find_case_law.html
@@ -10,7 +10,7 @@
     <p>Learn which judgments and decisions this service provides.</p>
   </a>
 
-  <a class="info-card" href="{% url 'computational_licence_form' %}" aria-label="Reuse Find Case Law records">
+  <a class="info-card" href="{% url "transactional-licence-form" %}" aria-label="Reuse Find Case Law records">
     <h3>Reuse Find Case Law records</h3>
     <p>Read what you’re allowed to do with records from this service.</p>
   </a>

--- a/ds_judgements_public_ui/templates/includes/info_cards_homepage.html
+++ b/ds_judgements_public_ui/templates/includes/info_cards_homepage.html
@@ -25,7 +25,7 @@
         <p class="homepage-cards__body-text">Learn how to search the full text of every judgment and decision available on Find Case Law.</p>
       </div>
     </a>
-    <a href="{% url 'computational_licence_form' %}" aria-label="Re-use Find Case Law records" class="homepage-cards__info-cards-home">
+    <a href="{% url "transactional-licence-form" %}" aria-label="Re-use Find Case Law records" class="homepage-cards__info-cards-home">
       <img class="homepage-cards__image"
            src="{% static 'images/person-working-on-a-laptop.jpg' %}"
            alt="Re-use Find Case Law records"

--- a/ds_judgements_public_ui/templates/includes/info_cards_judgments_decisions.html
+++ b/ds_judgements_public_ui/templates/includes/info_cards_judgments_decisions.html
@@ -13,7 +13,7 @@
         <h3>Publishing policy</h3>
         <p>Read how Find Case Law receives and publishes judgments and decisions.</p>
     </a>
-    <a class="info-card"  href="{% url 'computational_licence_form' %}"  aria-label="Reuse Find Case Law records">
+    <a class="info-card"  href="{% url "transactional-licence-form" %}"  aria-label="Reuse Find Case Law records">
         <h3>Reuse Find Case Law records</h3>
         <p>Read what you’re allowed to do with records from this service.</p>
     </a>

--- a/ds_judgements_public_ui/templates/pages/contact_us.html
+++ b/ds_judgements_public_ui/templates/pages/contact_us.html
@@ -36,7 +36,7 @@
             Please leave your number and message and we will call you back.
           </p>
           <h2 id="section-licensing">Licensing queries</h2>
-          <p>This website explains <a href="{% url 'computational_licence_form' %}">how you can use and re-use Find Case Law records</a>.</p>
+          <p>This website explains <a href="{% url "transactional-licence-form" %}">how you can use and re-use Find Case Law records</a>.</p>
           <p>If you have any questions about licensing, please email our Licensing Department at <a href="mailto:caselawlicence@nationalarchives.gov.uk">caselawlicence@nationalarchives.gov.uk</a>.</p>
           <h2 id="section-who">Who we are</h2>
           <p>Find Case Law is provided by <a href="https://www.nationalarchives.gov.uk/">The National Archives</a>, working in partnership with the Ministry of Justice, His Majesty's Courts and Tribunals Service, and the Judicial Office.</p>

--- a/ds_judgements_public_ui/templates/pages/help_and_guidance.html
+++ b/ds_judgements_public_ui/templates/pages/help_and_guidance.html
@@ -14,7 +14,7 @@
           <p class="govuk-grid-column-one-third__grid_info_text">Learn which judgments and decisions this service provides.</p>
         </div>
       </a>
-      <a href="{% url 'computational_licence_form' %}" class="grid-background-link" aria-label="Re-use information from Find Case Law">
+      <a href="{% url "transactional-licence-form" %}" class="grid-background-link" aria-label="Re-use information from Find Case Law">
         <div class="govuk-grid-column-one-third__info">
           <h3 class="govuk-grid-column-one-third__grid_info_heading">Re-use information from Find Case Law</h3>
           <p class="govuk-grid-column-one-third__grid_info_text">Read what you can and can’t do with material from this service.</p>

--- a/ds_judgements_public_ui/templates/pages/terms_and_policies.html
+++ b/ds_judgements_public_ui/templates/pages/terms_and_policies.html
@@ -20,7 +20,7 @@
           <p class="govuk-grid-column-one-third__grid_info_text">Learn which judgments and decisions this service provides.</p>
         </div>
       </a>
-      <a href="{% url 'computational_licence_form' %}" class="grid-background-link" aria-label="Re-use information from Find Case Law">
+      <a href="{% url "transactional-licence-form" %}" class="grid-background-link" aria-label="Re-use information from Find Case Law">
         <div class="govuk-grid-column-one-third__info">
           <h3 class="govuk-grid-column-one-third__grid_info_heading">Re-use information from Find Case Law</h3>
           <p class="govuk-grid-column-one-third__grid_info_text">Read what you can and can’t do with material from this service.</p>

--- a/ds_judgements_public_ui/templates/pages/terms_of_use.html
+++ b/ds_judgements_public_ui/templates/pages/terms_of_use.html
@@ -60,7 +60,7 @@
             You must apply for a licence to do computational analysis if you wish to conduct computational analysis of the information provided by Find Case Law.
           </p>
           <p>
-            For more detailed information, see our instructions on how to  <a href="{% url 'computational_licence_form' %}" >Reuse information from Find Case Law</a>.
+            For more detailed information, see our instructions on how to  <a href="{% url "transactional-licence-form" %}" >Reuse information from Find Case Law</a>.
           </p>
         </section>
       </div>


### PR DESCRIPTION
There were a few places around the site where we were still linking to the old computational licence form URL. Since this now redirects to the transactional licence form, we may as well send people straight there instead.