### PR TITLE
Run static analysis as its own parallel job in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,41 @@ jobs:
           name: django-image
           path: /tmp/django-image.tar
 
+  download-postgres:
+    needs: linter
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4.3.0
+
+      - name: Copy .env.example file
+        uses: canastro/copy-file-action@ae66602ce7d214dbd2e298c1db67a81388755a0a
+        with:
+          source: ".env.example"
+          target: ".env"
+
+      - name: Download Postgres image
+        run: docker compose pull postgres
+
+      - name: Save Postgres image
+        run: docker save -o /tmp/postgres-image.tar postgres
+
+      - name: Upload Postgres image
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: postgres-image
+          path: /tmp/postgres-image.tar
+
   static-analysis:
-    needs: build-django
+    needs:
+      - build-django
+      - download-postgres
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code Repository
@@ -127,8 +160,17 @@ jobs:
           name: django-image
           path: /tmp
 
+      - name: Download Postgres image
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: postgres-image
+          path: /tmp
+
       - name: Load Django image
         run: docker load --input /tmp/django-image.tar
+
+      - name: Load Postgres image
+        run: docker load --input /tmp/postgres-image.tar
 
       - name: Create docker network as used in dev
         run: docker network create caselaw
@@ -137,7 +179,9 @@ jobs:
         run: docker compose run django mypy ds_judgements_public_ui judgments
 
   pytest:
-    needs: build-django
+    needs:
+      - build-django
+      - download-postgres
     runs-on: ubuntu-latest
 
     steps:
@@ -161,8 +205,17 @@ jobs:
           name: django-image
           path: /tmp
 
+      - name: Download Postgres image
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: postgres-image
+          path: /tmp
+
       - name: Load Django image
         run: docker load --input /tmp/django-image.tar
+
+      - name: Load Postgres image
+        run: docker load --input /tmp/postgres-image.tar
 
       - name: Run DB Migrations
         run: docker compose run --rm django python manage.py migrate --settings=config.settings.test
@@ -186,6 +239,7 @@ jobs:
       - build-scss
       - js-tests
       - build-django
+      - download-postgres
       - pytest
       - static-analysis
     runs-on: ubuntu-latest
@@ -211,8 +265,17 @@ jobs:
           name: django-image
           path: /tmp
 
+      - name: Download Postgres image
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: postgres-image
+          path: /tmp
+
       - name: Load Django image
         run: docker load --input /tmp/django-image.tar
+
+      - name: Load Postgres image
+        run: docker load --input /tmp/postgres-image.tar
 
       - name: Checkout Marklogic repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,36 @@ jobs:
           name: django-image
           path: /tmp/django-image.tar
 
+  static-analysis:
+    needs: build-django
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Copy .env.example file
+        uses: canastro/copy-file-action@ae66602ce7d214dbd2e298c1db67a81388755a0a
+        with:
+          source: ".env.example"
+          target: ".env"
+
+      - name: Download Django image
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: django-image
+          path: /tmp
+
+      - name: Load Django image
+        run: docker load --input /tmp/django-image.tar
+
+      - name: Create docker network as used in dev
+        run: docker network create caselaw
+
+      - name: Run mypy
+        run: docker compose run django mypy ds_judgements_public_ui judgments
+
   pytest:
     needs: build-django
     runs-on: ubuntu-latest
@@ -143,9 +173,6 @@ jobs:
       - name: Generate coverage XML
         run: docker compose run django coverage xml
 
-      - name: Run mypy
-        run: docker compose run django mypy ds_judgements_public_ui judgments
-
       - name: Upload coverage to CodeClimate
         uses: paambaati/codeclimate-action@f429536ee076d758a24705203199548125a28ca7 # v9.0.0
         env:
@@ -156,11 +183,11 @@ jobs:
 
   e2e-tests:
     needs:
-      - linter
       - build-scss
       - js-tests
       - build-django
       - pytest
+      - static-analysis
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
At the moment we're running the `mypy` static analysis as a step within the `pytest` job. Optimise this by running it in parallel in its own job instead, reusing the already-built Docker image.

We also move downloading the `postgres` image to a job which runs in parallel and saves the result for reuse, rather than grabbing it separately in all the different jobs.