### PR TITLE
FCL-867 | remove align text right on search labels

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_result_controls.scss
+++ b/ds_judgements_public_ui/sass/includes/_result_controls.scss
@@ -49,6 +49,5 @@
 
   @media (min-width: $grid-breakpoint-extra-large) {
     margin: 0;
-    text-align: right;
   }
 }


### PR DESCRIPTION
## Changes in this PR:

Remove the align text right on search labels

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-867

## Screenshots of UI changes:

### Before

<img width="372" alt="image" src="https://github.com/user-attachments/assets/048ace4b-0c22-4bd2-8108-4a1755ea183c" />

### After

<img width="376" alt="image" src="https://github.com/user-attachments/assets/03da7b77-6c71-4305-95f9-983854dfea1b" />
