### PR TITLE
FCL-1020 | use document name for filename download if no human identi…

### DIFF
--- a/judgments/tests/test_judgment_utils.py
+++ b/judgments/tests/test_judgment_utils.py
@@ -22,6 +22,17 @@ class TestGetDocumentDownloadFilename(TestCase):
         assert result == expected
 
     @patch("judgments.utils.judgment_utils.get_published_document_by_uri")
+    def test_returns_document_name_if_only_body_present(self, mock_get_document_by_uri):
+        mock_document = Mock()
+        mock_document.body.name = "Smith-v-Jones"
+        mock_document.best_human_identifier = None
+        mock_get_document_by_uri.return_value = mock_document
+
+        result = get_document_download_filename(self.example_uri)
+        expected = quote("Smith-v-Jones")
+        assert result == expected
+
+    @patch("judgments.utils.judgment_utils.get_published_document_by_uri")
     def test_returns_quoted_uri_if_document_is_none(self, mock_get_document_by_uri):
         mock_get_document_by_uri.return_value = None
 

--- a/judgments/utils/judgment_utils.py
+++ b/judgments/utils/judgment_utils.py
@@ -29,5 +29,8 @@ def get_document_download_filename(document_uri: DocumentURIString) -> str:
     document = get_published_document_by_uri(document_uri)
     if document and document.body and document.best_human_identifier and document.best_human_identifier.value:
         return quote(f"{document.body.name}-{document.best_human_identifier.value}")
-    else:
-        return quote(document_uri)
+
+    if document and document.body:
+        return quote(document.body.name)
+
+    return quote(document_uri)


### PR DESCRIPTION
## Changes in this PR:

Uses just the document name if no best human identifier available for download document filenames.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-1020