### PR TITLE
Fcl 903/fix estate agent tribunal dates

### DIFF
--- a/judgments/templatetags/court_utils.py
+++ b/judgments/templatetags/court_utils.py
@@ -60,10 +60,15 @@ def get_court_date_range(court_param: CourtParam) -> str:
         court_dates = CourtDates.objects.get(pk=court_param)
         start_year = court_dates.start_year
         end_year = court_dates.end_year
+
     except CourtDates.DoesNotExist:
         court = all_courts.get_by_param(court_param)
         start_year = court.start_year
         end_year = court.end_year
+
+    if not start_year and end_year:
+        return mark_safe("%s&nbsp;to&nbsp;%s" % (end_year, end_year + 1))
+
     if start_year == end_year:
         return str(start_year)
     else:

--- a/judgments/tests/test_courts.py
+++ b/judgments/tests/test_courts.py
@@ -59,6 +59,11 @@ class TestCourtDatesHelper(TestCase):
         court = self.mock_court_dates(2011, 2012)
         self.assertEqual(get_court_date_range(court), "2013&nbsp;to&nbsp;2015")
 
+    def test_when_court_with_param_exists_and_end_year_but_no_start_year(self, get):
+        get.return_value = self.mock_court_dates(None, 2009)
+        court = self.mock_court_dates(None, 2009)
+        self.assertEqual(get_court_date_range(court), "2009&nbsp;to&nbsp;2010")
+
 
 class TestCourtContentHelpers(TestCase):
     def mock_court_param(self, param):


### PR DESCRIPTION
## Changes in this PR:

We have a case where Estate Agents Tribunal doesn't have a "Start date" and as such we want to show the start date as the end date, and the end date as a year later.

This feels a bit hacky, so maybe I've misunderstood this, but I'm not sure how the dates for these are generated.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-903

## Screenshots of UI changes:

### Before

<img width="471" alt="image" src="https://github.com/user-attachments/assets/35933155-21d0-481e-8235-13114036ba61" />


### After

<img width="469" alt="image" src="https://github.com/user-attachments/assets/39efc3af-3200-4ea5-8a2b-64ea3065433f" />


