### PR TITLE
Filter out pdfs from atom feed

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -273,6 +273,10 @@ class SearchJudgmentsFeed(JudgmentsFeed):
             search_parameters.order = "-date"
             search_parameters.page_size = per_page_integer
 
+        # for now we will filter out any records that don't have an HTML representation
+        # as we don't want to bloat the feed with records that don't have a HTML representation
+        search_parameters.only_with_html_representation = True
+
         search_response = search_judgments_and_parse_response(api_client, search_parameters)
         return {
             "query_string": request.GET.get("query", default=""),

--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -48,6 +48,7 @@ class TestAtomFeed(TestCase):
                 order="-date",
                 page=1,
                 page_size=50,
+                only_with_html_representation=True,
             ),
         )
 
@@ -163,6 +164,7 @@ class TestAtomFeed(TestCase):
                 date_to=None,
                 order="date",
                 page=5,
+                only_with_html_representation=True,
             ),
         )
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-environ==0.12.0 # https://github.com/joke2k/django-environ
 django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 requests~=2.32.2
 wsgi-basic-auth~=1.1.0
-ds-caselaw-marklogic-api-client==37.2.0
+ds-caselaw-marklogic-api-client==37.3.0
 ds-caselaw-utils==2.4.6
 rollbar
 django-weasyprint==2.4.0


### PR DESCRIPTION
## Changes in this PR:

Filter out pdfs from atom feed

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-558

**⚠️  Warning ⚠️ :** needs https://github.com/nationalarchives/ds-caselaw-marklogic/releases/tag/v4.2.0 to be deployed to corresponding environment when deploying this change