### PR TITLE
[FCL-823] Atom feed lists document identifiers

### DIFF
--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -112,6 +112,12 @@ class TestAtomFeed(TestCase):
         assert entry_tna_contenthash is not None
         assert entry_tna_contenthash.text == "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73"
 
+        entry_tna_neutral_citation = entry.find("tna:identifier", self.namespaces)
+        assert entry_tna_neutral_citation is not None
+        assert entry_tna_neutral_citation.text == "[2025] UKSC 123"
+        assert entry_tna_neutral_citation.attrib["type"] == "ukncn"
+        assert entry_tna_neutral_citation.attrib["slug"] == "uksc/2025/123"
+
         entry_tna_uri = entry.find("tna:uri", self.namespaces)
         assert entry_tna_uri is not None
         assert entry_tna_uri.text == "d-a1b2c3"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-environ==0.12.0 # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 requests~=2.32.2
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==37.1.0
+ds-caselaw-marklogic-api-client==37.2.0
 ds-caselaw-utils==2.4.6
 rollbar
 django-weasyprint==2.4.0


### PR DESCRIPTION
## Changes in this PR:
We add a tna:identifier tag, if there is are identifiers in the search results.

Needs API client updating with https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/1038

## Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136?selectedIssue=FCL-823

## Screenshots of UI changes:

```
<tna:identifier slug="ukftt/grc/2025/547" type="ukncn">[2025] UKFTT 547 (GRC)</tna:identifier>
<tna:identifier slug="tna.98dnps87" type="fclid">98dnps87</tna:identifier>
```
