### PR TITLE
[FCL-852] Swap sitemap to use document preferred slug and not uri

### DIFF
--- a/config/tests/test_caching.py
+++ b/config/tests/test_caching.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+
+
+class TestCacheHeaders(TestCase):
+    def test_static_headers(self):
+        url = "/static/images/tna_logo.svg"
+        response = self.client.get(url)
+        assert response.headers["Cache-Control"] == "max-age=900, public"
+
+    def test_view_headers(self):
+        url = "/about-this-service"
+        response = self.client.get(url)
+        assert response.headers["Cache-Control"] == "max-age=900, public"
+
+    def test_no_cache_transactional_steps(self):
+        url = "/re-use-find-case-law-records/steps/organization"
+        response = self.client.get(url)
+        assert response.headers["Cache-Control"] == "max-age=0, no-cache, no-store, must-revalidate, public"

--- a/config/tests/test_schema.py
+++ b/config/tests/test_schema.py
@@ -2,27 +2,9 @@ from unittest.mock import patch
 
 import pytest
 from django.http import Http404
-from django.test import TestCase
 
 from config.views.schema import schema
 from judgments.tests.fixtures import TestCaseWithMockAPI
-
-
-class TestCacheHeaders(TestCase):
-    def test_static_headers(self):
-        url = "/static/images/tna_logo.svg"
-        response = self.client.get(url)
-        assert response.headers["Cache-Control"] == "max-age=900, public"
-
-    def test_view_headers(self):
-        url = "/about-this-service"
-        response = self.client.get(url)
-        assert response.headers["Cache-Control"] == "max-age=900, public"
-
-    def test_no_cache_transactional_steps(self):
-        url = "/re-use-find-case-law-records/steps/organization"
-        response = self.client.get(url)
-        assert response.headers["Cache-Control"] == "max-age=0, no-cache, no-store, must-revalidate, public"
 
 
 class TestSchemas(TestCaseWithMockAPI):

--- a/config/tests/test_sitemap.py
+++ b/config/tests/test_sitemap.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+from unittest.mock import patch
+
+from caselawclient.factories import SearchResultFactory
+from django.test import TestCase
+
+from judgments.models import CourtDates
+from judgments.tests.fixture_data import FakeSearchResponseBaseClass
+
+
+class MockCourtYearSearchResult(FakeSearchResponseBaseClass):
+    results = [
+        SearchResultFactory.build(
+            uri="d-a1b2c3", slug="test/2025/123", transformation_date=datetime(2025, 1, 1, 1, 23).isoformat()
+        ),
+        SearchResultFactory.build(
+            uri="d-d4e5f6", slug="test/2025/456", transformation_date=datetime(2025, 2, 2, 4, 56).isoformat()
+        ),
+    ]
+
+
+class TestSitemaps(TestCase):
+    def setUp(self):
+        CourtDates.objects.create(param="testcourt", start_year=2023, end_year=2025)
+        CourtDates.objects.create(param="testcourt/b", start_year=2025, end_year=2025)
+
+    def test_sitemap_index_returns_expected_values(self):
+        response = self.client.get("/sitemap.xml")
+
+        assert response.status_code == 200
+
+        self.assertContains(response, "sitemap-static.xml")
+        self.assertContains(response, "sitemap-courts.xml")
+        self.assertContains(response, "sitemap-court-testcourt-2023.xml")
+        self.assertContains(response, "sitemap-court-testcourt-2024.xml")
+        self.assertContains(response, "sitemap-court-testcourt-2025.xml")
+        self.assertContains(response, "sitemap-court-testcourt/b-2025.xml")
+
+    def test_sitemap_static(self):
+        response = self.client.get("/sitemap-static.xml")
+
+        assert response.status_code == 200
+
+    def test_sitemap_courts(self):
+        response = self.client.get("/sitemap-courts.xml")
+
+        assert response.status_code == 200
+
+        self.assertContains(response, "courts-and-tribunals/testcourt")
+        self.assertContains(response, "courts-and-tribunals/testcourt/b")
+
+    @patch("config.views.sitemaps.search_judgments_and_parse_response")
+    def test_sitemap_court_year(self, mock_search_judgments_and_parse_response):
+        mock_search_judgments_and_parse_response.return_value = MockCourtYearSearchResult()
+
+        response = self.client.get("/sitemap-court-testcourt/b-2025.xml")
+
+        assert response.status_code == 200
+
+        self.assertContains(response, "/test/2025/123")
+        self.assertNotContains(response, "d-a1b2c3")
+        self.assertContains(response, "2025-01-01")
+
+        self.assertContains(response, "/test/2025/456")
+        self.assertNotContains(response, "d-d4e5f6")
+        self.assertContains(response, "2025-02-02")

--- a/config/views/sitemaps.py
+++ b/config/views/sitemaps.py
@@ -111,7 +111,7 @@ class SitemapCourtView(TemplateView, TemplateResponseMixin):
 
             context["items"] = [
                 {
-                    "url": self.request.build_absolute_uri("/" + result.uri),
+                    "url": self.request.build_absolute_uri("/" + result.slug),
                     "lastmod": datetime.datetime.strptime(result.transformation_date, "%Y-%m-%dT%H:%M:%S")
                     .date()
                     .isoformat(),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-environ==0.12.0 # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 requests~=2.32.2
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==37.0.0
+ds-caselaw-marklogic-api-client==37.0.2
 ds-caselaw-utils==2.4.4
 rollbar
 django-weasyprint==2.4.0


### PR DESCRIPTION
The document's URI no longer necessarily matches a resolvable URL; use the preferred identifier slug in links in the sitemap instead.

## Jira

FCL-852