### PR TITLE
[FCL-1092] change listing divider design on mobile to match desktop

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_judgments_table.scss
+++ b/ds_judgements_public_ui/sass/includes/_judgments_table.scss
@@ -127,7 +127,7 @@
           gap: $space-2;
 
           padding-bottom: $space-4;
-          border-bottom: 1px solid colour-var("accent-background-light");
+          border-bottom: 1px solid colour-var("keyline-dark");
 
           &:last-child {
             td {


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:
Change listing divider design on mobile to match desktop
## Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/jira/software/projects/FCL/boards/136?selectedIssue=FCL-1092
## Screenshots of UI changes:

### Before
[before.webm](https://github.com/user-attachments/assets/f5866e92-8894-4a9c-b6b9-ea3b2e0e6cf8)

### After
[after.webm](https://github.com/user-attachments/assets/6157c4b6-f129-4189-ba1a-7706ebba784d)


- [ ] Requires env variable(s) to be updated
