### PR TITLE
FCL-1002 | fix homepage card height

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_homepage_cards.scss
+++ b/ds_judgements_public_ui/sass/includes/_homepage_cards.scss
@@ -44,6 +44,8 @@
     flex: 1;
     flex-direction: row;
 
+    // NOTE: This is the height of the images contained inside
+    max-height: 146px;
     border-top: 4px solid colour-var("accent-brand");
 
     text-decoration: none;


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Fixes the issue with the cards on the homepage after the link underline was added

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-1002

## Screenshots of UI changes:

### Before

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/7cf6d3ed-5d62-4e60-bdb3-0ee8bf570605" />


### After

<img width="1193" alt="image" src="https://github.com/user-attachments/assets/fdd03c05-e03b-4a17-9d7c-50d011e68f8e" />

