### PR TITLE
FCL-925 | remove pipes and inline matching text on search

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgments_table.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgments_table.scss
@@ -13,13 +13,7 @@
 
   &__matches {
     p {
-      display: inline;
       line-height: $typography-lg-line-height;
-
-      &:not(:last-child)::after {
-        content: " | ";
-        color: colour-var("font-base");
-      }
     }
   }
 


### PR DESCRIPTION
## Changes in this PR:

To make it easier to understand the snippets on search, we're removing the pipes and not showing them inline

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-925

## Screenshots of UI changes:

### Before

<img width="1177" alt="image" src="https://github.com/user-attachments/assets/dfbf40b1-ed30-45b8-8220-bb98600ecaaa" />

### After

<img width="1177" alt="image" src="https://github.com/user-attachments/assets/b963decb-cef8-4026-bb96-04c522f06db8" />
