### PR TITLE
FCL-792 | adjust homepage card text lineheight

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_document_navigation_links.scss
+++ b/ds_judgements_public_ui/sass/includes/_document_navigation_links.scss
@@ -122,7 +122,7 @@
   &__query-wrapper {
     grid-column: 3;
     grid-row: 1;
-    line-height: $typography-xl-line-height;
+    line-height: $typography-2xl-line-height;
     text-align: center;
 
     @media (max-width: $grid-breakpoint-medium) {

--- a/ds_judgements_public_ui/sass/includes/_homepage_cards.scss
+++ b/ds_judgements_public_ui/sass/includes/_homepage_cards.scss
@@ -118,7 +118,7 @@
     margin: 0;
 
     font-size: $typography-sm-text-size;
-    line-height: $typography-md-line-height;
+    line-height: $typography-lg-line-height;
     color: colour-var("accent-font-base");
     text-decoration: none;
 

--- a/ds_judgements_public_ui/sass/includes/_judgments_listing.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgments_listing.scss
@@ -18,7 +18,7 @@
   }
 
   &__judgment {
-    line-height: $typography-2xl-line-height;
+    line-height: $typography-3xl-line-height;
 
     > span:first-child {
       @media (min-width: $grid-breakpoint-medium) {
@@ -55,7 +55,7 @@
     font-family: $font-roboto;
     font-size: $typography-md-text-size;
     font-weight: $typography-normal-font-weight;
-    line-height: $typography-lg-line-height;
+    line-height: $typography-xl-line-height;
   }
 
   &__court {

--- a/ds_judgements_public_ui/sass/includes/_mixins.scss
+++ b/ds_judgements_public_ui/sass/includes/_mixins.scss
@@ -124,7 +124,7 @@
   border-radius: 0;
 
   font-size: $typography-md-text-size;
-  line-height: $typography-lg-line-height;
+  line-height: $typography-xl-line-height;
   color: colour-var("input-foreground");
 
   appearance: none;

--- a/ds_judgements_public_ui/sass/includes/_results_search_component.scss
+++ b/ds_judgements_public_ui/sass/includes/_results_search_component.scss
@@ -19,7 +19,7 @@
     font-family: $font-roboto;
     font-size: $typography-md-text-size;
     font-weight: $typography-bold-font-weight;
-    line-height: $typography-3xl-line-height;
+    line-height: $typography-4xl-line-height;
     color: colour-var("accent-font-base");
   }
 

--- a/ds_judgements_public_ui/sass/includes/_standard_content.scss
+++ b/ds_judgements_public_ui/sass/includes/_standard_content.scss
@@ -11,7 +11,7 @@
     padding-top: $space-10;
 
     font-size: $typography-md-text-size;
-    line-height: $typography-lg-line-height;
+    line-height: $typography-xl-line-height;
 
     @media (min-width: $grid-breakpoint-medium) {
       flex-direction: row;

--- a/ds_judgements_public_ui/sass/includes/_typography.scss
+++ b/ds_judgements_public_ui/sass/includes/_typography.scss
@@ -52,13 +52,13 @@ code {
 
 mark {
   scroll-margin-top: 50vh;
+  border-bottom: 3px solid $color-yellow;
   font-weight: $typography-bold-font-weight;
   background-color: transparent;
-  border-bottom: 3px solid $color-yellow;
 
   &.current {
-    background-color: $color-yellow;
     border-top: 3px solid $color-yellow;
+    background-color: $color-yellow;
   }
 }
 
@@ -112,4 +112,8 @@ mark {
 
 .xl3-line-height {
   line-height: $typography-3xl-line-height;
+}
+
+.xl4-line-height {
+  line-height: $typography-4xl-line-height;
 }

--- a/ds_judgements_public_ui/sass/includes/_variables.scss
+++ b/ds_judgements_public_ui/sass/includes/_variables.scss
@@ -22,10 +22,11 @@ $typography-base-line-height: 1.2;
 $typography-xs-line-height: 0.8;
 $typography-sm-line-height: 1;
 $typography-md-line-height: 1.2;
-$typography-lg-line-height: 1.5;
+$typography-lg-line-height: 1.3;
 $typography-xl-line-height: 1.8;
 $typography-2xl-line-height: 2;
 $typography-3xl-line-height: 2.6;
+$typography-4xl-line-height: 2.6;
 $typography-normal-font-weight: 400;
 $typography-bold-font-weight: 700;
 

--- a/ds_judgements_public_ui/templates/includes/style_guide/line_heights.html
+++ b/ds_judgements_public_ui/templates/includes/style_guide/line_heights.html
@@ -2,11 +2,12 @@
 <p>These are the variables available to style your components:</p>
 
 <div class="style-guide__component-wrapper" >
-    <div class="style-guide__component-wrapper xl3-line-height">$typography-3xl-line-height</div>
-    <div class="style-guide__component-wrapper xl2-line-height">$typography-2xl-line-height</div>
-    <div class="style-guide__component-wrapper xl-line-height">$typography-xl-line-height</div>
-    <div class="style-guide__component-wrapper lg-line-height">$typography-lg-line-height</div>
-    <div class="style-guide__component-wrapper md-line-height">$typography-md-line-height</div>
-    <div class="style-guide__component-wrapper sm-line-height">$typography-sm-line-height</div>
-    <div class="style-guide__component-wrapper xs-line-height">$typography-xs-line-height</div>
+  <div class="style-guide__component-wrapper xl4-line-height">$typography-4xl-line-height</div>
+  <div class="style-guide__component-wrapper xl3-line-height">$typography-3xl-line-height</div>
+  <div class="style-guide__component-wrapper xl2-line-height">$typography-2xl-line-height</div>
+  <div class="style-guide__component-wrapper xl-line-height">$typography-xl-line-height</div>
+  <div class="style-guide__component-wrapper lg-line-height">$typography-lg-line-height</div>
+  <div class="style-guide__component-wrapper md-line-height">$typography-md-line-height</div>
+  <div class="style-guide__component-wrapper sm-line-height">$typography-sm-line-height</div>
+  <div class="style-guide__component-wrapper xs-line-height">$typography-xs-line-height</div>
 </div>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Adjust the line-height of the cards text component. As the requested line height wasn't one in our list of variables, I needed to add another and adjust the existing variable usage.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-792

## Screenshots of UI changes:

### Before

<img width="1196" alt="image" src="https://github.com/user-attachments/assets/3d609670-d68b-4992-81a3-e3830db0989e" />

### After

<img width="1194" alt="image" src="https://github.com/user-attachments/assets/ea4c04da-e63f-4b21-8cd0-721acf7b119a" />

