### PR TITLE
[FCL-829] Improve Atom feed following UUID-based URI switchover

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -79,15 +79,18 @@ class JudgmentAtomFeed(Atom1Feed):
 
     def add_item_elements(self, handler, item) -> None:
         super().add_item_elements(handler, item)
-        handler.addQuickElement("tna:contenthash", item.get("content_hash", ""))
-        link = item.get("link", "")
-        uri = item.get("uri", "")
-        handler.addQuickElement("tna:uri", uri)
-        if uri:
-            path_underscore = uri.replace("/", "_")
+
+        if content_hash := item.get("content_hash"):
+            handler.addQuickElement("tna:contenthash", content_hash)
+
+        if link := item.get("link"):
             handler.addQuickElement(
                 "link", "", {"rel": "alternate", "type": "application/akn+xml", "href": f"{link}/data.xml"}
             )
+
+        if uri := item.get("uri"):
+            handler.addQuickElement("tna:uri", uri)
+            path_underscore = uri.replace("/", "_")
             handler.addQuickElement(
                 "link",
                 "",

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -140,6 +140,7 @@ class JudgmentAtomFeed(Atom1Feed):
 class JudgmentsFeed(Feed):
     feed_type = JudgmentAtomFeed
     author_name = "The National Archives"
+    feed_copyright = "https://caselaw.nationalarchives.gov.uk/open-justice-licence"
 
     def items(self, obj) -> List[SearchResult]:
         return obj["search_response"].results

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -80,13 +80,13 @@ class JudgmentAtomFeed(Atom1Feed):
     def add_item_elements(self, handler, item) -> None:
         super().add_item_elements(handler, item)
         handler.addQuickElement("tna:contenthash", item.get("content_hash", ""))
-        path = item.get("uri", "")
-        handler.addQuickElement("tna:uri", path)
-        if path:
-            path_underscore = path.replace("/", "_")
-
+        link = item.get("link", "")
+        uri = item.get("uri", "")
+        handler.addQuickElement("tna:uri", uri)
+        if uri:
+            path_underscore = uri.replace("/", "_")
             handler.addQuickElement(
-                "link", "", {"rel": "alternate", "type": "application/akn+xml", "href": f"/{path}/data.xml"}
+                "link", "", {"rel": "alternate", "type": "application/akn+xml", "href": f"{link}/data.xml"}
             )
             handler.addQuickElement(
                 "link",
@@ -94,7 +94,7 @@ class JudgmentAtomFeed(Atom1Feed):
                 {
                     "rel": "alternate",
                     "type": "application/pdf",
-                    "href": f"https://assets.caselaw.nationalarchives.gov.uk/{path}/{path_underscore}.pdf",
+                    "href": f"https://assets.caselaw.nationalarchives.gov.uk/{uri}/{path_underscore}.pdf",
                 },
             )
 
@@ -147,8 +147,11 @@ class JudgmentsFeed(Feed):
     def item_title(self, item):
         return item.name
 
+    def item_guid(self, item) -> str:
+        return "https://caselaw.nationalarchives.gov.uk/id/" + item.uri
+
     def item_link(self, item) -> str:
-        return reverse("detail", kwargs={"document_uri": item.uri})
+        return reverse("detail", args=[item.slug])
 
     def item_author_name(self, item) -> Optional[str]:
         return item.court

--- a/judgments/tests/fixture_data.py
+++ b/judgments/tests/fixture_data.py
@@ -1,26 +1,4 @@
-from dataclasses import dataclass
-from datetime import datetime
-
-
-@dataclass
-class FakeMetadata:
-    author = "author"
-
-
-@dataclass
-class FakeSearchResult:
-    uri = "d-123456789abcdef"
-    neutral_citation = "neutral_citation"
-    name = "A SearchResult name!"
-    matches = None
-    court = "court"
-    date = datetime(2017, 8, 8, 0, 0)
-    author = "author"
-    last_modified = "last_modified"
-    content_hash = "content_hash"
-    transformation_date = "2023-04-09T18:05:45"
-    metadata = FakeMetadata()
-    slug = "fcl.x1y2z3"
+from caselawclient.factories import SearchResultFactory
 
 
 class FakeSearchResponseBaseClass:
@@ -31,16 +9,16 @@ class FakeSearchResponseBaseClass:
 
     total = 200
     results = [
-        FakeSearchResult(),
-        FakeSearchResult(),
-        FakeSearchResult(),
-        FakeSearchResult(),
-        FakeSearchResult(),
-        FakeSearchResult(),
-        FakeSearchResult(),
-        FakeSearchResult(),
-        FakeSearchResult(),
-        FakeSearchResult(),
+        SearchResultFactory.build(),
+        SearchResultFactory.build(),
+        SearchResultFactory.build(),
+        SearchResultFactory.build(),
+        SearchResultFactory.build(),
+        SearchResultFactory.build(),
+        SearchResultFactory.build(),
+        SearchResultFactory.build(),
+        SearchResultFactory.build(),
+        SearchResultFactory.build(),
     ]
     facets = {
         "EAT": "3",

--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -44,9 +44,9 @@ class TestAtomFeed(TestCase):
         # that it has an entry
         self.assertIn("<entry>", decoded_response)
         # and it contains actual content - neither neutral citation or court appear in the feed to test.
-        self.assertIn("A SearchResult name!", decoded_response)
+        self.assertIn("<title>Judgment v Judgement</title>", decoded_response)
         # and that the author is listed as the court, not the submitter.
-        self.assertIn("<author><name>court</name></author>", decoded_response)
+        self.assertIn("<author><name>Court of Testing</name></author>", decoded_response)
 
     @patch("judgments.feeds.search_judgments_and_parse_response")
     @patch("judgments.feeds.api_client")
@@ -98,7 +98,7 @@ class TestAtomFeed(TestCase):
         response = self.client.get("/atom.xml")
         decoded_response = response.content.decode("utf-8")
         self.assertEqual(response.status_code, 200)
-        self.assertIn("A SearchResult name!", decoded_response)
+        self.assertIn("<title>Judgment v Judgement</title>", decoded_response)
 
     def test_redirect_full(self):
         response = self.client.get("/ewhc/ch/2024/atom.xml")

--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -1,3 +1,4 @@
+import xml.etree.ElementTree as ET
 from unittest.mock import patch
 
 from caselawclient.search_parameters import SearchParameters
@@ -7,16 +8,34 @@ from judgments.tests.fixture_data import FakeSearchResponse, FakeSearchResponseM
 
 
 class TestAtomFeed(TestCase):
+    namespaces = {
+        "": "http://www.w3.org/2005/Atom",
+        "tna": "https://caselaw.nationalarchives.gov.uk",
+    }
+
     @patch("judgments.feeds.search_judgments_and_parse_response")
     @patch("judgments.feeds.api_client")
     def test_feed_exists(self, mock_api_client, mock_search_judgments_and_parse_response):
-        search_response = FakeSearchResponse()
-        mock_search_judgments_and_parse_response.return_value = search_response
+        """Check that the feed actually returns something."""
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
 
         response = self.client.get("/atom.xml")
-        decoded_response = response.content.decode("utf-8")
 
-        # that search_judgments_and_parse_response is called with the appropriate parameters
+        # that there is a successful response
+        self.assertEqual(response.status_code, 200)
+
+        # that it has the expected Content-Type
+        self.assertEqual(response["Content-Type"], "application/xml; charset=utf-8")
+
+    @patch("judgments.feeds.search_judgments_and_parse_response")
+    @patch("judgments.feeds.api_client")
+    def test_feed_query_handling(self, mock_api_client, mock_search_judgments_and_parse_response):
+        """Check that the feed is performing the expected searches behind the scenes."""
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
+
+        self.client.get("/atom.xml")
+
+        # that search_judgments_and_parse_response is called with the expected parameters
         mock_search_judgments_and_parse_response.assert_called_with(
             mock_api_client,
             SearchParameters(
@@ -32,21 +51,64 @@ class TestAtomFeed(TestCase):
             ),
         )
 
-        # that there is a successful response
-        self.assertEqual(response.status_code, 200)
-        # that it is an atom feed
-        self.assertEqual(response["Content-Type"], "application/xml; charset=utf-8")
+    @patch("judgments.feeds.search_judgments_and_parse_response")
+    @patch("judgments.feeds.api_client")
+    def test_feed_metadata(self, mock_api_client, mock_search_judgments_and_parse_response):
+        """Check that the basic feed metadata is intact."""
+        search_response = FakeSearchResponse()
+        mock_search_judgments_and_parse_response.return_value = search_response
 
-        # that it has the correct site name
-        self.assertIn("<name>The National Archives</name>", decoded_response)
-        # that it is like an Atom XML document
-        self.assertIn("http://www.w3.org/2005/Atom", decoded_response)
-        # that it has an entry
-        self.assertIn("<entry>", decoded_response)
-        # and it contains actual content - neither neutral citation or court appear in the feed to test.
-        self.assertIn("<title>Judgment v Judgement</title>", decoded_response)
-        # and that the author is listed as the court, not the submitter.
-        self.assertIn("<author><name>Court of Testing</name></author>", decoded_response)
+        response = self.client.get("/atom.xml")
+
+        feed_xml_tree = ET.fromstring(response.content.decode("utf-8"))
+
+        # We implicitly test that this is an Atom feed in the process of these assertions, since otherwise it won't parse and resolve the namespace.
+        assert feed_xml_tree.find("id", self.namespaces).text == "https://caselaw.nationalarchives.gov.uk/atom.xml"
+        assert feed_xml_tree.find("author/name", self.namespaces).text == "The National Archives"
+
+    @patch("judgments.feeds.search_judgments_and_parse_response")
+    @patch("judgments.feeds.api_client")
+    def test_feed_entry(self, mock_api_client, mock_search_judgments_and_parse_response):
+        """Check that a feed has the expected entry format."""
+        search_response = FakeSearchResponse()
+        mock_search_judgments_and_parse_response.return_value = search_response
+
+        response = self.client.get("/atom.xml")
+        feed_xml_tree = ET.fromstring(response.content.decode("utf-8"))
+
+        entry = feed_xml_tree.find("entry", self.namespaces)
+
+        assert entry.find("title", self.namespaces).text == "Judgment v Judgement"
+        assert entry.find("id", self.namespaces).text == "https://caselaw.nationalarchives.gov.uk/id/d-a1b2c3"
+        assert entry.find("published", self.namespaces).text == "2023-02-03T00:00:00+00:00"
+        assert entry.find("updated", self.namespaces).text == "2023-02-03T12:34:00+00:00"
+        assert entry.find("author/name", self.namespaces).text == "Court of Testing"
+
+        assert (
+            entry.find("tna:contenthash", self.namespaces).text
+            == "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73"
+        )
+        assert entry.find("tna:uri", self.namespaces).text == "d-a1b2c3"
+
+        self.assertCountEqual(
+            [e.attrib for e in entry.findall("link", self.namespaces)],
+            [
+                {
+                    "href": "http://testserver/uksc/2025/1",
+                    "rel": "alternate",
+                },
+                {
+                    "href": "http://testserver/uksc/2025/1/data.xml",
+                    "rel": "alternate",
+                    "type": "application/akn+xml",
+                },
+                {
+                    "href": "https://assets.caselaw.nationalarchives.gov.uk/d-a1b2c3/d-a1b2c3.pdf",
+                    "rel": "alternate",
+                    "type": "application/pdf",
+                },
+            ],
+        )
 
     @patch("judgments.feeds.search_judgments_and_parse_response")
     @patch("judgments.feeds.api_client")

--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -65,6 +65,10 @@ class TestAtomFeed(TestCase):
         # We implicitly test that this is an Atom feed in the process of these assertions, since otherwise it won't parse and resolve the namespace.
         assert feed_xml_tree.find("id", self.namespaces).text == "https://caselaw.nationalarchives.gov.uk/atom.xml"
         assert feed_xml_tree.find("author/name", self.namespaces).text == "The National Archives"
+        assert (
+            feed_xml_tree.find("rights", self.namespaces).text
+            == "https://caselaw.nationalarchives.gov.uk/open-justice-licence"
+        )
 
     @patch("judgments.feeds.search_judgments_and_parse_response")
     @patch("judgments.feeds.api_client")

--- a/judgments/tests/test_homepage.py
+++ b/judgments/tests/test_homepage.py
@@ -13,7 +13,7 @@ class TestHomepage(TestCase):
         mock_cached_recent_judgments.return_value = FakeSearchResponse()
         response = self.client.get("/")
         mock_cached_recent_judgments.assert_called_once()
-        self.assertContains(response, "A SearchResult name!", html=True)
+        self.assertContains(response, "Judgment v Judgement", html=True)
 
     @patch("judgments.views.index.api_client")
     @patch("judgments.views.index.search_judgments_and_parse_response")

--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -37,9 +37,9 @@ class TestBrowseResults(TestCase):
                 page_size=10,
             ),
         )
-        self.assertContains(response, "A SearchResult name!", html=True)
+        self.assertContains(response, "Judgment v Judgement", html=True)
         # search results reference the slug not the uri
-        self.assertContains(response, "/fcl.x1y2z3")
+        self.assertContains(response, "/uksc/2025/1")
         self.assertNotContains(response, "d-123456789abcdef")
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-environ==0.12.0 # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 requests~=2.32.2
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==36.0.0
+ds-caselaw-marklogic-api-client==36.0.1
 ds-caselaw-utils==2.4.3
 rollbar
 django-weasyprint==2.4.0


### PR DESCRIPTION
The Atom feed was making some unsafe (but not unreasonable) assumptions about where documents would be located.

This commit changes the Atom feed so that in each `entry`:

- The `link` of an entry now points to the preferred public URL
- The `id` of an entry now refers to the canonical URI of its work (see [ADR 4](https://github.com/nationalarchives/ds-find-caselaw-docs/blob/main/doc/adr/0004-adopt-a-standardised-url-scheme.md#works)). This _may_ cause duplicate entries to appear in some feed readers, but we're going to break things one way or another by changing `link` and this gives us resiliency against if a document's preferred URL changes in future.
- The XML alternate URL is now to a working resource, and is fully qualified rather than relative

And as an added bonus:

- Add a new `rights` element to the `feed` with a link to the OJL

## Examples

### Before

```xml
<entry>
    <title>Foo v Bar</title>
    <link href="https://caselaw.nationalarchives.gov.uk/d-914f4dc2-0bbf-4375-be82-e0542fb18f02" rel="alternate"/>
    <published>2025-04-29T00:00:00+00:00</published>
    <updated>2025-04-29T14:14:59+00:00</updated>
    <author>
        <name>First-tier Tribunal (General Regulatory Chamber) – Transport</name>
    </author>
    <id>https://caselaw.nationalarchives.gov.uk/d-914f4dc2-0bbf-4375-be82-e0542fb18f02</id>
    <summary type="html"/>
    <tna:contenthash>b9ee2626a13fb18b53906f777e7e7814dca1ad95e5821a3e4d4b4c5bd0b28f33</tna:contenthash>
    <tna:uri>d-914f4dc2-0bbf-4375-be82-e0542fb18f02</tna:uri>
    <link href="/d-914f4dc2-0bbf-4375-be82-e0542fb18f02/data.xml" rel="alternate" type="application/akn+xml"/>
    <link href="https://assets.caselaw.nationalarchives.gov.uk/d-914f4dc2-0bbf-4375-be82-e0542fb18f02/d-914f4dc2-0bbf-4375-be82-e0542fb18f02.pdf" rel="alternate" type="application/pdf"/>
</entry>
```

### After
```xml
<entry>
    <title>Foo v Bar</title>
    <link href="//caselaw.nationalarchives.gov.uk/ukftt/grc/2024/123" rel="alternate"/>
    <published>2025-04-29T00:00:00+00:00</published>
    <updated>2025-04-29T14:14:59+00:00</updated>
    <author>
        <name>First-tier Tribunal (General Regulatory Chamber) – Transport</name>
    </author>
    <id>https://caselaw.nationalarchives.gov.uk/id/d-914f4dc2-0bbf-4375-be82-e0542fb18f02</id>
    <summary type="html"/>
    <tna:contenthash>b9ee2626a13fb18b53906f777e7e7814dca1ad95e5821a3e4d4b4c5bd0b28f33</tna:contenthash>
    <tna:uri>d-914f4dc2-0bbf-4375-be82-e0542fb18f02</tna:uri>
    <link href="https://caselaw.nationalarchives.gov.uk/ukftt/grc/2024/123/data.xml" rel="alternate" type="application/akn+xml"/>
    <link href="https://assets.caselaw.nationalarchives.gov.uk/d-914f4dc2-0bbf-4375-be82-e0542fb18f02/d-914f4dc2-0bbf-4375-be82-e0542fb18f02.pdf" rel="alternate" type="application/pdf"/>
</entry>
```

### Diff

```diff
<entry>
    <title>Foo v Bar</title>
-    <link href="https://caselaw.nationalarchives.gov.uk/d-914f4dc2-0bbf-4375-be82-e0542fb18f02" rel="alternate"/>
+    <link href="https://caselaw.nationalarchives.gov.uk/ukftt/grc/2024/123" rel="alternate"/>
    <published>2025-04-29T00:00:00+00:00</published>
    <updated>2025-04-29T14:14:59+00:00</updated>
    <author>
        <name>First-tier Tribunal (General Regulatory Chamber) – Transport</name>
    </author>
-    <id>https://caselaw.nationalarchives.gov.uk/d-914f4dc2-0bbf-4375-be82-e0542fb18f02</id>
+    <id>https://caselaw.nationalarchives.gov.uk/id/d-914f4dc2-0bbf-4375-be82-e0542fb18f02</id>
    <summary type="html"/>
    <tna:contenthash>b9ee2626a13fb18b53906f777e7e7814dca1ad95e5821a3e4d4b4c5bd0b28f33</tna:contenthash>
    <tna:uri>d-914f4dc2-0bbf-4375-be82-e0542fb18f02</tna:uri>
-    <link href="/d-914f4dc2-0bbf-4375-be82-e0542fb18f02/data.xml" rel="alternate" type="application/akn+xml"/>
+    <link href="https://caselaw.nationalarchives.gov.uk/ukftt/grc/2024/123/data.xml" rel="alternate" type="application/akn+xml"/>
    <link href="https://assets.caselaw.nationalarchives.gov.uk/d-914f4dc2-0bbf-4375-be82-e0542fb18f02/d-914f4dc2-0bbf-4375-be82-e0542fb18f02.pdf" rel="alternate" type="application/pdf"/>
</entry>
```

## Jira

FCL-829
