### PR TITLE
FCL-845 | don't expose internal id on pdf download

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_download_options.html
@@ -3,7 +3,7 @@
   <h2 id="judgment-download-options-header" class="judgment-download-options__header">Document download options</h2>
   <div class="judgment-download-options__options-list">
     <div class="judgment-download-options__download-option">
-      <a href="{{ pdf_uri }}"
+      <a href="{% formatted_document_uri document.slug 'pdf' %}"
          class="btn"
          aria-label="Download {{ document|get_title_to_display_in_html }} as a PDF{% if pdf_size %} ({{ pdf_size }}){% endif %}"
          download="">

--- a/e2e_tests/test_judgment_page.py
+++ b/e2e_tests/test_judgment_page.py
@@ -16,9 +16,7 @@ documents = [
 
 
 def get_download_pdf_url(document_uri):
-    file_name = document_uri.strip("/").replace("/", "_")
-
-    return f"{document_uri}/{file_name}.pdf"
+    return f"{document_uri}/data.pdf"
 
 
 # def assert_download_options_link(page):

--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -95,8 +95,7 @@ class TestJudgmentPdfLinkText(TestCaseWithMockAPI):
         response = self.client.get("/test/2023/123")
         decoded_response = response.content.decode("utf-8")
 
-        self.assertIn("https://example.com/test/2023/123/test_2023_123.pdf", decoded_response)
-        self.assertNotIn("data.pdf", decoded_response)
+        self.assertIn("/tna.tn4t35ts/data.pdf", decoded_response)
         self.assertIn(f"({filesizeformat(1234)})", decoded_response)
 
     @patch("judgments.views.detail.detail_html.DocumentPdf")
@@ -111,7 +110,7 @@ class TestJudgmentPdfLinkText(TestCaseWithMockAPI):
         decoded_response = response.content.decode("utf-8")
 
         self.assertNotIn("test_2023_123.pdf", decoded_response)
-        self.assertIn("/test/2023/123/data.pdf", decoded_response)
+        self.assertIn("/tna.tn4t35ts/data.pdf", decoded_response)
 
 
 class TestDocumentDownloadOptions(MockAPI):
@@ -153,7 +152,7 @@ class TestDocumentDownloadOptions(MockAPI):
             <h2 id="judgment-download-options-header" class="judgment-download-options__header">Document download options</h2>
             <div class="judgment-download-options__options-list">
                 <div class="judgment-download-options__download-option">
-                    <a href="http://example.com/test.pdf" class="btn" aria-label="Download {document_title} as a PDF ({filesizeformat(112)})" download="">
+                    <a href="/tna.tn4t35ts/data.pdf" class="btn" aria-label="Download {document_title} as a PDF ({filesizeformat(112)})" download="">
                         Download PDF <span class="btn__label">({filesizeformat(112)})</span>
                     </a>
                     <p>The original format of the {document_noun} as handed down by the court, for printing and downloading.</p>

--- a/judgments/tests/views/detail/test_best_pdf.py
+++ b/judgments/tests/views/detail/test_best_pdf.py
@@ -1,0 +1,60 @@
+from unittest.mock import Mock, patch
+
+from django.http import HttpResponseRedirect
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+
+from judgments.models.document_pdf import DocumentPdf
+from judgments.views.detail import best_pdf
+
+
+class BestPdfViewTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.document_uri = "test/2025/123"
+        self.mock_pdf_uri = "http://mock-s3-url.com/example-document.pdf"
+
+    @patch.object(DocumentPdf, "generate_uri")
+    @patch("requests.get")
+    def test_returns_pdf_when_found(self, mock_get, mock_generate_uri):
+        mock_generate_uri.return_value = self.mock_pdf_uri
+        mock_get.return_value = Mock(status_code=200, content=b"%PDF-1.4 binary data")
+
+        request = self.factory.get(f"/data/{self.document_uri}.pdf")
+        response = best_pdf(request, self.document_uri)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+        self.assertEqual(response["Content-Disposition"], f"attachment; filename={self.document_uri}.pdf")
+        self.assertIn(b"%PDF-1.4", response.content)
+
+    @patch.object(DocumentPdf, "generate_uri")
+    @patch("requests.get")
+    def test_redirects_to_weasyprint_when_not_found(self, mock_get, mock_generate_uri):
+        mock_generate_uri.return_value = self.mock_pdf_uri
+        mock_get.return_value = Mock(status_code=404)
+
+        request = self.factory.get(f"/data/{self.document_uri}.pdf")
+        response = best_pdf(request, self.document_uri)
+
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(
+            response.url,
+            reverse(
+                "detail",
+                kwargs={"document_uri": self.document_uri, "file_format": "generated.pdf"},
+            ),
+        )
+
+    @patch.object(DocumentPdf, "generate_uri")
+    @patch("requests.get")
+    def test_logs_warning_and_redirects_on_unexpected_error(self, mock_get, mock_generate_uri):
+        mock_generate_uri.return_value = self.mock_pdf_uri
+        mock_get.return_value = Mock(status_code=500)
+
+        with self.assertLogs(level="WARNING") as log:
+            request = self.factory.get(f"/data/{self.document_uri}.pdf")
+            response = best_pdf(request, self.document_uri)
+
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertIn(f"Unexpected 500 error on {self.document_uri}", log.output[0])

--- a/judgments/views/detail/best_pdf.py
+++ b/judgments/views/detail/best_pdf.py
@@ -10,7 +10,7 @@ from judgments.models.document_pdf import DocumentPdf
 
 def best_pdf(request, document_uri):
     """
-    Response for the legacy data.pdf endpoint, used by data reusers
+    Response for the data.pdf endpoint, used by data reusers
 
     If there's a DOCX-derived PDF in the S3 bucket, return that.
     Otherwise fall back and redirect to the weasyprint version."""

--- a/judgments/views/detail/best_pdf.py
+++ b/judgments/views/detail/best_pdf.py
@@ -15,10 +15,15 @@ def best_pdf(request, document_uri):
     If there's a DOCX-derived PDF in the S3 bucket, return that.
     Otherwise fall back and redirect to the weasyprint version."""
     pdf = DocumentPdf(document_uri)
+
     response = requests.get(pdf.generate_uri())
     logging.debug("Response %s", response.status_code)
     if response.status_code == 200:
-        return HttpResponse(response.content, content_type="application/pdf")
+        response = HttpResponse(response.content, content_type="application/pdf")
+
+        response["Content-Disposition"] = f"attachment; filename={document_uri}.pdf"
+
+        return response
 
     if response.status_code != 404:
         logging.warn(f"Unexpected {response.status_code} error on {document_uri} whilst trying to get_best_pdf")

--- a/judgments/views/detail/best_pdf.py
+++ b/judgments/views/detail/best_pdf.py
@@ -16,17 +16,20 @@ def best_pdf(request, document_uri):
     Otherwise fall back and redirect to the weasyprint version."""
     pdf = DocumentPdf(document_uri)
 
-    response = requests.get(pdf.generate_uri())
-    logging.debug("Response %s", response.status_code)
-    if response.status_code == 200:
-        response = HttpResponse(response.content, content_type="application/pdf")
+    external_response = requests.get(pdf.generate_uri())
+    logging.debug("Response %s", external_response.status_code)
+
+    if external_response.status_code == 200:
+        response = HttpResponse(external_response.content, content_type="application/pdf")
 
         response["Content-Disposition"] = f"attachment; filename={document_uri}.pdf"
 
         return response
 
-    if response.status_code != 404:
-        logging.warn(f"Unexpected {response.status_code} error on {document_uri} whilst trying to get_best_pdf")
+    if external_response.status_code != 404:
+        logging.warn(
+            f"Unexpected {external_response.status_code} error on {document_uri} whilst trying to get_best_pdf"
+        )
     # fall back to weasy_pdf
 
     return redirect(


### PR DESCRIPTION
## Changes in this PR:

Hides the ID on the html and ensures we give the user a good filename when they download it.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-845
