### PR TITLE
Optimise the CI pipeline for faster runs and earlier failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,42 @@ jobs:
       - name: Run tests
         run: npm test
 
-  pytest:
+  build-django:
     needs: linter
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Copy .env.example file
+        uses: canastro/copy-file-action@master
+        with:
+          source: ".env.example"
+          target: ".env"
+
+      - name: Build the Stack
+        uses: docker/bake-action@v6
+        with:
+          targets: django
+          load: true
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
+            *.tags=ds_judgments_public_ui_django:latest
+            *.output=type=docker,dest=/tmp/django-image.tar
+
+      - name: Upload Django image
+        uses: actions/upload-artifact@v4
+        with:
+          name: django-image
+          path: /tmp/django-image.tar
+
+  pytest:
+    needs: build-django
     runs-on: ubuntu-latest
 
     steps:
@@ -77,20 +111,17 @@ jobs:
           source: ".env.example"
           target: ".env"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Create docker network as used in dev
         run: docker network create caselaw
 
-      - name: Build the Stack
-        uses: docker/bake-action@v6
+      - name: Download Django image
+        uses: actions/download-artifact@v4
         with:
-          targets: django
-          load: true
-          set: |
-            *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+          name: django-image
+          path: /tmp
+
+      - name: Load Django image
+        run: docker load --input /tmp/django-image.tar
 
       - name: Run DB Migrations
         run: docker compose run --rm django python manage.py migrate --settings=config.settings.test
@@ -120,6 +151,7 @@ jobs:
       - linter
       - build-scss
       - js-tests
+      - build-django
       - pytest
     runs-on: ubuntu-latest
 
@@ -133,20 +165,17 @@ jobs:
           source: ".env.example"
           target: ".env"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Create docker network as used in dev
         run: docker network create caselaw
 
-      - name: Build the Stack
-        uses: docker/bake-action@v6
+      - name: Download Django image
+        uses: actions/download-artifact@v4
         with:
-          targets: django
-          load: true
-          set: |
-            *.cache-from=type=gha
-            *.cache-to=type=gha,mode=max
+          name: django-image
+          path: /tmp
+
+      - name: Load Django image
+        run: docker load --input /tmp/django-image.tar
 
       - name: Checkout Marklogic repo
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
       - name: Run tests
         run: npm test
 
-  # With no caching at all the entire ci process takes 4m 30s to complete!
   pytest:
     needs: linter
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,36 +17,6 @@ on:
   merge_group:
 
 jobs:
-  build-scss:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code Repository
-        uses: actions/checkout@v4
-
-      - name: Set up node
-        uses: actions/setup-node@v4.2.0
-
-      - name: Install node dependencies
-        run: npm ci
-
-      - name: Build scss
-        run: npm run build
-
-  js-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code Repository
-        uses: actions/checkout@v4
-
-      - name: Set up node
-        uses: actions/setup-node@v4.2.0
-
-      - name: Install node dependencies
-        run: npm ci
-
-      - name: Run tests
-        run: npm test
-
   linter:
     runs-on: ubuntu-latest
     steps:
@@ -66,8 +36,41 @@ jobs:
         env:
           SKIP: no-commit-to-branch,stylelint
 
+  build-scss:
+    needs: linter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v4
+
+      - name: Set up node
+        uses: actions/setup-node@v4.2.0
+
+      - name: Install node dependencies
+        run: npm ci
+
+      - name: Build scss
+        run: npm run build
+
+  js-tests:
+    needs: linter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@v4
+
+      - name: Set up node
+        uses: actions/setup-node@v4.2.0
+
+      - name: Install node dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
   # With no caching at all the entire ci process takes 4m 30s to complete!
   pytest:
+    needs: linter
     runs-on: ubuntu-latest
 
     steps:
@@ -109,6 +112,7 @@ jobs:
         run: docker compose down
 
   e2e-tests:
+    needs: linter
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
       - linter
       - build-scss
       - js-tests
+      - pytest
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,10 @@ jobs:
         run: docker compose down
 
   e2e-tests:
-    needs: linter
+    needs:
+      - linter
+      - build-scss
+      - js-tests
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,5 @@
 name: CI
 
-# Enable Buildkit and let compose use it to speed up image building
-env:
-  DOCKER_BUILDKIT: 1
-  COMPOSE_DOCKER_CLI_BUILD: 1
-
 on:
   pull_request:
     branches: ["master", "main"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,17 +77,27 @@ jobs:
           source: ".env.example"
           target: ".env"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Create docker network as used in dev
         run: docker network create caselaw
 
       - name: Build the Stack
-        run: docker compose build postgres django
+        uses: docker/bake-action@v6
+        with:
+          targets: django
+          load: true
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
 
       - name: Run DB Migrations
         run: docker compose run --rm django python manage.py migrate --settings=config.settings.test
 
       - name: Run Django Tests with coverage
         run: docker compose run django coverage run -m pytest -vvvv -rsa -m "not local"
+
       - name: Generate coverage XML
         run: docker compose run django coverage xml
 
@@ -122,11 +132,20 @@ jobs:
           source: ".env.example"
           target: ".env"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Create docker network as used in dev
         run: docker network create caselaw
 
       - name: Build the Stack
-        run: docker compose build postgres django
+        uses: docker/bake-action@v6
+        with:
+          targets: django
+          load: true
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
 
       - name: Checkout Marklogic repo
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
         run: docker compose run --rm django python manage.py migrate --settings=config.settings.test
 
       - name: Setup django server for e2e tests
-        run: docker compose up -d
+        run: docker compose up -d django
 
       - name: Install NPM deps
         run: npm install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   django:
+    image: ds_judgments_public_ui_django
     platform: linux/amd64
     build:
       context: .


### PR DESCRIPTION
Improve our build process with two goals:

- Don't perform unnecessary work if we can fail earlier; add prerequisite steps so that CI follows a logical pipeline
- Leverage GitHub Actions cache so that Docker can do less work rebuilding images from scratch each time

by:

- [x] Making `linter` have to run before anything else
- [x] Run `e2e_tests` only after both JS and SCSS have completed
- [x] Using the GitHub Actions cache for Docker layer caching
- [x] Making `e2e_tests` run after `pytest`
- [x] Only build our Django image once and reuse it between test steps