### PR TITLE
FCL-988: Explicitly state assets_base in feed

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -106,6 +106,9 @@ class JudgmentAtomFeed(Atom1Feed):
                     "href": f"https://assets.caselaw.nationalarchives.gov.uk/{uri}/{path_underscore}.pdf",
                 },
             )
+            handler.addQuickElement(
+                "tna:assets_base", "", {"href": f"https://assets.caselaw.nationalarchives.gov.uk/{uri}/"}
+            )
 
     def add_root_elements(self, handler):
         super().add_root_elements(handler)

--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -123,6 +123,10 @@ class TestAtomFeed(TestCase):
         assert entry_tna_uri is not None
         assert entry_tna_uri.text == "d-a1b2c3"
 
+        assets_tna_uri = entry.find("tna:assets_base", self.namespaces)
+        assert assets_tna_uri is not None
+        assert assets_tna_uri.attrib["href"] == "https://assets.caselaw.nationalarchives.gov.uk/d-a1b2c3/"
+
         self.assertCountEqual(
             [e.attrib for e in entry.findall("link", self.namespaces)],
             [


### PR DESCRIPTION
<!-- Amend as appropriate -->

Before there wasn't a way of getting the base assets URI. Now there's tna:assets 

`<tna:assets href="https://assets.caselaw.nationalarchives.gov.uk/ewhc/ch/2024/505/"/>`

docs PR: https://github.com/nationalarchives/ds-find-caselaw-docs/pull/205
## Changes in this PR:

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-988

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
