### PR TITLE
Try to preserve playwright test traces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,3 +192,10 @@ jobs:
           name: playwright-report
           path: artifacts
           retention-days: 7
+
+      - name: Tear down marklogic
+        run: docker compose down
+        working-directory: "./marklogic"
+
+      - name: Tear down the Stack
+        run: docker compose down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
-          path: playwright-report/
+          path: ./e2e_tests/test-results/ (in docker)
           retention-days: 30
 
       - name: Tear down marklogic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,14 @@ jobs:
         run: docker compose build e2e_tests
 
       - name: Run playwright e2e tests
-        run: docker compose run e2e_tests pytest --base-url http://django:3000
+        run: docker compose run e2e_tests pytest --base-url http://django:3000 --tracing retain-on-failure
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
 
       - name: Tear down marklogic
         run: docker compose down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,10 +154,6 @@ jobs:
         run: python ./development_scripts/populate_from_caselaw.py
         working-directory: "./marklogic"
 
-      - name: Publish imported documents
-        run: gradle publishAllDocuments
-        working-directory: "./marklogic"
-
       - name: Run DB Migrations
         run: docker compose run --rm django python manage.py migrate --settings=config.settings.test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,22 +172,21 @@ jobs:
 
       - name: Kick off the django server itself
         run: docker compose exec -d django python manage.py runserver 0.0.0.0:3000
+
       - name: Build playwright runner container
         run: docker compose build e2e_tests
+      - run: docker compose up -d e2e_tests
 
       - name: Run playwright e2e tests
-        run: docker compose run e2e_tests pytest --base-url http://django:3000 --tracing retain-on-failure
+        run: docker compose exec e2e_tests pytest --base-url http://django:3000 --tracing retain-on-failure
 
-      - uses: actions/upload-artifact@v4
+      - name: Copy trace files from container
+        run: docker compose cp e2e_tests:/app/test-results artifacts
+
+      - name: Upload trace files as github artifacts
+        uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
-          path: ./e2e_tests/test-results/ (in docker)
-          retention-days: 30
-
-      - name: Tear down marklogic
-        run: docker compose down
-        working-directory: "./marklogic"
-
-      - name: Tear down the Stack
-        run: docker compose down
+          path: artifacts
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,11 +181,13 @@ jobs:
         run: docker compose exec e2e_tests pytest --base-url http://django:3000 --tracing retain-on-failure
 
       - name: Copy trace files from container
+        if: ${{ always() }}
+
         run: docker compose cp e2e_tests:/app/test-results artifacts
 
       - name: Upload trace files as github artifacts
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+        if: ${{ always() }}
         with:
           name: playwright-report
           path: artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,8 +178,8 @@ jobs:
 
       - name: Copy trace files from container
         if: ${{ always() }}
-
         run: docker compose cp e2e_tests:/app/test-results artifacts
+        continue-on-error: true
 
       - name: Upload trace files as github artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -148,13 +148,13 @@ It's because the editor UI project is still running, you'll need to reopen that 
 Now go back to the Public UI project and use the same command `fab stop`.
 Now you can restart the project up again with `fab run`.
 
-### 8. Other development tips
+## Other development tips
 
 For day to day development, running `fab run` should provide you with all you need.
 
 Other useful commands are:
 
-#### Start Docker containers (in the background)
+### Start Docker containers (in the background)
 
 Note that running this command will fail if you have already started the application with
 `fab run`
@@ -163,19 +163,19 @@ Note that running this command will fail if you have already started the applica
 fab start
 ```
 
-#### To stop any running containers
+### To stop any running containers
 
 ```console
 fab stop
 ```
 
-#### Start a shell session with the 'django' container
+### Start a shell session with the 'django' container
 
 ```console
 fab sh
 ```
 
-#### Apply database migrations
+### Apply database migrations
 
 Run the following inside the `django` container
 
@@ -183,13 +183,13 @@ Run the following inside the `django` container
 python manage.py migrate
 ```
 
-#### Run a 'development' web server
+### Run a 'development' web server
 
 ```console
 python manage.py runserver_plus 0.0.0.0:3000
 ```
 
-#### Running the test suite
+### Running the test suite
 
 Pytest unit tests can be run with:
 
@@ -205,7 +205,7 @@ fab e2etest
 
 These will run by default against the running `django` container. You can supply a `baseURL` argument to test against staging or production.
 
-#### Accessibility testing with E2E tests
+### Accessibility testing with E2E tests
 
 We use axe playwright to automatically check for accessibility issues on our pages. When adding a new page, you should also add a test to ensure it is accessible and stays accessible.
 
@@ -219,7 +219,11 @@ def test_my_page(page: Page):
 
 If the page is accessible, the console won't output anything other than the usual test output. If there are accessibility issues, there will be output that explains what the issues are and also helpful links explaining how to fix them.
 
-#### Viewing code coverage
+#### Test traces in CI
+
+If there are failing tests in the end to end tests, there will be test traces available as artifacts in Github. Download the zipfile, extract a failing test file from inside (also a zip) and drag it onto the [Playwright Trace Viewer](https://trace.playwright.dev/)
+
+### Viewing code coverage
 
 ```console
 fab coverage
@@ -243,7 +247,7 @@ cannot load library 'gobject-2.0-0'
 
 Then it means the dependencies for WeasyPrint have not been installed correctly. Try rebuilding the docker image using the command `docker-compose build django` and then running `fab run`.
 
-## Setting up the pre-commit hooks (strongly advised)
+### Setting up the pre-commit hooks (strongly advised)
 
 To use this, you will need to install [pre-commit](https://pre-commit.com/) on your development machine, typically using `pip install pre-commit`. If you prefer Homebrew, you can use `brew install pre-commit`.
 
@@ -253,7 +257,7 @@ Install the git hooks configured in `.pre-commit-config.yaml` with:
 
 This will set up various checks including Python linting and style checks when you commit and push to the repo and alert you to any linting issues that will cause CI to fail.
 
-## Setting up commit signing
+### Setting up commit signing
 
 Any commit that's merged to `main` needs to be [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits), to ensure the identity of the author is who they say they are.
 

--- a/compose/local/e2e_tests/Dockerfile
+++ b/compose/local/e2e_tests/Dockerfile
@@ -7,4 +7,4 @@ COPY . .
 
 EXPOSE 9222
 
-CMD ["true"]
+CMD ["tail", "-f", "/dev/null"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,12 +56,15 @@ services:
     command: /start-docs
 
   e2e_tests:
+    container_name: e2e_tests_container
     build:
       context: ./e2e_tests
       dockerfile: "../compose/local/e2e_tests/Dockerfile"
+
     profiles: [e2e_tests]
     volumes:
       - "./e2e_tests:/app:z"
+    command: tail -f /dev/null
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     profiles: [e2e_tests]
     volumes:
       - "./e2e_tests:/app:z"
-    command: tail -f /dev/null
+    tty: true
 
 networks:
   default:


### PR DESCRIPTION
Playwright allows us to preserve the test traces so we can open them up in the [Playwright Trace Viewer](https://trace.playwright.dev/). This zips up the failing test traces, which is **not** a valid Trace file -- unzip it locally and drag one of the sub-zip files into the Trace Viewer to view.

Not 100% sure where the best place to see the artifacts is -- there is a link in the voluminous console log.

<img width="1134" alt="image" src="https://github.com/user-attachments/assets/84ff8a8e-4f2d-472b-a9d3-2728edc50b19" />
