### PR TITLE
Stop requiring django-stubs twice

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -31,4 +31,3 @@ pytest-timeout==2.3.1
 # type stubs
 types-python-dateutil==2.9.0.20241206
 types-requests==2.32.0.20250328
-django-stubs==5.1.3


### PR DESCRIPTION
`django-stubs` was for some reason included twice in the `local.txt` requirements file. We only need it once.