### PR TITLE
[FCL-884] Remove feedback banner from document pages

### DIFF
--- a/ds_judgements_public_ui/templates/judgment/detail.html
+++ b/ds_judgements_public_ui/templates/judgment/detail.html
@@ -9,7 +9,6 @@
   Find Case Law
 {% endblock title %}
 {% block precontent %}
-  {% include "includes/survey_banner.html" %}
   {% include "includes/judgment_text_toolbar.html" %}
 {% endblock precontent %}
 {% block body_class %}document-detail{% endblock body_class %}


### PR DESCRIPTION
The blue feedback banner should not be present on document pages; remove it.