### PR TITLE
FCL-1295 | fix missing search container CSS

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_structured_search.scss
+++ b/ds_judgements_public_ui/sass/includes/_structured_search.scss
@@ -16,8 +16,6 @@
   }
 
   &__container {
-    @include container;
-
     max-width: 100%;
     padding: 0;
     text-align: left;

--- a/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
+++ b/ds_judgements_public_ui/templates/includes/results_filters_inputs.html
@@ -2,7 +2,7 @@
 
 <div id="js-results-facets"
      class="structured-search__filter-options js-results-facets">
-  <div class="structured-search__container">
+  <div class="structured-search__container container">
     <div class="structured-search__multi-fields-panel">
       <div class="structured-search__limit-to-container">
         <fieldset class="{% if form.non_field_errors or form.from_date.errors %}with-errors{% endif %}">

--- a/ds_judgements_public_ui/templates/includes/search/structured_search_form.html
+++ b/ds_judgements_public_ui/templates/includes/search/structured_search_form.html
@@ -1,5 +1,5 @@
 <div class="structured-search__main-search">
-  <div class="structured-search__container">
+  <div class="structured-search__container container">
     {% include "includes/search_term_component.html" with heading="Advanced search" %}
   </div>
 </div>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

For some reason `@include container` has stopped working. Luckily this is the only place that we are still using it, so have just applied the container class instead.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCL-1295

## Screenshots of UI changes:

<img width="1440" height="754" alt="image" src="https://github.com/user-attachments/assets/96a0033b-d29f-4f8c-b885-02273e859794" />
