### PR TITLE
FCL-961 | add red border around form inputs

### DIFF
--- a/transactional_licence_form/forms.py
+++ b/transactional_licence_form/forms.py
@@ -29,6 +29,8 @@ class ContactForm(FCLForm):
     contact_email = fields.FCLEmailField(
         label="2. Contact Email address",
         max_length=50,
+        # NOTE: this is a temporary workaround as there is a bug in crispy-forms-gds where they forgot to apply error styling to email inputs
+        widget=forms.TextInput(attrs={"type": "email"}),
     )
     # NOTE: please see comment in transactional_lcence_form.js if changing the wording / order of the options here.
     alternative_contact = fields.FCLChoiceField(


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

The update to the latest crispy-forms-gds added the red border to most components, however it didn't add them to the email inputs. I think this is a bug their side so I will open a PR to suggest the fix (https://github.com/StuartMacKay/crispy-forms-gds/pull/93)

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-961

## Screenshots of UI changes:

<img width="1201" alt="image" src="https://github.com/user-attachments/assets/4732e201-c13d-42b4-a98f-8a61a0d604d7" />

