### PR TITLE
FCL-822 Use doc.content_as_html not doc.body's

### DIFF
--- a/judgments/views/detail/detail_html.py
+++ b/judgments/views/detail/detail_html.py
@@ -36,7 +36,7 @@ def detail_html(request, document_uri):
         document = get_published_document_by_uri(document_uri, search_query=cleaned_search_query)
         context["query"] = query
         if document.body.has_content:
-            document_content = document.body.content_as_html()
+            document_content = document.content_as_html()
             if document_content:
                 context["number_of_mentions"] = number_of_mentions(document_content, cleaned_search_query)
     else:
@@ -50,7 +50,7 @@ def detail_html(request, document_uri):
     # TODO: handle multiple documents
 
     context["linked_document_uri"] = related_documents[0].slug if related_documents else None
-    context["document_html"] = document.body.content_as_html()
+    context["document_html"] = document.content_as_html()
     context["pdf_size"] = f" ({filesizeformat(pdf.size)})" if pdf.size else " (unknown size)"
 
     form: AdvancedSearchForm = AdvancedSearchForm(request.GET)

--- a/judgments/views/detail/generated_pdf.py
+++ b/judgments/views/detail/generated_pdf.py
@@ -30,7 +30,7 @@ class PdfDetailView(WeasyTemplateResponseMixin, TemplateView):
 
         self.pdf_filename = f"{document.uri}.pdf"
 
-        context["document"] = document.body.content_as_html()
+        context["document"] = document.content_as_html()
 
         return context
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-environ==0.12.0 # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 requests~=2.32.2
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==36.0.2
+ds-caselaw-marklogic-api-client==37.0.0
 ds-caselaw-utils==2.4.3
 rollbar
 django-weasyprint==2.4.0


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCL-822

Uses API Client 37 to correctly write the image names.
