### PR TITLE
FCL-623 | fix firefox link focus issue

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_standard_content.scss
+++ b/ds_judgements_public_ui/sass/includes/_standard_content.scss
@@ -70,6 +70,10 @@
       padding: 0;
 
       list-style-type: none;
+
+      a {
+        display: block;
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

This is how you fix outline issues on firefox - chrome knows to group an inline element into 1 node and outline the lot. Firefox doesn't do that. If you explicitly give it display block, firefox sees the element as a box shape.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-623

## Screenshots of UI changes:

### Before

<img width="684" alt="image" src="https://github.com/user-attachments/assets/625c9cc2-a654-44f4-85b6-eefbf78eb72f" />


### After

<img width="686" alt="image" src="https://github.com/user-attachments/assets/ef2d884d-5082-4bc9-86c2-9f7d887101e1" />
