### PR TITLE
fix: don't allow users to select clipboard tooltip

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgment_document_paragraph_anchors.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_document_paragraph_anchors.scss
@@ -24,11 +24,14 @@
   }
 
   &__copy-link-tooltip {
+    user-select: none;
+
     position: absolute;
     top: -8px;
     right: 30px;
 
     padding: 5px 10px;
+    border: 1px solid colour-var("input-border");
 
     font-family: Roboto, sans-serif;
     font-size: 14px;
@@ -38,7 +41,6 @@
 
     opacity: 0;
     background: colour-var("background");
-    border: 1px solid colour-var("input-border");
 
     transition: opacity ease 0.3s;
 
@@ -52,10 +54,10 @@
 
       width: 8px;
       height: 8px;
-
-      background: colour-var("background");
       border-top: 1px solid colour-var("input-border");
       border-right: 1px solid colour-var("input-border");
+
+      background: colour-var("background");
     }
   }
 


### PR DESCRIPTION
## Changes in this PR:

Don't allow users to select clipboard tooltip
