### PR TITLE
FCL-835 | remove visited all judgments button styling

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_recent_judgments.scss
+++ b/ds_judgements_public_ui/sass/includes/_recent_judgments.scss
@@ -48,10 +48,4 @@
     flex-direction: column;
     justify-content: center;
   }
-
-  &__cta-button {
-    &:visited {
-      color: brand-colour("navy");
-    }
-  }
 }


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Fix for the view all judgments button showing up as blue text when visited.

## Jira card / Rollbar error (etc)


https://national-archives.atlassian.net/browse/FCL-835

### Before

<img width="353" alt="image" src="https://github.com/user-attachments/assets/407c6df7-9493-4981-bc61-a8bd6eb26705" />


### After

<img width="338" alt="image" src="https://github.com/user-attachments/assets/be7da42f-93b5-41fa-9fe6-80dc5f6b1f95" />
