### PR TITLE
Caching middleware

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -3,6 +3,7 @@ from urllib.parse import urlencode
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils.cache import patch_cache_control
 
 
 class RobotsTagMiddleware:
@@ -25,6 +26,27 @@ class RobotsTagMiddleware:
 
         # In all other cases, assume we don't want it indexing and add the noindex X-Robots-Tag.
         response.headers["X-Robots-Tag"] = "noindex,nofollow"
+        return response
+
+
+class CacheHeaderMiddleware:
+    # via https://docs.djangoproject.com/en/4.1/topics/http/middleware/
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # One-time configuration and initialization.
+
+    def __call__(self, request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+
+        response = self.get_response(request)
+
+        patch_cache_control(response, max_age=15 * 60, public=True)
+
+        # Code to be executed for each request/response after
+        # the view is called.
+
         return response
 
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -125,6 +125,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
+    "config.middleware.CacheHeaderMiddleware",
     "config.middleware.RobotsTagMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",

--- a/config/tests.py
+++ b/config/tests.py
@@ -8,10 +8,20 @@ from config.views.schema import schema
 
 
 class TestCacheHeaders(TestCase):
+    def test_static_headers(self):
+        url = "/static/images/tna_logo.svg"
+        response = self.client.get(url)
+        assert response.headers["Cache-Control"] == "max-age=900, public"
+
+    def test_view_headers(self):
+        url = "/about-this-service"
+        response = self.client.get(url)
+        assert response.headers["Cache-Control"] == "max-age=900, public"
+
     def test_no_cache_transactional_steps(self):
         url = "/re-use-find-case-law-records/steps/organization"
         response = self.client.get(url)
-        assert response.headers["Cache-Control"] == "max-age=0, no-cache, no-store, must-revalidate, private"
+        assert response.headers["Cache-Control"] == "max-age=0, no-cache, no-store, must-revalidate, public"
 
 
 class TestSchemas(TestCase):

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -450,9 +450,9 @@ class TestDocumentHeadings(TestCase):
                     body=DocumentBodyFactory.build(
                         name="Press Summary of Judgment A (with some slightly different wording)",
                     ),
-                    neutral_citation="Judgment_A_NCN",
+                    neutral_citation="[2023] EAT 1",
                 )
-                press_summary_ncn = PressSummaryRelatedNCNIdentifier(value="Judgment_A_NCN")
+                press_summary_ncn = PressSummaryRelatedNCNIdentifier(value="[2023] EAT 1")
                 press_summary.identifiers.add(press_summary_ncn)
                 return press_summary
             elif document_uri == "eat/2023/1":
@@ -462,9 +462,9 @@ class TestDocumentHeadings(TestCase):
                     body=DocumentBodyFactory.build(
                         name="Judgment A",
                     ),
-                    neutral_citation="Judgment_A_NCN",
+                    neutral_citation="[2023] EAT 1",
                 )
-                judgment_ncn = NeutralCitationNumber(value="Judgment_A_NCN")
+                judgment_ncn = NeutralCitationNumber(value="[2023] EAT 1")
                 judgment.identifiers.add(judgment_ncn)
                 return judgment
             else:
@@ -476,7 +476,7 @@ class TestDocumentHeadings(TestCase):
         reference_xpath_query = "//p[@class='judgment-toolbar__reference']"
 
         assert_response_contains_text(response, "Judgment A (with some slightly different wording)", h1_xpath_query)
-        assert_response_contains_text(response, "Judgment_A_NCN", reference_xpath_query)
+        assert_response_contains_text(response, "[2023] EAT 1", reference_xpath_query)
 
     @patch("judgments.views.detail.detail_html.DocumentPdf", autospec=True)
     @patch("judgments.views.detail.detail_html.get_published_document_by_uri")
@@ -514,7 +514,7 @@ class TestDocumentHeadings(TestCase):
             body=DocumentBodyFactory.build(name="Judgment A"),
         )
 
-        document_ncn = NeutralCitationNumber(value="Judgment_A_NCN")
+        document_ncn = NeutralCitationNumber(value="[1234] UKSC 1")
         document.identifiers.add(document_ncn)
 
         mock_get_document_by_uri.return_value = document
@@ -522,7 +522,7 @@ class TestDocumentHeadings(TestCase):
         response = self.client.get("/eat/2023/1")
         reference_xpath_query = "//p[@class='judgment-toolbar__reference']"
 
-        assert_response_contains_text(response, "Judgment_A_NCN", reference_xpath_query)
+        assert_response_contains_text(response, "[1234] UKSC 1", reference_xpath_query)
 
 
 class TestHTMLTitle(TestCase):


### PR DESCRIPTION
 Re-add middleware adding the cache header to all pages
    
We disable the cache header when we were A/B testing the site, but that
is no longer needed, and we had performance problems this morning potentially
due to a dynamically generated PDF being generated multiple times.
    
Revert "perf(FCL-255): remove middleware adding cache header to all pages"

This reverts commit aeaf92fd6bc0d778bee9e2cafe1d7e6c8a06cdda.