### PR TITLE
Install node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,11 +52,22 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   # WeasyPrint dependencies \
   weasyprint \
   python3-cffi python3-brotli libpango-1.0-0 libpangoft2-1.0-0 \
-  # node install
-  nodejs npm \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js
+# Download and install nvm:
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash \
+  # in lieu of restarting the shell
+  \. "$HOME/.nvm/nvm.sh" \
+  # Download and install Node.js:
+  nvm install 22 \
+  # Verify the Node.js version:
+  node -v \
+  nvm current \
+  # Verify npm version:
+  npm -v
 
 # All absolute dir copies ignore workdir instruction. All relative dir copies are wrt to the workdir instruction
 # copy python dependency wheels from python-build-stage


### PR DESCRIPTION
## Changes in this PR:

Install node 22 so we are on the LTS version of node. Recently our PUI docker builds broke as https://github.com/stylelint-scss/stylelint-config-recommended-scss/ got updated and now requires node versions >= 20. Prebiously we were not specifying which node version we use but I believe it was below 20