### PR TITLE
Upgrade docker containers to debian bookworm

### DIFF
--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=3.12-slim-bookworm
 
 # define an alias for the specfic python version used in this file.
 FROM python:${PYTHON_VERSION} AS python

--- a/compose/local/docs/Dockerfile
+++ b/compose/local/docs/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=3.12-slim-bookworm
 
 # define an alias for the specfic python version used in this file.
 FROM python:${PYTHON_VERSION} AS python

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=3.12-slim-bookworm
 
 
 


### PR DESCRIPTION
We noticed the base image was looking a little long in the tooth (still in LTS) and thought we should see if we can upgrade cleanly.