### PR TITLE
FCL-870 | fix typo on border css

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_results_search_component.scss
+++ b/ds_judgements_public_ui/sass/includes/_results_search_component.scss
@@ -198,7 +198,7 @@
     display: inline-block;
 
     padding: $space-2 $space-2 $space-2 $space-4;
-    border: 0.188rem colour-var("accent-brand");
+    border: 0.188rem solid colour-var("accent-brand");
 
     color: colour-var("accent-link");
     text-decoration: none;


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Puts the border weight back in that was accidentally removed. 

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-870

## Screenshots of UI changes:

### Before

<img width="376" alt="image" src="https://github.com/user-attachments/assets/6d461c31-f9da-4991-b160-cb91a8fef3bf" />


### After

<img width="360" alt="image" src="https://github.com/user-attachments/assets/f82625d1-6858-4133-ac45-dd3414ef4552" />

