### PR TITLE
[FCL-811] Remove duplicated declaration of canonical URL in document headers

### DIFF
--- a/ds_judgements_public_ui/templates/judgment/detail.html
+++ b/ds_judgements_public_ui/templates/judgment/detail.html
@@ -1,8 +1,5 @@
 {% extends "layouts/base.html" %}
 {% load document_utils waffle_tags static %}
-{% block extra_head_tags %}
-  <link rel="canonical" href="{{ document_canonical_url }}" />
-{% endblock extra_head_tags %}
 {% block javascript %}
   <script type="module" defer src="{% static 'js/dist/document_navigation_links.js' %}"></script>
   <script type="module" defer src="{% static 'js/dist/document_paragraph_tooltip_anchors.js' %}"></script>

--- a/judgments/views/detail/detail_html.py
+++ b/judgments/views/detail/detail_html.py
@@ -83,7 +83,6 @@ def detail_html(request, document_uri):
     context["search_context"] = search_context_from_url(request.META.get("HTTP_REFERER"))
     context["document"] = document
     context["page_canonical_url"] = document.public_uri
-    context["document_canonical_url"] = document.public_uri
     context["feedback_survey_document_uri"] = document.slug  # TODO: Remove this from context
     context["page_title"] = document.body.name  # TODO: Remove this from context
     context["pdf_uri"] = pdf.uri  # TODO: Remove this from context


### PR DESCRIPTION
We're declaring a canonical URL twice when we don't need to; clean it up.