### PR TITLE
FCL-944 | allow service to be used with failing marklogic requests

### DIFF
--- a/ds_judgements_public_ui/templates/includes/recent_judgments.html
+++ b/ds_judgements_public_ui/templates/includes/recent_judgments.html
@@ -1,12 +1,14 @@
 <div class="recent-judgments">
   <div class="recent-judgments__container">
-    {% include "includes/judgments_table.html" with judgments=recent_judgments table_title="Recently published judgments" %}
-    <section class="recent-judgments__more-info-footer">
-      <a role="button"
-         draggable="false"
-         rel="noreferrer noopener"
-         class="recent-judgments__cta-button button-primary"
-         href="{% url 'search' %}">View all judgments</a>
-    </section>
+    {% if recent_judgments %}
+      {% include "includes/judgments_table.html" with judgments=recent_judgments table_title="Recently published judgments" %}
+      <section class="recent-judgments__more-info-footer">
+        <a role="button"
+           draggable="false"
+           rel="noreferrer noopener"
+           class="recent-judgments__cta-button button-primary"
+           href="{% url 'search' %}">View all judgments</a>
+      </section>
+    {% endif %}
   </div>
 </div>

--- a/ds_judgements_public_ui/templates/judgment/results.html
+++ b/ds_judgements_public_ui/templates/judgment/results.html
@@ -1,49 +1,32 @@
-{% extends "layouts/base.html" %}
-{% load utilities search_results_filters static %}
-{% block title %}
-  Search results - Find Case Law
-{% endblock title %}
-{% block extra_head_tags %}
-  <link rel="alternate" type="application/atom+xml" title="{{ breadcrumbs.0.text }}" href="{% url 'search-feed' %}?{{ query_param_string }}"/>
-{% endblock extra_head_tags %}
-{% block javascript %}
-  <script type="module" defer src="{% static 'js/dist/manage_filters.js' %}"></script>
-{% endblock javascript %}
-{% block content %}
-  <div class="results">
-    <h1>Search results</h1>
-    {% include "includes/results_search_component.html" %}
-    <div class="results__container">
-      <div class="results__list-layout-container">
-        {% if show_no_exact_ncn_warning %}
-          {% with message="There is no judgment with the Neutral Citation of %s in our database."|interpolate:query %}
-            {% include "includes/advice_message.html" with message=message %}
-          {% endwith %}
-        {% endif %}
-        {% if requires_from_warning %}
-          {% url "about_this_service" as url_value %}
-          {% include "includes/advice_message.html" with message=date_warning url_text="Find out what records are available on this service." url_value=url_value url_anchor="section-coverage" %}
-        {% endif %}
-        {% if total > 0 %}
-          <div class="results__result-header-container">
-            {% include "includes/result_header.html" %}
-            {% include "includes/result_atom_feed_button.html" %}
-            {% include "includes/result_controls.html" %}
-          </div>
-
-          <div class="results__result-list-container">
-            {% include "includes/results_list.html" %}
-          </div>
-
-          {% if not paginator.has_next_page %}
-            {% include "includes/no_results_message.html" with title="End of results" %}
-          {% endif %}
-
-          {% include "includes/pagination.html" %}
-        {% else %}
-          {% include "includes/no_results_message.html" %}
-        {% endif %}
-      </div>
+{% extends "layouts/search_results.html" %}
+{% load utilities %}
+{% block content_body %}
+  {% if show_no_exact_ncn_warning %}
+    {% with message="There is no judgment with the Neutral Citation of %s in our database."|interpolate:query %}
+      {% include "includes/advice_message.html" with message=message %}
+    {% endwith %}
+  {% endif %}
+  {% if requires_from_warning %}
+    {% url "about_this_service" as url_value %}
+    {% include "includes/advice_message.html" with message=date_warning url_text="Find out what records are available on this service." url_value=url_value url_anchor="section-coverage" %}
+  {% endif %}
+  {% if total > 0 %}
+    <div class="results__result-header-container">
+      {% include "includes/result_header.html" %}
+      {% include "includes/result_atom_feed_button.html" %}
+      {% include "includes/result_controls.html" %}
     </div>
-  </div>
-{% endblock content %}
+
+    <div class="results__result-list-container">
+      {% include "includes/results_list.html" %}
+    </div>
+
+    {% if not paginator.has_next_page %}
+      {% include "includes/no_results_message.html" with title="End of results" %}
+    {% endif %}
+
+    {% include "includes/pagination.html" %}
+  {% else %}
+    {% include "includes/no_results_message.html" %}
+  {% endif %}
+{% endblock content_body %}

--- a/ds_judgements_public_ui/templates/judgment/results_error.html
+++ b/ds_judgements_public_ui/templates/judgment/results_error.html
@@ -1,0 +1,12 @@
+{% extends "layouts/search_results.html" %}
+{% block content_body %}
+  <div class="results">
+    <h1>Search results</h1>
+    {% include "includes/results_search_component.html" %}
+    <div class="results__container">
+      <div class="results__list-layout-container">
+        {% include "includes/no_results_message.html" %}
+      </div>
+    </div>
+  </div>
+{% endblock content_body %}

--- a/ds_judgements_public_ui/templates/layouts/search_results.html
+++ b/ds_judgements_public_ui/templates/layouts/search_results.html
@@ -1,0 +1,23 @@
+{% extends "layouts/base.html" %}
+{% load utilities search_results_filters static %}
+{% block title %}
+  Search results - Find Case Law
+{% endblock title %}
+{% block extra_head_tags %}
+  <link rel="alternate" type="application/atom+xml" title="{{ breadcrumbs.0.text }}" href="{% url 'search-feed' %}?{{ query_param_string }}"/>
+{% endblock extra_head_tags %}
+{% block javascript %}
+  <script type="module" defer src="{% static 'js/dist/manage_filters.js' %}"></script>
+{% endblock javascript %}
+{% block content %}
+  <div class="results">
+    <h1>Search results</h1>
+    {% include "includes/results_search_component.html" %}
+    <div class="results__container">
+      <div class="results__list-layout-container">
+        {% block content_body %}
+        {% endblock content_body %}
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/judgments/templatetags/court_utils.py
+++ b/judgments/templatetags/court_utils.py
@@ -10,6 +10,7 @@ from django import template
 from django.utils.safestring import mark_safe
 from ds_caselaw_utils.courts import Court, CourtNotFoundException, CourtParam
 from ds_caselaw_utils.courts import courts as all_courts
+from requests.exceptions import RequestException
 
 from judgments.models.court_dates import CourtDates
 from judgments.utils import api_client
@@ -72,6 +73,9 @@ def get_court_date_range(court_param: CourtParam) -> str:
 
 @register.filter
 def get_court_judgments_count(court: Court) -> int:
-    return int(
-        search_judgments_and_parse_response(api_client, SearchParameters(court=court.canonical_param)).total
-    )  # TODO: This should really be an integer coming from the API Client
+    try:
+        return int(
+            search_judgments_and_parse_response(api_client, SearchParameters(court=court.canonical_param)).total
+        )  # TODO: This should really be an integer coming from the API Client
+    except RequestException:
+        return 0

--- a/judgments/views/index.py
+++ b/judgments/views/index.py
@@ -10,6 +10,7 @@ from caselawclient.search_parameters import SearchParameters
 from django.http import Http404
 from django.urls import reverse
 from django.views.generic import TemplateView
+from requests.exceptions import RequestException
 
 from judgments.forms import AdvancedSearchForm
 from judgments.utils import api_client
@@ -32,6 +33,8 @@ class IndexView(TemplateView):
 
         context["page_canonical_url"] = self.request.build_absolute_uri(reverse("home"))
         context["page_allow_index"] = True
+        context["feedback_survey_type"] = "home"
+        context["form"] = AdvancedSearchForm()
 
         try:
             search_response = cached_recent_judgments(ttl_hash=round(time() / 900))  # Expire cache in 15 mins
@@ -40,8 +43,8 @@ class IndexView(TemplateView):
 
         except MarklogicResourceNotFoundError:
             raise Http404("Search results not found")  # TODO: This should be something else!
-
-        context["feedback_survey_type"] = "home"
-        context["form"] = AdvancedSearchForm()
+        except RequestException:
+            context["recent_judgments"] = []
+            return context
 
         return context


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

The 2 main things included in this PR are:

 - Ensure we can still use the service when MarkLogic isn't available.
 - Refactor the search views

The original reason for ensuring you can use the service without the MarkLogic service being available was so that developers who want to spin up the project can get it running without immediately seeing an error.

The other reason for doing this is to build in more resilience should something happen and things fail.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-944
