### PR TITLE
[FCL-675] Improve appearance of court landing pages

### DIFF
--- a/ds_judgements_public_ui/templates/pages/court_or_tribunal.html
+++ b/ds_judgements_public_ui/templates/pages/court_or_tribunal.html
@@ -11,9 +11,12 @@
 
     {% if court|get_court_judgments_count > 0 %}
       <p>
-        We currently hold <a href="{% url "search" %}?{{ type }}={{ court.canonical_param }}">{{ court | get_court_judgments_count }} documents from
-          the {{ court.name }}</a>, from {{ court.canonical_param | get_court_date_range }}.
+        We currently hold <b>{{ court | get_court_judgments_count }} documents</b> from
+        the {{ court.name }}, from {{ court.canonical_param | get_court_date_range }}.
       </p>
+      <p><a
+        class="button-primary"
+        href="{% url "search" %}?{{ court.type.value }}={{ court.canonical_param }}">See all documents from the {{ court.name }}</a></p>
     {% else %}
       <p>We do not currently hold any documents from the {{ court.name }}.</p>
     {% endif %}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 requests~=2.32.2
 wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client~=31.1.0
-ds-caselaw-utils==2.2.1
+ds-caselaw-utils==2.3.0
 rollbar
 django-weasyprint==2.3.1
 django-waffle==4.2.0  # https://github.com/django-waffle/django-waffle


### PR DESCRIPTION
Our 'court landing' pages aren't linked to from within the service, but they are included in sitemaps and recommended to search engines for indexing. We're already seeing some traffic starting to be driven to them, so they should probably look a little bit snappier.

- Provide a clearer call to action on the page so it feels like less of a dead end
- Fix broken links where searches were actually just for all documents, not specific to that institution

## Before

![United Kingdom Supreme Court - Find Case Law - The National Archives](https://github.com/user-attachments/assets/25636670-93ce-41aa-99c1-a42ee4b28c01)

## After

![United Kingdom Supreme Court - Find Case Law - The National Archives · 10 25am · 02-26](https://github.com/user-attachments/assets/3221d02b-da3f-44f6-b741-027e511afbbf)