### PR TITLE
FCL-974 | fix notification banner box sizing

### DIFF
--- a/ds_judgements_public_ui/sass/includes/vendors/_home_office.scss
+++ b/ds_judgements_public_ui/sass/includes/vendors/_home_office.scss
@@ -6,6 +6,7 @@
   $home-office-alert-success-background-colour: #c6ece9;
   $home-office-alert-success-border-colour: #28a197;
 
+  box-sizing: border-box;
   margin-top: $space-5;
   margin-bottom: $space-5;
   padding: $space-4;


### PR DESCRIPTION
## Changes in this PR:

Adds box sizing to the home office banner so it's positioned correctly.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-974


### Before

<img width="887" alt="image" src="https://github.com/user-attachments/assets/5a4917cf-037a-441a-a1d0-13efe79633b5" />


### After

<img width="890" alt="image" src="https://github.com/user-attachments/assets/445590d6-3660-443b-9f22-d8f43f3c29bc" />
