### PR TITLE
Pin crispy-forms-gds to 0.3.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ rollbar
 django-weasyprint==2.4.0
 django-waffle==4.2.0  # https://github.com/django-waffle/django-waffle
 django-formtools~=2.5.1
-crispy-forms-gds==0.3.2
+crispy-forms-gds==0.3.1
 markdown-it-py~=3.0.0
 mdit-py-plugins~=0.4.0
 


### PR DESCRIPTION
crispy-forms-gds 0.3.2 isn't compatible with Django 5. It's probable that 0.3.1 isn't, properly, but it doesn't complain. Revert to 0.3.1 for now, look at https://github.com/nationalarchives/ds-caselaw-public-ui/pull/1883 for longer term upgrade. 