### PR TITLE
FCL-586 | ensure h1 don't have excessive margins

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_standard_content.scss
+++ b/ds_judgements_public_ui/sass/includes/_standard_content.scss
@@ -70,7 +70,7 @@
       margin-bottom: $space-4;
     }
 
-    > h1,
+    h1,
     > h2 {
       margin: 0 0 $space-8;
     }


### PR DESCRIPTION
## Changes in this PR:

Added the `>` to both headings by accident - should only be on h2s.