### PR TITLE
Use identifier for XML filename not marklogic uri

### DIFF
--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -176,6 +176,7 @@ class TestRobotsDirectives(TestCaseWithMockAPI):
         mock_get_document_by_uri.assert_called_with("ml-eat/2023/1")
         self.assertContains(response, "This is a document.")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow,noai")
+        self.assertEqual(response.headers.get("Content-Disposition"), "attachment; filename=tna.tn4t35ts.xml")
 
     @patch("judgments.views.detail.detail_xml.get_published_document_by_uri")
     def test_xml_press_summary(self, mock_get_document_by_uri):
@@ -184,6 +185,7 @@ class TestRobotsDirectives(TestCaseWithMockAPI):
         mock_get_document_by_uri.assert_called_with("ml-eat/2023/1/press-summary/1")
         self.assertContains(response, "This is a document.")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow,noai")
+        self.assertEqual(response.headers.get("Content-Disposition"), "attachment; filename=tna.tn4t35ts.xml")
 
     @patch.object(PdfDetailView, "pdf_stylesheets", [])
     @patch("judgments.views.detail.generated_pdf.PdfDetailView.get_context_data")

--- a/judgments/views/detail/detail_xml.py
+++ b/judgments/views/detail/detail_xml.py
@@ -12,5 +12,6 @@ def detail_xml(_request, document_uri: DocumentURIString) -> HttpResponse:
     document_xml = document.body.content_as_xml
 
     response = HttpResponse(document_xml, content_type="application/xml")
-    response["Content-Disposition"] = f"attachment; filename={document.uri}.xml"
+    slug_filename = document.slug.replace("/", "_")
+    response["Content-Disposition"] = f"attachment; filename={slug_filename}.xml"
     return response


### PR DESCRIPTION
When downloading the XML it would download with the filename of the marklogic URI. Instead download with a public identifier.

Before:
<img width="467" alt="image" src="https://github.com/user-attachments/assets/be2de2fc-4b6a-4216-8584-9c14a23aa7da" />

