### PR TITLE
[FCL-758] fix error focus order for licence

### DIFF
--- a/ds_judgements_public_ui/static/js/src/transactional_licence_form.js
+++ b/ds_judgements_public_ui/static/js/src/transactional_licence_form.js
@@ -75,12 +75,12 @@ export const setupPreviousButton = function () {
     }
 };
 
-export const firstErrorField = function () {
+export const goToFirstErrorField = function () {
     $("html, body").animate(
         {
             scrollTop: $(".govuk-error-message").offset().top - 80,
         },
-        500,
+        1,
         function () {
             $(".govuk-error-message").focus();
         },
@@ -90,5 +90,5 @@ export const firstErrorField = function () {
 $(function () {
     setupTogglableFields();
     setupPreviousButton();
-    firstErrorField();
+    goToFirstErrorField();
 });

--- a/ds_judgements_public_ui/static/js/src/transactional_licence_form.js
+++ b/ds_judgements_public_ui/static/js/src/transactional_licence_form.js
@@ -75,7 +75,20 @@ export const setupPreviousButton = function () {
     }
 };
 
+export const firstErrorField = function () {
+    $("html, body").animate(
+        {
+            scrollTop: $(".govuk-error-message").offset().top - 80,
+        },
+        500,
+        function () {
+            $(".govuk-error-message").focus();
+        },
+    );
+};
+
 $(function () {
     setupTogglableFields();
     setupPreviousButton();
+    firstErrorField();
 });

--- a/ds_judgements_public_ui/static/js/tests/transactional_licence_form.test.js
+++ b/ds_judgements_public_ui/static/js/tests/transactional_licence_form.test.js
@@ -4,6 +4,7 @@ import $ from "jquery";
 import {
     setupTogglableFields,
     setupPreviousButton,
+    firstErrorField,
 } from "../src/transactional_licence_form";
 
 describe("setupTogglableFields", () => {
@@ -85,5 +86,37 @@ describe("setupPreviousButton", () => {
             "transactional-licence-form-previous-button",
         );
         expect(button.style.display).toBe("inline");
+    });
+});
+
+describe("firstErrorField", () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+          <div style="margin-top: 500px;" class="govuk-error-message" tabindex="-1">This is an error</div>
+    `;
+        $.fn.animate = function (props, duration, callback) {
+            callback();
+            return this;
+        };
+
+        $.fn.focus = jest.fn();
+    });
+
+    it("scrolls to the error-message and focuses it", () => {
+        const firstErrorField = function () {
+            $("html, body").animate(
+                {
+                    scrollTop: $(".govuk-error-message").offset().top - 80,
+                },
+                500,
+                function () {
+                    $(".govuk-error-message").focus();
+                },
+            );
+        };
+
+        firstErrorField();
+
+        expect($.fn.focus).toHaveBeenCalled();
     });
 });

--- a/ds_judgements_public_ui/static/js/tests/transactional_licence_form.test.js
+++ b/ds_judgements_public_ui/static/js/tests/transactional_licence_form.test.js
@@ -4,7 +4,7 @@ import $ from "jquery";
 import {
     setupTogglableFields,
     setupPreviousButton,
-    firstErrorField,
+    goToFirstErrorField,
 } from "../src/transactional_licence_form";
 
 describe("setupTogglableFields", () => {
@@ -89,7 +89,7 @@ describe("setupPreviousButton", () => {
     });
 });
 
-describe("firstErrorField", () => {
+describe("goToFirstErrorField", () => {
     beforeEach(() => {
         document.body.innerHTML = `
           <div style="margin-top: 500px;" class="govuk-error-message" tabindex="-1">This is an error</div>
@@ -103,19 +103,7 @@ describe("firstErrorField", () => {
     });
 
     it("scrolls to the error-message and focuses it", () => {
-        const firstErrorField = function () {
-            $("html, body").animate(
-                {
-                    scrollTop: $(".govuk-error-message").offset().top - 80,
-                },
-                500,
-                function () {
-                    $(".govuk-error-message").focus();
-                },
-            );
-        };
-
-        firstErrorField();
+        goToFirstErrorField();
 
         expect($.fn.focus).toHaveBeenCalled();
     });


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
fix focus order to move to the first error on page -users are now informed that an error has occurred on the page and no longer unaware of why they are not able to continue without having to navigate the page content to locate the error messages.
## Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136?selectedIssue=FCL-758
## Screenshots of UI changes:

### Before
[before.webm](https://github.com/user-attachments/assets/15b7dfda-98a4-4772-bd30-4f1dd1bc5069)

### After
[after-3.webm](https://github.com/user-attachments/assets/8b67d34e-4681-43ce-a002-cc5d7fb7af50)

- [ ] Requires env variable(s) to be updated
