### PR TITLE
[FCL-794] Fix broken tests under CI

### DIFF
--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -448,7 +448,6 @@ class TestDocumentHeadings(TestCaseWithMockAPI):
                     body=DocumentBodyFactory.build(
                         name="Press Summary of Judgment A (with some slightly different wording)",
                     ),
-                    neutral_citation="[2023] EAT 1",
                 )
                 press_summary_ncn = PressSummaryRelatedNCNIdentifier(value="[2023] EAT 1")
                 press_summary.identifiers.add(press_summary_ncn)
@@ -460,7 +459,6 @@ class TestDocumentHeadings(TestCaseWithMockAPI):
                     body=DocumentBodyFactory.build(
                         name="Judgment A",
                     ),
-                    neutral_citation="[2023] EAT 1",
                 )
                 judgment_ncn = NeutralCitationNumber(value="[2023] EAT 1")
                 judgment.identifiers.add(judgment_ncn)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-environ==0.12.0 # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 requests~=2.32.2
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=35.1.0
+ds-caselaw-marklogic-api-client==35.1.0
 ds-caselaw-utils==2.3.0
 rollbar
 django-weasyprint==2.4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-environ==0.12.0 # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 requests~=2.32.2
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client~=34.1.1
+ds-caselaw-marklogic-api-client~=35.1.0
 ds-caselaw-utils==2.3.0
 rollbar
 django-weasyprint==2.4.0


### PR DESCRIPTION
Our tests are failing because of press summaries not showing the expected preferred human identifier. This was the result of a change in the API Client to the prioritisation of identifiers.

To fix this we bump the API Client to v35.1.0 which includes better prioritisation, and we also pin the API Client package to an exact version which will prevent these kind of spooky failures in future. 