### PR TITLE
put pre-footer with survey button behind switch

### DIFF
--- a/ds_judgements_public_ui/templates/includes/help_improve_this_service.html
+++ b/ds_judgements_public_ui/templates/includes/help_improve_this_service.html
@@ -1,11 +1,15 @@
-<section class="pre-footer" aria-labelledby="pre-footer-heading">
-  <div class="pre-footer__container">
-    <h2 id="pre-footer-heading">Help us improve this service</h2>
-    <a target="_blank"
-       role="button"
-       draggable="false"
-       rel="noreferrer noopener"
-       class="button-secondary"
-       href="{{ feedback_survey_link }}">Complete short survey</a>
-  </div>
-</section>
+{% load waffle_tags %}
+
+{% switch pre_footer %}
+  <section class="pre-footer" aria-labelledby="pre-footer-heading">
+    <div class="pre-footer__container">
+      <h2 id="pre-footer-heading">Help us improve this service</h2>
+      <a target="_blank"
+         role="button"
+         draggable="false"
+         rel="noreferrer noopener"
+         class="button-secondary"
+         href="{{ feedback_survey_link }}">Complete short survey</a>
+    </div>
+  </section>
+{% endswitch %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Added our pre footer section which has the survey button already on the website behind a switch as we are basically turning this button on/off for a certain period/time. Used switch instead of flag thanks to @jacksonj04 mentioned switch earlier in the survey banner PR.

## Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136?selectedIssue=FCL-700
## Screenshots of UI changes:

### Before
![before](https://github.com/user-attachments/assets/c9015780-3b45-407d-8104-099c4cb7c165)

### After
![after](https://github.com/user-attachments/assets/d53350c2-1c03-4227-8648-0254895298d6)

- [ ] Requires env variable(s) to be updated
