### PR TITLE
FCL-964: atom feed id tag value is fclid

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -6,6 +6,7 @@ from caselawclient.client_helpers.search_helpers import (
     search_judgments_and_parse_response,
 )
 from caselawclient.models.identifiers import Identifier
+from caselawclient.models.identifiers.fclid import FindCaseLawIdentifier
 from caselawclient.responses.search_result import SearchResult
 from caselawclient.search_parameters import SearchParameters
 from django.contrib.syndication.views import Feed
@@ -158,7 +159,17 @@ class JudgmentsFeed(Feed):
         return item.name
 
     def item_guid(self, item) -> str:
-        return "https://caselaw.nationalarchives.gov.uk/id/" + item.uri
+        fclid = item.identifiers.of_type(FindCaseLawIdentifier)
+
+        if not fclid:
+            msg = f"No FindCaseLawIdentifier for search result {item}"
+            raise RuntimeError(msg)
+
+        if len(fclid) > 1:
+            msg = f"Multiple FindCaseLawIdentifiers for search result {item}"
+            raise RuntimeError(msg)
+
+        return "https://caselaw.nationalarchives.gov.uk/id/" + fclid[0].url_slug
 
     def item_link(self, item) -> str:
         return reverse("detail", args=[item.slug])

--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -95,7 +95,7 @@ class TestAtomFeed(TestCase):
 
         entry_id = entry.find("id", self.namespaces)
         assert entry_id is not None
-        assert entry_id.text == "https://caselaw.nationalarchives.gov.uk/id/d-a1b2c3"
+        assert entry_id.text == "https://caselaw.nationalarchives.gov.uk/id/tna.bcdfghjk"
 
         entry_published = entry.find("published", self.namespaces)
         assert entry_published is not None


### PR DESCRIPTION
## Changes in this PR:

The <id> tag in the atom feed will be `https://caselaw.nationalarchives.gov.uk/id/fcl.bcdfghjk` not `d-a1b2c3`. This may be a small breaking change for consumers.


Requires https://github.com/nationalarchives/ds-caselaw-custom-api-client/pull/1105 to ensure the tests pass (ensures search result factories have proper Identifiers not dicts, and that there's an FCL ID)

## Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136/backlog?assignee=unassigned%2C60bdecb0c90cb2006806ae0f&selectedIssue=FCL-964
