### PR TITLE
Allow HEAD request on search (by removing the explicit check on HTTP verb)

### DIFF
--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -29,6 +29,20 @@ class TestAtomFeed(TestCase):
 
     @patch("judgments.feeds.search_judgments_and_parse_response")
     @patch("judgments.feeds.api_client")
+    def test_feed_exists_head(self, mock_api_client, mock_search_judgments_and_parse_response):
+        """Check that the feed actually returns something."""
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
+
+        response = self.client.head("/atom.xml")
+
+        # that there is a successful response
+        self.assertEqual(response.status_code, 200)
+
+        # that it has the expected Content-Type
+        self.assertEqual(response["Content-Type"], "application/xml; charset=utf-8")
+
+    @patch("judgments.feeds.search_judgments_and_parse_response")
+    @patch("judgments.feeds.api_client")
     def test_feed_query_handling(self, mock_api_client, mock_search_judgments_and_parse_response):
         """Check that the feed is performing the expected searches behind the scenes."""
         mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()

--- a/judgments/utils/search_request_to_parameters.py
+++ b/judgments/utils/search_request_to_parameters.py
@@ -23,12 +23,7 @@ def search_request_to_parameters(request: HttpRequest) -> SearchParameters:
     * Given a valid search form, query Marklogic and return the results
     * Given an invalid search form, render it again with the errors
     * Given GET request without form submission return an empty form
-    * Given anything except an HTTP GET request raise an error
     """
-    # We should only be handling GET requests here since we aren't changing anything on the server
-    if request.method != "GET":
-        # Raise an error if the user has tried any non GET HTTP requests.
-        raise BadRequest("GET requests only to search_request_to_results")
 
     form: AdvancedSearchForm = AdvancedSearchForm(request.GET)
     params = request.GET


### PR DESCRIPTION
https://dxw.slack.com/archives/C02TP2L2Z0F/p1758201302819729?thread_ts=1758200165.696399&cid=C02TP2L2Z0F
https://national-archives.atlassian.net/browse/FCL-1305

~~It might seem odd that .GET works just fine on HEAD, but apparently so. (It is GET lite, I suppose)~~
We remove the test as it isn't doing anything