### PR TITLE
FCL-665 | analytics link class template tag

### DIFF
--- a/ds_judgements_public_ui/templates/includes/search/search_help_text.html
+++ b/ds_judgements_public_ui/templates/includes/search/search_help_text.html
@@ -1,3 +1,6 @@
+{% load link_tags %}
+
 <p class="search-term-component__help-text">
-  <a href='{% url "how_to_use_this_service" %}#section-search'>How to search</a>
+  {% url 'how_to_use_this_service' as search_url %}
+  {% trackable_link "How to search" href=search_url|add:"#section-search" %}
 </p>

--- a/judgments/templatetags/link_tags.py
+++ b/judgments/templatetags/link_tags.py
@@ -1,0 +1,20 @@
+import re
+
+from django import template
+
+register = template.Library()
+
+BASE_TRACKING_CLASS = "analytics"
+
+
+def trackable_class_name(text):
+    context_class = re.sub(r"\s+", "-", text.strip().lower())
+
+    return f"{BASE_TRACKING_CLASS}-{re.sub(r'[^a-z0-9-]', '', context_class)}"
+
+
+@register.inclusion_tag("tags/trackable_link.html")
+def trackable_link(text, **attrs):
+    class_name = trackable_class_name(text)
+
+    return {"text": text, "attrs": attrs, "class_name": class_name}

--- a/judgments/tests/template_tags/test_link_tags.py
+++ b/judgments/tests/template_tags/test_link_tags.py
@@ -1,0 +1,64 @@
+import pytest
+from django.template import Context, Template
+
+from judgments.templatetags.link_tags import trackable_class_name
+
+
+@pytest.mark.parametrize(
+    "input_text, expected_class_name",
+    [
+        ("Test Text", "analytics-test-text"),
+        ("  leading and trailing spaces  ", "analytics-leading-and-trailing-spaces"),
+        ("Multiple     Spaces", "analytics-multiple-spaces"),
+        ("Special!@#Chars", "analytics-specialchars"),
+        ("UPPERCASE", "analytics-uppercase"),
+    ],
+)
+def test_trackable_class_name(input_text, expected_class_name):
+    assert trackable_class_name(input_text) == expected_class_name
+
+
+@pytest.mark.django_db
+def test_trackable_link_tag_no_attrs():
+    template = Template("{% load link_tags %}{% trackable_link 'Click me' %}")
+    rendered = template.render(Context())
+
+    assert "<a " in rendered
+    assert 'class="analytics-click-me"' in rendered
+    assert ">Click me<" in rendered
+
+
+@pytest.mark.django_db
+def test_trackable_link_tag_with_attrs():
+    template = Template("{% load link_tags %}{% trackable_link 'Click me' href='/test-url' target='_blank' %}")
+    rendered = template.render(Context())
+
+    assert "<a " in rendered
+    assert 'class="analytics-click-me"' in rendered
+    assert 'href="/test-url"' in rendered
+    assert 'target="_blank"' in rendered
+    assert ">Click me<" in rendered
+
+
+@pytest.mark.django_db
+def test_trackable_link_tag_with_special_characters():
+    template = Template("{% load link_tags %}{% trackable_link 'Hello World!' href='/hello-world' %}")
+    rendered = template.render(Context())
+
+    assert "<a " in rendered
+    assert 'class="analytics-hello-world"' in rendered
+    assert 'href="/hello-world"' in rendered
+    assert ">Hello World!<" in rendered
+
+
+@pytest.mark.django_db
+def test_trackable_link_tag_with_anchor():
+    template = Template(
+        "{% load link_tags %}{% url 'how_to_use_this_service' as my_url %}{% trackable_link 'Click me' href=my_url|add:'#anchor' %}"
+    )
+    context = Context()
+    rendered = template.render(context)
+
+    assert "<a " in rendered
+    assert 'href="/how-to-use-this-service#anchor"' in rendered
+    assert ">Click me<" in rendered


### PR DESCRIPTION
## Changes in this PR:

Adds a template tag that allows turning a link into a trackable link.

TODO before this can be in use:

 - [ ] Add this to all relevant links
 - [ ] Probably update the template tag code if a link already has a class (join the classes together)
 - [ ] Might need to have a look at if we need to be add links that have HTML inside

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-665
