### PR TITLE
Update document URI conversion regex to allow for all new URL forms

### DIFF
--- a/judgments/converters.py
+++ b/judgments/converters.py
@@ -55,7 +55,7 @@ class FileFormatConverter:
 
 
 class DocumentUriConverter:
-    regex = r".*/\d{4}/\d+.*"
+    regex = r"[a-z0-9./-]+"
 
     def to_python(self, value):
         return value

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -354,7 +354,7 @@ class TestBreadcrumbs:
                 )
             else:
                 return JudgmentFactory.build(
-                    uri=DocumentURIString("eat/2023/1/the_judgment_uri"),
+                    uri=DocumentURIString("eat/2023/1"),
                     is_published=True,
                     body=DocumentBodyFactory.build(
                         name="The Title of Judgment A",
@@ -365,7 +365,7 @@ class TestBreadcrumbs:
 
         response = self.client.get("/eat/2023/1/press-summary/1")
         judgment_breadcrumb_html = """
-                    <li><a href="/eat/2023/1/the_judgment_uri">Judgment A</a></li>
+                    <li><a href="/eat/2023/1">Judgment A</a></li>
         """
 
         summary_breadcrumb_html = """


### PR DESCRIPTION
Our new-style URIs or compiled URL slugs can include a wider range of characters than older NCN-based URIs. Adapt the regex used for URI matching accordingly.

This is a temporary measure as we complete the transition from URI-based URLs to compiled identifier-based URLs.