### PR TITLE
FCL-178 | ensure we validate the word count for the public statement …

### DIFF
--- a/transactional_licence_form/forms.py
+++ b/transactional_licence_form/forms.py
@@ -3,7 +3,7 @@ from crispy_forms_gds.layout import Field, Layout
 from django import forms
 
 from . import choices, fields
-from .utils import countries_and_territories_choices, list_to_choices
+from .utils import countries_and_territories_choices, list_to_choices, validate_max_words
 
 
 class FCLForm(forms.Form):
@@ -139,7 +139,8 @@ class PublicStatementForm(FCLForm):
     public_statement = fields.FCLCharField(
         label="15. Please provide a public statement",
         help_text="Please aim for 150 words",
-        widget=forms.Textarea(attrs={"maxlength": 1500}),
+        widget=forms.Textarea(),
+        validators=[lambda v: validate_max_words(v, max_words=150)],
     )
 
 

--- a/transactional_licence_form/forms.py
+++ b/transactional_licence_form/forms.py
@@ -138,7 +138,7 @@ class PublicStatementForm(FCLForm):
 
     public_statement = fields.FCLCharField(
         label="15. Please provide a public statement",
-        help_text="Please aim for 150 words",
+        help_text="Please aim for 50-150 words",
         widget=forms.Textarea(),
         validators=[lambda v: validate_max_words(v, max_words=150)],
     )

--- a/transactional_licence_form/utils.py
+++ b/transactional_licence_form/utils.py
@@ -5,6 +5,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 
@@ -87,3 +88,9 @@ def sanitize_and_format_response_as_xml(form_data):
         else:
             sanitized_fields[key] = sanitize_value(value)
     return render_to_string(EMAIL_TEMPLATE_PATH, sanitized_fields)
+
+
+def validate_max_words(value, max_words=150):
+    word_count = len(value.split())
+    if word_count > max_words:
+        raise ValidationError(f"Maximum {max_words} words allowed.")

--- a/transactional_licence_form/utils.py
+++ b/transactional_licence_form/utils.py
@@ -90,7 +90,7 @@ def sanitize_and_format_response_as_xml(form_data):
     return render_to_string(EMAIL_TEMPLATE_PATH, sanitized_fields)
 
 
-def validate_max_words(value, max_words=150):
+def validate_max_words(value: str, max_words: int = 150):
     word_count = len(value.split())
     if word_count > max_words:
         raise ValidationError(f"Maximum {max_words} words allowed.")


### PR DESCRIPTION
…field

## Changes in this PR:

Validates the public statement field on submit to ensure the user doesn't go over 150.

Also note `maxlength` isn't a valid field on a textarea, and it wouldn't work anyway as we're limiting on words not characters.

Wording might need adjusting?

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-178

## Screenshots of UI changes:

<img width="763" alt="image" src="https://github.com/user-attachments/assets/555a4f74-6a4c-4d0a-a9b1-c6e91d0e03bb" />
