### PR TITLE
FCL-636 | fixes for govuk details section

### DIFF
--- a/ds_judgements_public_ui/sass/includes/govuk_overrides/_details.scss
+++ b/ds_judgements_public_ui/sass/includes/govuk_overrides/_details.scss
@@ -24,6 +24,7 @@
 .govuk-details__summary {
   padding-left: $space-6;
   color: colour-var("link");
+  text-decoration: underline;
 
   &::before {
     top: 2px;

--- a/ds_judgements_public_ui/templates/includes/courts_and_tribunals_court.html
+++ b/ds_judgements_public_ui/templates/includes/courts_and_tribunals_court.html
@@ -6,7 +6,7 @@
     <h2 id="{{ court.name|slugify }}" class="courts-and-tribunals__header">{{ court.grouped_name }}</h2>
   {% endif %}
   {% if court.description_text_as_html %}
-    <details class="govuk-details--compact">
+    <details class="govuk-details govuk-details--compact">
       <summary class="govuk-details__summary">
         About the {{ court.grouped_name }}
       </summary>
@@ -26,7 +26,7 @@
     {% endif %}
   </p>
   {% if court.historic_documents_support_text_as_html %}
-    <details class="govuk-details--compact">
+    <details class="govuk-details govuk-details--compact">
       <summary class="govuk-details__summary">
         Looking for older documents
       </summary>

--- a/ds_judgements_public_ui/templates/pages/atom_feed.html
+++ b/ds_judgements_public_ui/templates/pages/atom_feed.html
@@ -2,7 +2,7 @@
 {% load query_filters court_utils %}
 
 {% block article_navigation %}
-  <details class="govuk-details--compact">
+  <details class="govuk-details govuk-details--compact">
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">What is an Atom feed?</span>
     </summary>

--- a/ds_judgements_public_ui/templates/pages/courts_and_tribunals.html
+++ b/ds_judgements_public_ui/templates/pages/courts_and_tribunals.html
@@ -39,7 +39,7 @@
 
       {% if tribunal.display_heading %}
         <li>
-          <a href="#{{ tribunal.name|slugify }}">{{ tribunal.name }} ({{ court.courts|length }})</a>
+          <a href="#{{ tribunal.name|slugify }}">{{ tribunal.name }} ({{ tribunal.courts|length }})</a>
         </li>
       {% else %}
         {% for subcourt in tribunal.courts %}


### PR DESCRIPTION
## Changes in this PR:

Fix for details section to change the arrow direction when the details section is open.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-636
