### PR TITLE
FCL-1189 | update utils to 2.7.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-model-utils==5.0.0  # https://github.com/jazzband/django-model-utils
 requests~=2.32.2
 wsgi-basic-auth~=1.1.0
 ds-caselaw-marklogic-api-client==40.0.0
-ds-caselaw-utils==2.7.0
+ds-caselaw-utils==2.7.1
 rollbar
 django-weasyprint==2.4.0
 django-waffle==5.0.0  # https://github.com/django-waffle/django-waffle


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Updates the utils version so we can see the latest historic tribunals text/urls.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-1189
