### PR TITLE
FCL-954 | repoisition update filters button on advanced search

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -182,7 +182,6 @@
 
   &__submit-container {
     margin-top: $space-2;
-    text-align: right;
 
     @media (max-width: $grid-breakpoint-medium) {
       margin: $space-4;


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Reposition the update filters button on the advanced search to the left.


## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-954

## Screenshots of UI changes:

### Before

<img width="1260" alt="image" src="https://github.com/user-attachments/assets/63ab32e4-3301-49e0-8ba6-83f6ca201499" />


### After

<img width="1209" alt="image" src="https://github.com/user-attachments/assets/a5214b8b-c3a9-48d0-bce1-66b72f2ba457" />

