### PR TITLE
FCL-770 | add new judgment text styling under feature flag

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_document_detail.scss
+++ b/ds_judgements_public_ui/sass/includes/_document_detail.scss
@@ -1,0 +1,18 @@
+body {
+  &.document-detail {
+    background: brand-colour("white");
+  }
+
+  &.document-detail-v2 {
+    .judgment {
+      font-family: $font-pt-serif;
+      font-size: $typography-md-text-size;
+      line-height: $typography-xl-line-height;
+
+      @media (min-width: $grid-breakpoint-medium) {
+        max-width: 44rem;
+        font-size: $typography-lg-text-size;
+      }
+    }
+  }
+}

--- a/ds_judgements_public_ui/sass/includes/_layout.scss
+++ b/ds_judgements_public_ui/sass/includes/_layout.scss
@@ -21,10 +21,6 @@ body {
   font-family: $font-open-sans;
   color: colour-var("font-base");
   background: colour-var("background");
-
-  &.document-detail {
-    background: brand-colour("white");
-  }
 }
 
 html {

--- a/ds_judgements_public_ui/sass/includes/_variables.scss
+++ b/ds_judgements_public_ui/sass/includes/_variables.scss
@@ -9,6 +9,7 @@ $grid-breakpoint-extra-large: 1200px;
 // TODO: Rename these
 $font-roboto: "Roboto", sans-serif;
 $font-open-sans: "Open Sans", sans-serif;
+$font-pt-serif: "PT serif", serif;
 $font-serif: serif;
 $typography-display-font-family: $font-roboto;
 $typography-body-font-family: $font-open-sans;

--- a/ds_judgements_public_ui/sass/main.scss
+++ b/ds_judgements_public_ui/sass/main.scss
@@ -91,6 +91,8 @@ $govuk-focus-colour: colour-var("focus-outline");
 @import "includes/sticky_menu";
 
 // Judgments
+@import "includes/document_detail";
+
 @import "includes/judgment_document_paragraph_anchors";
 @import "includes/judgment_text_download_options";
 @import "includes/judgment_catalogue_card";

--- a/ds_judgements_public_ui/templates/judgment/detail.html
+++ b/ds_judgements_public_ui/templates/judgment/detail.html
@@ -12,7 +12,7 @@
   {% include "includes/survey_banner.html" %}
   {% include "includes/judgment_text_toolbar.html" %}
 {% endblock precontent %}
-{% block body_class %}document-detail{% endblock body_class %}
+{% block body_class %}document-detail {% flag document_detail_v2 %}document-detail-v2{% endflag %}{% endblock body_class %}
 {% block content %}
   {% include "includes/judgment_navigation.html" %}
   {% if document_html %}

--- a/ds_judgements_public_ui/templates/layouts/base.html
+++ b/ds_judgements_public_ui/templates/layouts/base.html
@@ -1,4 +1,4 @@
-{% load static navigation_tags %}
+{% load static navigation_tags waffle_tags %}
 <!DOCTYPE html>
 <html lang="en-gb">
   <head>
@@ -26,6 +26,9 @@
     {% block css %}
       <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&amp;family=Roboto:wght@400;600;700&amp;family=Roboto+Mono:wght@400;600;700&amp;display=swap"
             rel="stylesheet" />
+      {% flag document_detail_v2 %}
+        <link href="https://fonts.googleapis.com/css2?family=PT+Serif:wght@400;700&display=swap" rel="stylesheet" />
+      {% endflag %}
       <link href="{% static 'css/includes/govuk-country-and-territory-autocomplete/location-autocomplete.min.css' %}"
             rel="stylesheet" />
       <link href="{% static 'css/main.css' %}" rel="stylesheet" />


### PR DESCRIPTION
## Changes in this PR:

Adds the new judgment text styling under a feature flag.

## Jira card / Rollbar error (etc)

## Screenshots of UI changes:

### Before header desktop

<img width="1426" alt="image" src="https://github.com/user-attachments/assets/ac16cf64-afb8-436b-95d3-e92e1fad68de" />


### After header desktop

<img width="1426" alt="image" src="https://github.com/user-attachments/assets/fff41afa-f49f-4146-8821-c294a051c3c5" />


### Before header mobile:

<img width="455" alt="image" src="https://github.com/user-attachments/assets/9bce45b6-18b8-44fa-9a83-74594715a4d9" />

### After header mobile

<img width="454" alt="image" src="https://github.com/user-attachments/assets/73adcc55-5c94-4773-9d9b-85ef3d7da0d6" />


### Before body desktop

<img width="1425" alt="image" src="https://github.com/user-attachments/assets/4729f0e8-c97a-455b-ab2f-755f131fa44d" />

### After body desktop

<img width="1425" alt="image" src="https://github.com/user-attachments/assets/16fcdcd3-39a0-4344-8c92-bb4c960be8ff" />


### Before body mobile

<img width="453" alt="image" src="https://github.com/user-attachments/assets/1e2330d1-c7fb-4099-b8d9-cfa879822333" />

### After body mobile

<img width="456" alt="image" src="https://github.com/user-attachments/assets/60c8521e-1479-4356-8cc1-87b88b7ccffc" />

