### PR TITLE
Reduce the number of requests before a worker is restarted

### DIFF
--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -4,8 +4,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-
 npm run build
 python /app/manage.py collectstatic --noinput
 cd /app
-/usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app --access-logfile - -w 5 --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s "%({x-forwarded-for}i)s" "%({cloudfront-viewer-address}i)s" "%({x-amz-cf-id}i)s" "%({x-amzn-trace-id}i)s"' --max-requests 2000 --max-requests-jitter 200
+/usr/local/bin/gunicorn config.wsgi --bind 0.0.0.0:5000 --chdir=/app --access-logfile - -w 5 --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s "%({x-forwarded-for}i)s" "%({cloudfront-viewer-address}i)s" "%({x-amz-cf-id}i)s" "%({x-amzn-trace-id}i)s"' --max-requests 1000 --max-requests-jitter 100


### PR DESCRIPTION
We are still seeing a memory leak, so let's reduce the number of
requests again to see if that will stop the instances running out of
memory and then causing downtime when the OOM killer decides to do its
thing.