### PR TITLE
pip install playwright-python 1.54.0 in e2e tests docker image which …

### DIFF
--- a/compose/local/e2e_tests/Dockerfile
+++ b/compose/local/e2e_tests/Dockerfile
@@ -2,6 +2,9 @@ FROM mcr.microsoft.com/playwright/python:v1.54.0-noble@sha256:9e85bdc9c6980dc230
 
 WORKDIR /app
 
+RUN pip install playwright==1.54.0 && \
+    playwright install --with-deps
+
 RUN pip install pytest-playwright axe-playwright-python pillow numpy scikit-image
 COPY . .
 


### PR DESCRIPTION
## Changes in this PR:

pip install playwright-python 1.54.0 in e2e tests docker image which uses python playwright image 1.54.0 already as per https://github.com/nationalarchives/ds-caselaw-public-ui/pull/2354 although I havent changed the base image just yet.... but can probably change to base python one now we explicitly set playwright version ourselves although would require some extra bits like browser installation so leaving for now. 

Reason:
e2e tests started failing again since 1.55.0 was released, due to the issue detailed in: https://github.com/microsoft/playwright/issues/20010


## Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/browse/FCL-1208