### PR TITLE
FCL-846 | add box-sizing to cookie banner after it's been moved

### DIFF
--- a/ds_judgements_public_ui/sass/includes/cookie_consent/_cookie-consent.scss
+++ b/ds_judgements_public_ui/sass/includes/cookie_consent/_cookie-consent.scss
@@ -1,4 +1,6 @@
 #ds-cookie-consent-banner {
+  box-sizing: border-box;
+
   .container {
     @include container;
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

The cookie banner was moved at some point which caused a horizontal scroll because it doesn't have the correct box sizing set. This fixes that.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-846

## Screenshots of UI changes:

### Before

<img width="432" alt="image" src="https://github.com/user-attachments/assets/f671290e-57bf-47af-97f9-a06200d58644" />


### After

<img width="452" alt="image" src="https://github.com/user-attachments/assets/919e7a67-0f59-4f34-a806-60865309fc25" />

