### PR TITLE
[FCL-633] Fix errant calls to document.* instead of document.body.*

### DIFF
--- a/ds_judgements_public_ui/templates/judgment/press_summaries/list.html
+++ b/ds_judgements_public_ui/templates/judgment/press_summaries/list.html
@@ -13,10 +13,10 @@
     {% if page_title %}
       <h1>{{ page_title }}</h1>
     {% endif %}
-    <div class="results__container">
-      <div class="results__list-layout-container">
-        {% include "includes/judgment_listing.html" with judgments=press_summaries %}
-      </div>
-    </div>
+    <ul>
+      {% for press_summary in press_summaries %}
+        <li><a href="{% url 'detail' press_summary.uri %}">{{ press_summary.body.name }}</a></li>
+      {% endfor %}
+    </ul>
   </div>
 {% endblock content %}

--- a/judgments/tests/test_press_summaries.py
+++ b/judgments/tests/test_press_summaries.py
@@ -17,12 +17,12 @@ class TestPressSummaries(TestCase):
         press_summary_1 = PressSummaryFactory.build()
         press_summary_2 = PressSummaryFactory.build()
 
-        excepted_press_summaries = [
+        expected_press_summaries = [
             press_summary_1,
             press_summary_2,
         ]
 
-        mock_get_press_summaries_for_document_uri.return_value = excepted_press_summaries
+        mock_get_press_summaries_for_document_uri.return_value = expected_press_summaries
 
         request = Mock()
         document_uri = "foo/bar/baz"
@@ -36,7 +36,7 @@ class TestPressSummaries(TestCase):
                 "page_title": f"{linked_doc_title(press_summary_1)} - Press Summaries",
                 "judgment_name": linked_doc_title(press_summary_1),
                 "breadcrumbs": press_summary_list_breadcrumbs(press_summary_1),
-                "press_summaries": excepted_press_summaries,
+                "press_summaries": expected_press_summaries,
             },
         )
 


### PR DESCRIPTION
This resolves some deprecation warnings we're getting where listing press summaries is including `judgment_listing.html`, which expects a search result (which are a different shape).

We don't currently have any cases where we have multiple press summaries in the wild, and this is being replaced soon by better related documents, so for the time being this is dramatically simplified.