### PR TITLE
FCL-985 | highlight colour change to solid rather than with a border

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_typography.scss
+++ b/ds_judgements_public_ui/sass/includes/_typography.scss
@@ -56,7 +56,7 @@ mark {
   background: color-mix(in srgb, colour-var("accent-brand") 50%, transparent);
 
   &.current {
-    border-top: 3px solid colour-var("accent-brand");
+    background: colour-var("accent-brand");
   }
 }
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Changes the highlight colour on search to be solid rather than 50% and a border at full opacity.


## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-985

## Screenshots of UI changes:

### Before

<img width="116" alt="image" src="https://github.com/user-attachments/assets/b1bc1d34-b796-4511-a30c-d243a2e2062c" />


### After

<img width="98" alt="image" src="https://github.com/user-attachments/assets/08eef6f0-dda5-4637-bbdf-35d4244807cb" />
