### PR TITLE
FCL-1276 | add jinja templating

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -165,6 +165,7 @@ TEMPLATES = [
     {
         # https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-TEMPLATES-BACKEND
         "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "NAME": "django",
         # https://docs.djangoproject.com/en/dev/ref/settings/#dirs
         "DIRS": [str(APPS_DIR / "templates"), django.__path__[0] + "/forms/templates"],
         # https://docs.djangoproject.com/en/dev/ref/settings/#app-dirs
@@ -184,7 +185,19 @@ TEMPLATES = [
                 "judgments.context_processors.environment",
             ],
         },
-    }
+    },
+    {
+        "BACKEND": "django.template.backends.jinja2.Jinja2",
+        "NAME": "jinja",
+        "DIRS": [str(APPS_DIR / "templates")],
+        "APP_DIRS": False,
+        "OPTIONS": {
+            "environment": "judgments.jinja.environment",
+            "context_processors": [
+                "django.template.context_processors.request",
+            ],
+        },
+    },
 ]
 
 CRISPY_ALLOWED_TEMPLATE_PACKS = ["gds"]

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,6 +13,7 @@ from judgments.views.search import AdvancedSearchView, SearchResultsView
 from .converters import SchemaFileConverter
 from .views import static as static_views
 from .views.check import status
+from .views.components import ComponentsView
 from .views.courts import CourtOrTribunalView, CourtsTribunalsListView
 from .views.errors import NotFoundView, PermissionDeniedView, ServerErrorView
 from .views.schema import schema
@@ -157,6 +158,12 @@ urlpatterns = [
         "style-guide",
         StyleGuideView.as_view(),
         name="style_guide",
+    ),
+    # Components
+    path(
+        "components",
+        ComponentsView.as_view(),
+        name="components",
     ),
     # Test page
     path(

--- a/config/views/components.py
+++ b/config/views/components.py
@@ -1,0 +1,6 @@
+from django.views.generic import TemplateView
+
+
+class ComponentsView(TemplateView):
+    template_engine = "jinja"
+    template_name = "pages/components.jinja"

--- a/ds_judgements_public_ui/templates/layouts/base.jinja
+++ b/ds_judgements_public_ui/templates/layouts/base.jinja
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en-gb">
+  <head>
+    <meta charset="utf-8" />
+    {% block meta_description %}
+      {% if page_description %}
+        <meta name="description" content="{{ page_description }}" />
+      {% endif %}
+    {% endblock meta_description %}
+
+    {% block robots %}
+      {% if not page_allow_index %}
+        <meta name="robots" content="noindex,nofollow,noai" />
+      {% endif %}
+    {% endblock robots %}
+
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+
+    {% if page_canonical_url %}
+      <link rel="canonical" href="{{ page_canonical_url }}" />
+    {% endif %}
+
+    <title>
+      {% block title %}{% if page_title %}{{ page_title }} - {% endif %}Find Case Law{% endblock title %} - The National Archives
+    </title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="{{ static('images/favicons/favicon.png') }}" />
+
+    {% block css %}
+      <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&amp;family=Roboto:wght@400;600;700&amp;family=Roboto+Mono:wght@400;600;700&amp;display=swap"
+            rel="stylesheet" />
+      <link href="https://fonts.googleapis.com/css2?family=PT+Serif:wght@400;700&display=swap"
+            rel="stylesheet" />
+      <link href="{{ static('css/includes/govuk-country-and-territory-autocomplete/location-autocomplete.min.css') }}"
+            rel="stylesheet" />
+      <link href="{{ static('css/main.css') }}" rel="stylesheet" />
+    {% endblock css %}
+  </head>
+  <body class="{% block body_class %}{% endblock body_class %}">
+    <main id="main-content">
+      {% block content %}{% endblock content %}
+    </main>
+  </body>
+</html>

--- a/ds_judgements_public_ui/templates/pages/components.jinja
+++ b/ds_judgements_public_ui/templates/pages/components.jinja
@@ -1,0 +1,8 @@
+{% extends "layouts/base.jinja" %}
+
+{% block content %}
+  <div class="container">
+    <h1>Components</h1>
+    <p>As we create the components in jinja templates we can add them to this template to ensure they work as expected</p>
+    </div>
+{% endblock content %}

--- a/judgments/jinja.py
+++ b/judgments/jinja.py
@@ -1,0 +1,22 @@
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.urls import reverse
+from jinja2 import Environment, select_autoescape
+
+
+def environment(**options):
+    options.pop("autoescape", None)
+    env = Environment(
+        autoescape=select_autoescape(
+            enabled_extensions=("jinja"),
+            default_for_string=True,
+            default=True,
+        ),
+        **options,
+    )
+    env.globals.update(
+        {
+            "static": staticfiles_storage.url,
+            "url": reverse,
+        }
+    )
+    return env

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,6 +17,7 @@ django-waffle==5.0.0  # https://github.com/django-waffle/django-waffle
 django-formtools~=2.5.1
 crispy-forms-gds==2.0.1
 defusedxml==0.7.1
+Jinja2>=3.0
 
 # Type stubs
 mypy-boto3-s3==1.40.0


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Adds jinja templating. Also adds a page where we can add jinja components as we build them.

The base.jinja has the very basic stuff needed to render a page - doesn't include the header/footer etc as that'll come later.


## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-1276

## Screenshots of UI changes:

Page for adding templates currently looks like this (could swap this to storybook at a later date):

<img width="963" height="736" alt="image" src="https://github.com/user-attachments/assets/202394d0-dc21-4cee-849c-d095e219727a" />
