### PR TITLE
Bandit

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -29,7 +29,7 @@ EMAIL_BACKEND = env("DJANGO_EMAIL_BACKEND", default="django.core.mail.backends.c
 # http://whitenoise.evans.io/en/latest/django.html#using-whitenoise-in-development
 INSTALLED_APPS = ["whitenoise.runserver_nostatic"] + INSTALLED_APPS  # noqa F405
 
-SECRET_KEY = "not-secret-whatsoever"
+SECRET_KEY = "not-secret-whatsoever"  # noqa: S105 hardcoded password
 
 
 # django-extensions

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -6,7 +6,7 @@ from .base import *  # noqa
 
 # GENERAL
 # ------------------------------------------------------------------------------
-SECRET_KEY = "not-secret-whatsoever"
+SECRET_KEY = "not-secret-whatsoever"  # noqa: S105 hardcoded password
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#test-runner
 TEST_RUNNER = "django.test.runner.DiscoverRunner"

--- a/config/views/schema.py
+++ b/config/views/schema.py
@@ -5,7 +5,7 @@ SCHEMA_ROOT = "https://raw.githubusercontent.com/nationalarchives/ds-caselaw-mar
 
 
 def schema(request, schemafile: str):
-    response = requests.get(f"{SCHEMA_ROOT}{schemafile}")
+    response = requests.get(f"{SCHEMA_ROOT}{schemafile}", timeout=5)
     if response.status_code != 200:
         raise Http404("Could not get schema")
 

--- a/judgments/models/document_pdf.py
+++ b/judgments/models/document_pdf.py
@@ -19,6 +19,7 @@ class DocumentPdf:
             # it is possible that "" is a better value than None, but that is untested
             self.generate_uri(),
             headers={"Accept-Encoding": None},
+            timeout=5,
         )
         content_length = response.headers.get("Content-Length", None)
         if response.status_code >= 400:

--- a/judgments/templatetags/court_utils.py
+++ b/judgments/templatetags/court_utils.py
@@ -68,7 +68,7 @@ def get_court_date_range(court_param: CourtParam) -> str:
     if start_year == end_year:
         return str(start_year)
     else:
-        return mark_safe("%s&nbsp;to&nbsp;%s" % (start_year, end_year))
+        return mark_safe("%s&nbsp;to&nbsp;%s" % (start_year, end_year))  # noqa: S308 XSS [safe because years are numbers or None]
 
 
 @register.filter

--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -1,6 +1,6 @@
-import xml.etree.ElementTree as ET
 from unittest.mock import patch
 
+import defusedxml.ElementTree as ET
 from caselawclient.search_parameters import SearchParameters
 from django.test import TestCase
 

--- a/judgments/tests/test_pdf.py
+++ b/judgments/tests/test_pdf.py
@@ -1,5 +1,5 @@
 from os import environ
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from caselawclient.factories import JudgmentFactory
 from caselawclient.models.documents import DocumentURIString
@@ -20,7 +20,9 @@ class TestDocumentPdf:
 
         assert document_pdf.size == 100
 
-        requests_mock.head.assert_called_once_with(document_pdf.generate_uri(), headers={"Accept-Encoding": None})
+        requests_mock.head.assert_called_once_with(
+            document_pdf.generate_uri(), headers={"Accept-Encoding": None}, timeout=ANY
+        )
 
     @patch("judgments.models.document_pdf.requests")
     def test_get_pdf_size_returns_blank_string_if_404(self, requests_mock):

--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -1,5 +1,5 @@
 import re
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from caselawclient.factories import JudgmentFactory
 from django.test import TestCase
@@ -158,7 +158,7 @@ class TestRobotsDirectives(TestCaseWithMockAPI):
         mock_get.return_value.status_code = 200
         mock_get_filename.return_value = "some_download_filename"
         response = self.client.get("/eat/2023/1/data.pdf")
-        mock_get.assert_called_with(url)
+        mock_get.assert_called_with(url, timeout=ANY)
         self.assertContains(response, "CAT")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow,noai")
 
@@ -172,7 +172,7 @@ class TestRobotsDirectives(TestCaseWithMockAPI):
         mock_get.return_value.status_code = 200
         mock_get_filename.return_value = "some_download_filename"
         response = self.client.get("/eat/2023/1/press-summary/1/data.pdf")
-        mock_get.assert_called_with(url)
+        mock_get.assert_called_with(url, timeout=ANY)
         self.assertContains(response, "CAT")
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow,noai")
 

--- a/judgments/views/detail/best_pdf.py
+++ b/judgments/views/detail/best_pdf.py
@@ -19,7 +19,7 @@ def best_pdf(request, document_uri):
     Otherwise fall back and redirect to the weasyprint version."""
     pdf = DocumentPdf(document_uri)
 
-    external_response = requests.get(pdf.generate_uri())
+    external_response = requests.get(pdf.generate_uri(), timeout=10)
 
     logging.debug("Response %s", external_response.status_code)
 

--- a/merge_production_dotenvs_in_dotenv.py
+++ b/merge_production_dotenvs_in_dotenv.py
@@ -58,7 +58,8 @@ def test_merge(tmpdir_factory, merged_file_count: int, append_linesep: bool):
     with open(output_file_path, "r") as output_file:
         actual_output_file_content = output_file.read()
 
-    assert actual_output_file_content == expected_output_file_content
+    if actual_output_file_content != expected_output_file_content:
+        raise AssertionError("Actual output isn't expected output")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,16 @@ line-length = 120
 
 [tool.ruff.lint]
 ignore = ["E501", "G004", "PLR2004", "RUF005", "RUF012", "UP040"] # long lines, fstrings in logs, magic values, consider not concat, mutable classbits, type instead of TypeAlias
-extend-select = ["W", "I", "C90"]
-# extend-select = [ "B", "Q", "I", "UP", "YTT", "ASYNC", "S", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
+extend-select = ["W", "I", "C90", "S"]
+# extend-select = [ "B", "Q", "I", "UP", "YTT", "ASYNC", "BLE", "A", "COM", "C4", "DTZ", "T10", "DJ", "EM", "EXE", "FA",
 #                  "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLF", "SLOT", "SIM", "TID", "TCH", "INT", "PTH",
 #                  "FIX", "PGH", "PL", "TRY", "FLY", "PERF", "RUF"]
 unfixable = ["ERA"]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "tests/*" = ["S101"]  # `assert` is fine in tests
+"judgments/tests/*" = ["S101"]  # `assert` is fine in tests
+"config/tests/*" = ["S101"] # `assert` is fine in tests
+"e2e_tests/*" = ["S101"]  # `assert` is fine in tests
+"fabfile.py" = ["S607",  # starting a process (docker) with an executable defined by PATH
+                "S603", ] # untrusted input to subprocess (docker commands)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,6 +18,7 @@ django-formtools~=2.5.1
 crispy-forms-gds==2.0.1
 markdown-it-py~=3.0.0
 mdit-py-plugins~=0.4.0
+defusedxml==0.7.1
 
 # Type stubs
 mypy-boto3-s3==1.39.5

--- a/transactional_licence_form/tests/test_tlf_utils.py
+++ b/transactional_licence_form/tests/test_tlf_utils.py
@@ -15,7 +15,7 @@ class TestTLFUtils(unittest.TestCase):
         delivery_email = "delivery@example.com"
         email_subject = "email subject"
         ses_username = "smtp_username"
-        ses_password = "smtp_password"
+        ses_password = "smtp_password"  # noqa: S105 hardcoded password
         ses_server = "smtp_server"
         ses_port = 1234
         sanitized_text = "sanitized text"

--- a/transactional_licence_form/utils.py
+++ b/transactional_licence_form/utils.py
@@ -7,9 +7,7 @@ from email.mime.text import MIMEText
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.template.loader import render_to_string
-from django.utils.safestring import mark_safe
-
-DISALLOWED_CHARACTERS = {"<": "&lt;", ">": "&gt;"}
+from django.utils.html import escape as escape_for_html
 
 COUNTRIES_AND_TERRITORIES_JSON_PATH = "ds_judgements_public_ui/static/js/location-autocomplete-canonical-list.json"
 
@@ -71,12 +69,11 @@ def send_form_response_to_dynamics(form_data):
 
 
 def sanitize_value(value):
-    sanitized = value
-    if isinstance(sanitized, list):
-        sanitized = ", ".join(sanitized)
-    for remove, replacement in DISALLOWED_CHARACTERS.items():
-        sanitized = sanitized.replace(remove, replacement)
-    return mark_safe(sanitized)
+    if isinstance(value, list):
+        value_string = ", ".join(value)
+    else:
+        value_string = str(value)
+    return escape_for_html(value_string)
 
 
 def sanitize_and_format_response_as_xml(form_data):


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/FCL-1050

<!-- Amend as appropriate -->

## Changes in this PR:

Turn on Bandit tests for ruff.

Major:
* overhaul `sanitized_value` and just use `escape` instead (to avoid potential actual XSS)

Minor:
* set `requests` timeouts
* use `defusedxml`
* remove an `assert` in prod code

Slightly dubious ignores:
* don't complain fabfile passing user (developer) input to docker
* don't complain about fabfile calling an unspecific `docker` executable somewhere on the path.

Ignored:
* ignore some "hardcoded passwords" in local and test environments
* ignore "1995 to 2005" as an XSS vector
* ignore `assert`s in tests


## Jira card / Rollbar error (etc)

https://dxw.slack.com/archives/C04FQ3GFGUQ/p1752504806313179?thread_ts=1752500939.154289&cid=C04FQ3GFGUQ

## Screenshots of UI changes:

### Before

### After

- [ ] Requires env variable(s) to be updated
