### PR TITLE
Make 'no NCN' indicator in result tables an emdash

### DIFF
--- a/ds_judgements_public_ui/templates/includes/judgments_table.html
+++ b/ds_judgements_public_ui/templates/includes/judgments_table.html
@@ -45,7 +45,7 @@
           </td>
           <td>
             <span class="judgments-table__heading">Neutral citation</span>
-            {{ item.neutral_citation|default_if_none:"&ndash;" }}
+            {{ item.neutral_citation|default_if_none:"&mdash;" }}
           </td>
           <td>
             <span class="judgments-table__heading">Handed down</span>


### PR DESCRIPTION
To make the case where an NCN isn't present more obvious, change the indicator from a "–" to a "—".