### PR TITLE
FCL-883 | add min widths to judgment columns so it's always got enoug…

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgments_table.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgments_table.scss
@@ -62,10 +62,16 @@
       }
 
       td {
+        min-width: 200px;
         padding: $space-4 0;
         border-bottom: 1px solid colour-var("accent-background-light");
+
         text-align: left;
         vertical-align: top;
+
+        &:last-child {
+          min-width: 115px;
+        }
       }
 
       @media (max-width: $grid-breakpoint-medium) {


### PR DESCRIPTION


## Changes in this PR:

Fixes the spacing issue when there is a judgment with a very long title as seen on production.


## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-883?atlOrigin=eyJpIjoiYTc5NGIyMzllMGQyNGU5NjgxMzMyYzgzZDhkNWYyMmIiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

## Screenshots of UI changes:

### Before

<img width="1187" alt="image" src="https://github.com/user-attachments/assets/83538514-3eee-4a78-978d-e820f15b6e32" />


### After

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/d9105bcf-4f3c-412b-912c-9012c821fa2e" />
