### PR TITLE
Fcl 737/move breadcrumbs out of header

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_breadcrumbs.scss
+++ b/ds_judgements_public_ui/sass/includes/_breadcrumbs.scss
@@ -1,9 +1,11 @@
 .breadcrumbs {
-  display: flex;
-  align-items: end;
-  padding: $space-4 0 $space-2 0;
+  background-color: colour-var("contrast-background");
 
   &__flex-container {
+    display: flex;
+    align-items: end;
+    padding: $space-4 0 $space-2 0;
+
     @media only screen and (max-width: $grid-breakpoint-medium) {
       flex-grow: 1;
     }
@@ -49,7 +51,6 @@
           width: 7px;
           height: 7px;
           margin: auto 0;
-
           border: solid;
           border-color: colour-var("contrast-link");
           border-width: 0.125rem 0.125rem 0 0;

--- a/ds_judgements_public_ui/sass/includes/_breadcrumbs.scss
+++ b/ds_judgements_public_ui/sass/includes/_breadcrumbs.scss
@@ -5,10 +5,6 @@
     display: flex;
     align-items: end;
     padding: $space-4 0 $space-2 0;
-
-    @media only screen and (max-width: $grid-breakpoint-medium) {
-      flex-grow: 1;
-    }
   }
 
   ol {
@@ -54,6 +50,11 @@
           border: solid;
           border-color: colour-var("contrast-link");
           border-width: 0.125rem 0.125rem 0 0;
+
+          @media only screen and (max-width: $grid-breakpoint-medium) {
+            top: 6px;
+            bottom: auto;
+          }
         }
       }
     }
@@ -64,7 +65,6 @@
   }
 
   &__prefix {
-    margin-right: $space-2;
     color: colour-var("contrast-link");
   }
 

--- a/ds_judgements_public_ui/templates/includes/breadcrumbs.html
+++ b/ds_judgements_public_ui/templates/includes/breadcrumbs.html
@@ -18,22 +18,24 @@
 </script>
 
 <div class="breadcrumbs">
-  <nav class="breadcrumbs__flex-container"
-       aria-label="Breadcrumb">
-    <ol>
-      <li>
-        <span class="breadcrumbs__prefix">You are in:</span>
-        <a href="{% url 'home' %}">Find Case Law</a>
-      </li>
-      {% for breadcrumb in breadcrumbs %}
-        {% if breadcrumb.url %}
-          <li>
-            <a href="{{ breadcrumb.url }}">{{ breadcrumb.text }}</a>
-          </li>
-        {% else %}
-          <li>{{ breadcrumb.text }}</li>
-        {% endif %}
-      {% endfor %}
-    </ol>
-  </nav>
+  <div class="container">
+    <nav class="breadcrumbs__flex-container"
+         aria-label="Breadcrumb">
+      <ol>
+        <li>
+          <span class="breadcrumbs__prefix">You are in:</span>
+          <a href="{% url 'home' %}">Find Case Law</a>
+        </li>
+        {% for breadcrumb in breadcrumbs %}
+          {% if breadcrumb.url %}
+            <li>
+              <a href="{{ breadcrumb.url }}">{{ breadcrumb.text }}</a>
+            </li>
+          {% else %}
+            <li>{{ breadcrumb.text }}</li>
+          {% endif %}
+        {% endfor %}
+      </ol>
+    </nav>
+  </div>
 </div>

--- a/ds_judgements_public_ui/templates/includes/breadcrumbs.html
+++ b/ds_judgements_public_ui/templates/includes/breadcrumbs.html
@@ -23,7 +23,7 @@
          aria-label="Breadcrumb">
       <ol>
         <li>
-          <span class="breadcrumbs__prefix">You are in:</span>
+          <span class="breadcrumbs__prefix">You are in</span>
           <a href="{% url 'home' %}">Find Case Law</a>
         </li>
         {% for breadcrumb in breadcrumbs %}

--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -46,12 +46,13 @@
       <header class="govuk-header" data-module="govuk-header">
         <div class="container">
           {% include "includes/header.html" %}
-          {% block breadcrumbs %}
-            {% include "includes/breadcrumbs.html" %}
-          {% endblock breadcrumbs %}
         </div>
       </header>
     {% endblock header %}
+
+    {% block breadcrumbs %}
+      {% include "includes/breadcrumbs.html" %}
+    {% endblock breadcrumbs %}
 
     {% include "includes/notifications.html" %}
     {% block precontent %}


### PR DESCRIPTION
## Changes in this PR:

Some adjustments to the breadcrumbs:

 - Move it out of the header so it's semantically correct
 - Remove the colon and padding from the prefix
 - Fix the chevron on mobile so it's aligned correctly

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-737

## Screenshots of UI changes:

### Before

<img width="415" alt="image" src="https://github.com/user-attachments/assets/327e67a2-ea59-4f36-bcb3-3ce8e3552b09" />

### After

<img width="414" alt="image" src="https://github.com/user-attachments/assets/89ebb7b6-4ac6-49e0-ba4b-02d5174de0fd" />

