### PR TITLE
FCL-1011 | update link mixin to extend from govuk-link mixin

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_mixins.scss
+++ b/ds_judgements_public_ui/sass/includes/_mixins.scss
@@ -40,10 +40,12 @@
 @mixin link {
   color: colour-var("link");
   text-decoration: underline;
+  text-decoration-thickness: $link-underline-thickness;
+  text-underline-offset: $link-underline-offset;
 
   &:hover {
     color: colour-var("link");
-    text-decoration-thickness: $link-hover-thickness;
+    text-decoration-thickness: $link-hover-underline-thickness;
   }
 
   &:visited {
@@ -74,12 +76,12 @@
 }
 
 @mixin contrast-link {
+  @include link;
+
   color: colour-var("contrast-link");
-  text-decoration: underline;
 
   &:hover {
     color: colour-var("contrast-link");
-    text-decoration-thickness: $link-hover-thickness;
   }
 
   &:visited {
@@ -91,8 +93,6 @@
   }
 
   &:focus {
-    @include focus-default;
-
     outline-color: colour-var("contrast-link");
   }
 }

--- a/ds_judgements_public_ui/sass/includes/_variables.scss
+++ b/ds_judgements_public_ui/sass/includes/_variables.scss
@@ -1,11 +1,16 @@
 @import "@nationalarchives/ds-caselaw-frontend/src/includes/variables/variables";
 
+// GOVUK Variables
+@import "govuk-frontend/dist/govuk/settings";
+
 $gutter_unit: 25px;
 $grid-breakpoint-small: 576px;
 $grid-breakpoint-medium: 768px;
 $grid-breakpoint-large: 992px;
 $grid-breakpoint-extra-large: 1200px;
-$link-hover-thickness: 0.1875rem;
+$link-underline-thickness: $govuk-link-underline-thickness;
+$link-hover-underline-thickness: $govuk-link-hover-underline-thickness;
+$link-underline-offset: $govuk-link-underline-offset;
 
 // TODO: Rename these
 $font-roboto: "Roboto", sans-serif;

--- a/ds_judgements_public_ui/sass/includes/govuk_overrides/_header.scss
+++ b/ds_judgements_public_ui/sass/includes/govuk_overrides/_header.scss
@@ -10,7 +10,7 @@
 .govuk-header__navigation-item--active a:link {
   font-weight: bold !important;
   color: colour-var("accent-brand") !important;
-  text-decoration-thickness: $link-hover-thickness;
+  text-decoration-thickness: $link-hover-underline-thickness;
 
   &:focus {
     background-color: transparent;

--- a/ds_judgements_public_ui/sass/includes/govuk_overrides/_tabs.scss
+++ b/ds_judgements_public_ui/sass/includes/govuk_overrides/_tabs.scss
@@ -19,7 +19,7 @@
     &__tab {
       &:focus {
         text-decoration: underline;
-        text-decoration-thickness: $link-hover-thickness;
+        text-decoration-thickness: $link-hover-underline-thickness;
         background-color: transparent;
         box-shadow: none;
       }

--- a/ds_judgements_public_ui/sass/main.scss
+++ b/ds_judgements_public_ui/sass/main.scss
@@ -25,7 +25,6 @@
 $govuk-font-family: $font-open-sans;
 $govuk-focus-colour: colour-var("focus-outline");
 
-@import "govuk-frontend/dist/govuk/settings";
 @import "govuk-frontend/dist/govuk/helpers";
 @import "govuk-frontend/dist/govuk/tools";
 @import "govuk-frontend/dist/govuk/utilities/visually-hidden";


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Ensures we extend our link mixin from the govuk link mixin. Includes the text decoration underline offset.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-1011
