### PR TITLE
FCL 1056: Set up memray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,3 +298,8 @@ docker/*
 
 # common location for custom versions of dependencies
 /addons-dev
+
+# memray
+memray.out
+memray-flamegraph*
+memray-manage*

--- a/README.md
+++ b/README.md
@@ -170,19 +170,18 @@ python manage.py runserver_plus 0.0.0.0:3000
 
 ### Running the test suite
 
-Pytest unit tests can be run with:
+After running `fab start`
 
-```console
-fab test
-```
+Pytest unit tests can be run with `fab test`.
 
-We also have a suite of end to end tests (in the `e2e_tests/` directory) written with [playwright-pytest](https://playwright.dev/python/docs/api/class-playwright), which can be run with:
-
-```console
-fab e2etest
-```
-
+We also have a suite of end to end tests (in the `e2e_tests/` directory) written with [playwright-pytest](https://playwright.dev/python/docs/api/class-playwright), which can be run with `fab e2etest`.
 These will run by default against the running `django` container. You can supply a `baseURL` argument to test against staging or production.
+
+### memray memory tools
+
+To generate a flamegraph run `fab flamegraph`. After using the application, press Ctrl-C and the application will quit and the flamegraph will appear in your browser.
+
+To see live memory usage run `fab memray` and `fab live` in different terminals.
 
 ### Accessibility testing with E2E tests
 

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libpq-dev \
   weasyprint \
   python3-cffi python3-brotli libpango-1.0-0 libpangoft2-1.0-0 fonts-liberation \
+  lldb procps libcap2-bin \
   # cleaning up unused files
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -31,3 +31,6 @@ pytest-timeout==2.4.0
 # type stubs
 types-python-dateutil==2.9.0.20250708
 types-requests==2.32.4.20250611
+
+# memray
+memray==1.17.2


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

## Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136

## Screenshots of UI changes:
<img width="1073" height="227" alt="image" src="https://github.com/user-attachments/assets/cc432da2-5d6e-4783-81d7-1a27bfa686fa" />

<img width="1365" height="591" alt="image" src="https://github.com/user-attachments/assets/71f77900-2fc1-4e7a-9025-2ed2489d87df" />


new commands:

`fab memray` -- launch an instrumented version of the app: use `fab live` to get a live view (in a different window)
`fab flamegraph` -- run an instrumented version of the app and output a flamegraph of max memory at end

### Before

### After

- [ ] Requires env variable(s) to be updated
