### PR TITLE
Don't pin markdown-it etc, rely on API client versioning

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,8 +16,6 @@ django-weasyprint==2.4.0
 django-waffle==5.0.0  # https://github.com/django-waffle/django-waffle
 django-formtools~=2.5.1
 crispy-forms-gds==2.0.1
-markdown-it-py~=3.0.0
-mdit-py-plugins~=0.4.0
 defusedxml==0.7.1
 
 # Type stubs


### PR DESCRIPTION
https://github.com/nationalarchives/ds-caselaw-public-ui/pull/2325 can't be upgraded because API client pins it; API client should take ownership of what the version is, rather than specifying in two places.