### PR TITLE
Fix node installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,23 +51,15 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   curl \
   # WeasyPrint dependencies \
   weasyprint \
-  python3-cffi python3-brotli libpango-1.0-0 libpangoft2-1.0-0 \
-  # cleaning up unused files
-  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-  && rm -rf /var/lib/apt/lists/*
+  python3-cffi python3-brotli libpango-1.0-0 libpangoft2-1.0-0
 
-# Install Node.js
-# Download and install nvm:
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash \
-  # in lieu of restarting the shell
-  \. "$HOME/.nvm/nvm.sh" \
-  # Download and install Node.js:
-  nvm install 22 \
-  # Verify the Node.js version:
-  node -v \
-  nvm current \
-  # Verify npm version:
-  npm -v
+# Install Specific Node.js version
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x  | bash -
+RUN apt-get -y install nodejs
+
+# cleaning up unused files
+RUN apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && rm -rf /var/lib/apt/lists/*
 
 # All absolute dir copies ignore workdir instruction. All relative dir copies are wrt to the workdir instruction
 # copy python dependency wheels from python-build-stage


### PR DESCRIPTION
## Changes in this PR:

Fix node installation

My initial attempt had issues due to using nvm and how without dealing with the shell each RUN is executed in, npm wasn't being placed on the path. Don't need a version manager, just need the one version of node, so this way is simpler.


Have verified locally that this gets past the issue we originally had by temporarily adding the line 
`RUN npm install stylelint-config-recommended-scss@15.0.1` after the 2 lines installing node/np and it works!