### PR TITLE
Remove e2e_build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,8 +324,7 @@ jobs:
         run: docker compose exec -d django python manage.py runserver 0.0.0.0:3000
 
       - name: Build playwright runner container
-        run: docker compose build e2e_tests
-      - run: docker compose up -d e2e_tests
+        run: docker compose up -d e2e_tests
 
       - name: Run playwright e2e tests
         run: docker compose exec e2e_tests pytest --base-url http://django:3000 --tracing retain-on-failure


### PR DESCRIPTION
<!-- Amend as appropriate -->

We theorise that the separate `docker compose build e2e_tests` should be unnecessary since `docker compose up -d e2e_tests` should cover it.