### PR TITLE
bump API to 36.0.2 -- T3 NCNs

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-environ==0.12.0 # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 requests~=2.32.2
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==36.0.1
+ds-caselaw-marklogic-api-client==36.0.2
 ds-caselaw-utils==2.4.3
 rollbar
 django-weasyprint==2.4.0


### PR DESCRIPTION
<!-- Amend as appropriate -->

Support EWCOP (T3) NCNs

## Changes in this PR:

## Jira card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
