### PR TITLE
FCL-1012 | always show the view download options button

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
+++ b/ds_judgements_public_ui/templates/includes/judgment_text_toolbar.html
@@ -24,7 +24,7 @@
           </a>
         {% endspaceless %}
       {% endif %}
-      {% if document.best_human_identifier %}
+      {% if document_html %}
         <a href="#download-options" class="judgment-toolbar__download-options-link"  aria-label="View download options">View download options</a>
       {% endif %}
     </div>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Before we checked the NCN to determine whether to show download options. We changed this on the actual download options but not here. Making it consistent.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-1012

## Screenshots of UI changes:

With no HTML:

<img width="1174" alt="image" src="https://github.com/user-attachments/assets/077fd2f8-cf6c-4bc3-8afe-ae1f26e3af6a" />

With HTML and no NCN:

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/9d7356a7-6344-47d0-9ed6-fb91469dfd47" />



