### PR TITLE
Fcl 835/update view all button

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_footer.scss
+++ b/ds_judgements_public_ui/sass/includes/_footer.scss
@@ -5,7 +5,7 @@
   background-color: colour-var("accent-background-light");
 
   h2 {
-    margin-bottom: 0;
+    margin: 0;
     padding-top: 0;
     font-size: $typography-lg-text-size;
     font-weight: $typography-normal-font-weight;
@@ -14,8 +14,12 @@
   &__container {
     @include container;
 
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
     margin-top: 0;
-    padding: $space-1 0 $space-8 $space-8;
+    padding: $space-8 0;
   }
 }
 
@@ -93,6 +97,7 @@
     font-weight: bold;
 
     @media (max-width: $grid-breakpoint-medium) {
+      margin-top: 0;
       margin-bottom: $space-1;
       padding-top: $space-4;
       font-size: $space-6;

--- a/ds_judgements_public_ui/templates/includes/recent_judgments.html
+++ b/ds_judgements_public_ui/templates/includes/recent_judgments.html
@@ -7,7 +7,7 @@
         <a role="button"
            draggable="false"
            rel="noreferrer noopener"
-           class="recent-judgments__cta-button button-secondary"
+           class="recent-judgments__cta-button button-primary"
            href="{% url 'search' %}">View all judgments</a>
       </div>
     </section>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Change the "view all judgments" from a secondary to primary button.

After doing this it was very clear the pre-footer wasn't centrally aligned. I've fixed that.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-835

## Screenshots of UI changes:

### Before

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/59c5960b-7d9c-4da6-9f2b-3642308f8d02" />

### After

<img width="1217" alt="image" src="https://github.com/user-attachments/assets/30971f2c-13c2-450f-9c14-cd13782a63e6" />
