### PR TITLE
Always display catalogue card on non-HTML documents

### DIFF
--- a/ds_judgements_public_ui/templates/judgment/detail.html
+++ b/ds_judgements_public_ui/templates/judgment/detail.html
@@ -34,5 +34,9 @@
 
 {% block postcontent %}
   {% include "includes/judgment_text_download_options.html" %}
-  {% flag "document_catalogue_card" %}{% include "includes/judgment_catalogue_card.html" %}{% endflag %}
+  {% if not document_html %}
+    {% include "includes/judgment_catalogue_card.html" %}
+  {% else %}
+    {% flag "document_catalogue_card" %}{% include "includes/judgment_catalogue_card.html" %}{% endflag %}
+  {% endif %}
 {% endblock postcontent %}


### PR DESCRIPTION
The catalogue card component is currently feature flagged for all documents; make it always appear for documents without HTML representation.