### PR TITLE
[FCL-862] Swap Atom XSLT to use correct link tag instead of id

### DIFF
--- a/ds_judgements_public_ui/static/atom.xsl
+++ b/ds_judgements_public_ui/static/atom.xsl
@@ -52,7 +52,7 @@
       <h3>
         <a target="_blank">
           <xsl:attribute name="href">
-            <xsl:value-of select="atom:id"/>
+            <xsl:value-of select="atom:link[@rel='alternate']/@href"/>
           </xsl:attribute>
           <xsl:value-of select="atom:title"/>
         </a>


### PR DESCRIPTION
Using the value of the `<id>` element instead of the appropriate `<link>` tag means links to individual documents in the Atom feed for users viewing it in the browser do not resolve correctly.