### PR TITLE
Pin docker CI to v28.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,8 @@ jobs:
 
       - name: Set up Docker
         uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4.3.0
+        with:
+          version: v2.37.0
 
       - name: Copy .env.example file
         uses: canastro/copy-file-action@ae66602ce7d214dbd2e298c1db67a81388755a0a


### PR DESCRIPTION
We encountered a problem where the version of docker in github CI wasn't pinned, and a dodgy minor release lead to inexplicable failures. We want to pin Docker to a known version.

We're concerned that this might not get automatically updated by renovate etc.

Original fix PR: https://github.com/nationalarchives/ds-caselaw-public-ui/pull/2127 

<!-- Amend as appropriate -->

## Changes in this PR:

## Jira card / Rollbar error (etc)

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
