### PR TITLE
Bump crispy-forms-gds to 2.0.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ rollbar
 django-weasyprint==2.4.0
 django-waffle==4.2.0  # https://github.com/django-waffle/django-waffle
 django-formtools~=2.5.1
-crispy-forms-gds==0.3.2
+crispy-forms-gds==2.0.1
 markdown-it-py~=3.0.0
 mdit-py-plugins~=0.4.0
 


### PR DESCRIPTION
Looks OK to me.

<img width="366" alt="Screenshot 2025-03-13 at 14 34 55" src="https://github.com/user-attachments/assets/0a6bcbca-f2b3-411e-901a-892441557dcf" />

<img width="367" alt="Screenshot 2025-03-13 at 14 34 40" src="https://github.com/user-attachments/assets/e90103e8-80fa-48df-bf6c-1c738c12f21f" />
