### PR TITLE
FCL-868 | remove padding causing alignment issues

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_results_search_component.scss
+++ b/ds_judgements_public_ui/sass/includes/_results_search_component.scss
@@ -14,7 +14,7 @@
     flex-shrink: 0;
 
     margin: 0 $space-1 0 0;
-    padding: 0.1rem 0 0;
+    padding: 0;
 
     font-family: $font-roboto;
     font-size: $typography-md-text-size;


### PR DESCRIPTION
## Changes in this PR:

Fixes an alignment issue on the search results page.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-868

## Screenshots of UI changes:

### Before

<img width="344" alt="image" src="https://github.com/user-attachments/assets/dee53d94-8ada-4c76-8234-af4d5adf6917" />

### After

<img width="341" alt="image" src="https://github.com/user-attachments/assets/a96d4c0e-4655-470a-b527-33ea60cbe287" />
