### PR TITLE
FCL-754 | fix issues with sticky judgment header

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_document_navigation_links.scss
+++ b/ds_judgements_public_ui/sass/includes/_document_navigation_links.scss
@@ -2,7 +2,7 @@
   position: fixed;
   top: 0;
 
-  width: 100vw;
+  width: 100%;
   padding: $spacer-unit 0 0;
 
   background-color: colour-var("background");
@@ -55,28 +55,19 @@
   justify-content: space-between;
 
   box-sizing: border-box;
-  width: 100vw;
+  width: 100%;
   margin: auto;
   margin: 0;
   padding: $space-4;
   padding: $spacer-unit;
-
   border-bottom: 1px solid colour-var("font-base");
   border-bottom: none;
-
-  &__query-wrapper {
-    grid-column: 2;
-  }
-
-  &__down-wrapper {
-    grid-column: 3;
-    text-align: right;
-  }
 
   &__up-wrapper {
     grid-column: 1;
     grid-row: 1;
     text-align: right;
+    white-space: nowrap;
 
     @media (max-width: $grid-breakpoint-medium) {
       text-align: left;
@@ -87,6 +78,7 @@
     grid-column: 5;
     grid-row: 1;
     text-align: left;
+    white-space: nowrap;
 
     @media (max-width: $grid-breakpoint-medium) {
       text-align: right;
@@ -118,6 +110,7 @@
     grid-column: 2;
     grid-row: 1;
     text-align: right;
+    white-space: nowrap;
 
     @media (max-width: $grid-breakpoint-medium) {
       grid-column: 1;
@@ -129,6 +122,7 @@
   &__query-wrapper {
     grid-column: 3;
     grid-row: 1;
+    line-height: $typography-xl-line-height;
     text-align: center;
 
     @media (max-width: $grid-breakpoint-medium) {
@@ -152,6 +146,7 @@
     grid-column: 4;
     grid-row: 1;
     text-align: left;
+    white-space: nowrap;
 
     @media (max-width: $grid-breakpoint-medium) {
       grid-column: 3;
@@ -322,9 +317,9 @@
   }
 
   &__query-text {
+    border-bottom: 3px solid $color-yellow;
     font-weight: $typography-bold-font-weight;
     background-color: transparent;
-    border-bottom: 3px solid $color-yellow;
   }
 
   @media (max-width: $grid-breakpoint-medium) {


### PR DESCRIPTION
## Changes in this PR:

Fixes the judgment sticky header on various breakpoints.

One of the main issues was we were using `100vw` for the width, which doesn't take into account of scrollbars. `width:100%` works perfectly fine instead and takes into consideration if the user has scrollbars visible or not.

Also removed some redundant styles that were being directly overridden below.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-754

## Screenshots of UI changes:

### Before

<img width="656" alt="image" src="https://github.com/user-attachments/assets/54d02904-b383-4a1e-8fb8-f63253967398" />

<img width="792" alt="image" src="https://github.com/user-attachments/assets/69f46827-de4c-4b04-932c-421b06cb0096" />


### After

<img width="624" alt="image" src="https://github.com/user-attachments/assets/bc384f92-27f0-4716-a78d-25de4d25e83c" />

<img width="838" alt="image" src="https://github.com/user-attachments/assets/db71653f-011c-47f5-a012-603e5b3c7af1" />