### PR TITLE
FCL-952 | update link styling to have thicker underline on hover

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_basic_search_form.scss
+++ b/ds_judgements_public_ui/sass/includes/_basic_search_form.scss
@@ -30,6 +30,8 @@
     line-height: $typography-sm-line-height;
 
     input[type="submit"] {
+      @include link;
+
       position: relative;
 
       display: inline-block;
@@ -40,18 +42,11 @@
       font-family: $font-roboto;
       font-size: $typography-md-text-size;
       font-weight: bold;
-      color: colour-var("link");
-      text-decoration: underline;
 
       background: transparent;
 
       &:visited {
         color: colour-var("link");
-      }
-
-      &:hover {
-        color: colour-var("link");
-        text-decoration: none;
       }
     }
 
@@ -121,6 +116,12 @@
     margin: $space-2 $space-4 0 $space-4;
     font-size: $typography-xs-text-size;
     text-align: left;
+
+    a {
+      &:visited {
+        color: colour-var("link");
+      }
+    }
 
     @media (min-width: $grid-breakpoint-medium) {
       margin: $space-1 0 $space-2 0;

--- a/ds_judgements_public_ui/sass/includes/_breadcrumbs.scss
+++ b/ds_judgements_public_ui/sass/includes/_breadcrumbs.scss
@@ -60,7 +60,13 @@
     }
 
     a {
-      @include link-on-dark-bg;
+      @include link;
+
+      color: colour-var("contrast-link");
+
+      &:visited {
+        color: colour-var("contrast-link");
+      }
     }
   }
 

--- a/ds_judgements_public_ui/sass/includes/_document_navigation_links.scss
+++ b/ds_judgements_public_ui/sass/includes/_document_navigation_links.scss
@@ -179,6 +179,8 @@
   }
 
   a {
+    @include link;
+
     position: relative;
 
     &.document-navigation-links__link-up {
@@ -262,7 +264,6 @@
     &:visited,
     &:link {
       color: colour-var("link");
-      text-decoration: underline;
 
       &.document-navigation-links__link-left {
         &::before {
@@ -279,8 +280,6 @@
 
     &:hover {
       &.document-navigation-links__link-up {
-        color: colour-var("link");
-
         &::before {
           background-image: url($fa_chevron_up_link_hover_blue);
         }
@@ -296,8 +295,6 @@
     }
 
     &:link:hover {
-      color: colour-var("link");
-
       &.document-navigation-links__link-left {
         &::before {
           background-image: url($fa_chevron_left_link_hover_blue);

--- a/ds_judgements_public_ui/sass/includes/_footer.scss
+++ b/ds_judgements_public_ui/sass/includes/_footer.scss
@@ -141,7 +141,7 @@
   }
 
   a {
-    @include link-on-dark-bg;
+    @include contrast-link;
 
     &:focus {
       color: colour-var("accent-button-text");

--- a/ds_judgements_public_ui/sass/includes/_homepage_cards.scss
+++ b/ds_judgements_public_ui/sass/includes/_homepage_cards.scss
@@ -88,15 +88,9 @@
   }
 
   &__heading {
-    margin: 0;
-    color: colour-var("link");
-    text-decoration: underline;
-    text-decoration-color: colour-var("link");
+    @include link;
 
-    &:hover {
-      color: brand-colour("navy");
-      text-decoration: none;
-    }
+    margin: 0;
 
     @media (max-width: $grid-breakpoint-medium) {
       text-wrap: nowrap;
@@ -107,11 +101,6 @@
     color: colour-var("link-visited");
     text-decoration-color: colour-var("link-visited");
     text-decoration-line: underline;
-  }
-
-  &__heading:hover {
-    color: colour-var("link");
-    text-decoration: none;
   }
 
   &__body-text {

--- a/ds_judgements_public_ui/sass/includes/_judgment_document_paragraph_anchors.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_document_paragraph_anchors.scss
@@ -24,6 +24,8 @@
   }
 
   &__copy-link-tooltip {
+    @include link;
+
     user-select: none;
 
     position: absolute;
@@ -35,8 +37,6 @@
 
     font-family: Roboto, sans-serif;
     font-size: 14px;
-    color: colour-var("link");
-    text-decoration: underline;
     white-space: nowrap;
 
     opacity: 0;

--- a/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgment_text_toolbar.scss
@@ -39,17 +39,14 @@
     margin: 0;
 
     font-size: $typography-md-text-size;
-    color: colour-var("link");
-    text-decoration: none;
-    text-decoration: underline;
 
     background: url($fa_chevron_down_link_blue) right no-repeat;
     background-color: transparent;
     background-size: $space-5;
     outline-offset: 3px;
 
-    &:hover {
-      text-decoration: none;
+    &:visited {
+      color: colour-var("link");
     }
 
     @media (max-width: $grid-breakpoint-medium) {
@@ -61,6 +58,8 @@
     @media (min-width: $grid-breakpoint-small) {
       padding-right: $space-8;
     }
+
+    @include link;
   }
 
   &__actions {

--- a/ds_judgements_public_ui/sass/includes/_mixins.scss
+++ b/ds_judgements_public_ui/sass/includes/_mixins.scss
@@ -43,7 +43,7 @@
 
   &:hover {
     color: colour-var("link");
-    text-decoration: none;
+    text-decoration-thickness: 0.1875rem;
   }
 
   &:visited {
@@ -73,13 +73,13 @@
   outline-offset: 2px;
 }
 
-@mixin link-on-dark-bg {
+@mixin contrast-link {
   color: colour-var("contrast-link");
   text-decoration: underline;
 
   &:hover {
     color: colour-var("contrast-link");
-    text-decoration: none;
+    text-decoration-thickness: 0.1875rem;
   }
 
   &:visited {

--- a/ds_judgements_public_ui/sass/includes/_mixins.scss
+++ b/ds_judgements_public_ui/sass/includes/_mixins.scss
@@ -43,7 +43,7 @@
 
   &:hover {
     color: colour-var("link");
-    text-decoration-thickness: 0.1875rem;
+    text-decoration-thickness: $link-hover-thickness;
   }
 
   &:visited {
@@ -79,7 +79,7 @@
 
   &:hover {
     color: colour-var("contrast-link");
-    text-decoration-thickness: 0.1875rem;
+    text-decoration-thickness: $link-hover-thickness;
   }
 
   &:visited {

--- a/ds_judgements_public_ui/sass/includes/_variables.scss
+++ b/ds_judgements_public_ui/sass/includes/_variables.scss
@@ -5,6 +5,7 @@ $grid-breakpoint-small: 576px;
 $grid-breakpoint-medium: 768px;
 $grid-breakpoint-large: 992px;
 $grid-breakpoint-extra-large: 1200px;
+$link-hover-thickness: 0.1875rem;
 
 // TODO: Rename these
 $font-roboto: "Roboto", sans-serif;

--- a/ds_judgements_public_ui/sass/includes/govuk_overrides/_details.scss
+++ b/ds_judgements_public_ui/sass/includes/govuk_overrides/_details.scss
@@ -22,9 +22,9 @@
 }
 
 .govuk-details__summary {
+  @include link;
+
   padding-left: $space-6;
-  color: colour-var("link");
-  text-decoration: underline;
 
   &::before {
     top: 2px;

--- a/ds_judgements_public_ui/sass/includes/govuk_overrides/_header.scss
+++ b/ds_judgements_public_ui/sass/includes/govuk_overrides/_header.scss
@@ -9,7 +9,8 @@
 .govuk-header__navigation-item--active .govuk-header__link:visited,
 .govuk-header__navigation-item--active a:link {
   font-weight: bold !important;
-  color: colour-var("accent-brand");
+  color: colour-var("accent-brand") !important;
+  text-decoration-thickness: $link-hover-thickness;
 
   &:focus {
     background-color: transparent;

--- a/ds_judgements_public_ui/sass/includes/govuk_overrides/_header.scss
+++ b/ds_judgements_public_ui/sass/includes/govuk_overrides/_header.scss
@@ -4,19 +4,12 @@
   background-color: colour-var("contrast-background");
 }
 
-.govuk-header__link--homepage:hover,
-.govuk-header__link--homepage:active {
-  border-bottom: 0.25rem solid colour-var("black");
-}
-
 .govuk-header__navigation-item--active .govuk-header__link,
 .govuk-header__navigation-item--active .govuk-header__link:hover,
 .govuk-header__navigation-item--active .govuk-header__link:visited,
 .govuk-header__navigation-item--active a:link {
-  border-bottom: 0.25rem solid colour-var("accent-brand");
   font-weight: bold !important;
   color: colour-var("accent-brand");
-  text-decoration: none;
 
   &:focus {
     background-color: transparent;
@@ -29,11 +22,7 @@
 }
 
 .govuk-header__link {
-  &:hover {
-    border-bottom: none;
-    color: colour-var("contrast-link");
-    text-decoration: none !important;
-  }
+  @include link;
 
   &:focus {
     @include focus-default;
@@ -46,11 +35,14 @@
 }
 
 .govuk-header__navigation-item .govuk-header__link {
+  @include link;
+
   display: inline-block;
 
   font-size: $typography-xs-text-size;
   font-weight: normal;
   line-height: $typography-md-line-height;
+  color: colour-var("contrast-link");
   text-decoration: underline;
   text-underline-offset: 0.25rem;
   white-space: nowrap;
@@ -73,6 +65,10 @@
     box-shadow: none;
   }
 
+  &:visited {
+    color: colour-var("contrast-link");
+  }
+
   @media only screen and (max-width: $grid-breakpoint-medium) {
     text-decoration: none;
   }
@@ -80,10 +76,6 @@
 
 .govuk-header__menu-button:focus {
   outline: $space-1 solid transparent;
-}
-
-.govuk-header__menu-button:hover {
-  text-decoration: none;
 }
 
 .govuk-header__content {


### PR DESCRIPTION
## Changes in this PR:

Updates the link hover styling.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-952

## Screenshots of UI changes:

### Before

<img width="236" alt="image" src="https://github.com/user-attachments/assets/e85e9bd4-5c96-4b49-bbc5-a97291e793fe" />


### After

<img width="301" alt="image" src="https://github.com/user-attachments/assets/72ddd8bb-c204-4e99-943f-950ab1231a54" />


- [ ] Requires env variable(s) to be updated
