### PR TITLE
FCL-903 | update utils to 2.4.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 requests~=2.32.2
 wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client==37.4.0
-ds-caselaw-utils==2.4.6
+ds-caselaw-utils==2.4.7
 rollbar
 django-weasyprint==2.4.0
 django-waffle==4.2.0  # https://github.com/django-waffle/django-waffle


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Update utils to 2.4.7 to get the estate tribunal date changes.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-903

## Screenshots of UI changes:

<img width="468" alt="image" src="https://github.com/user-attachments/assets/e1fe22a3-44b3-493f-9b8b-42f21b9a7174" />

