### PR TITLE
Pin MarkLogic to known good ref for e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
         with:
           repository: "nationalarchives/ds-caselaw-marklogic"
           path: "./marklogic"
+          ref: "v3.18.0"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
To avoid causing test failures whilst the MarkLogic repository is in an intermediate state, pin the installed version in e2e tests to the known-good v3.18.0.