### PR TITLE
Build/pin versions and security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,15 @@ ARG BUILD_ENVIRONMENT=production
 # Install apt packages for building
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # dependencies for building Python packages
-  build-essential \
+  build-essential=12.9 \
   # psycopg2 dependencies
-  libpq-dev \
+  libpq-dev=15.16-0+deb12u1 \
   # WeasyPrint dependencies
-  weasyprint \
-  python3-cffi python3-brotli libpango-1.0-0 libpangoft2-1.0-0 \
+  weasyprint=57.2-1 \
+  python3-cffi=1.15.1-5 \
+  python3-brotli=1.0.9-2+b6 \
+  libpango-1.0-0=1.50.12+ds-1 \
+  libpangoft2-1.0-0=1.50.12+ds-1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Requirements are installed here to ensure they will be cached.
@@ -40,10 +43,13 @@ WORKDIR ${APP_HOME}
 # Install runtime system dependencies (shared by both local and production)
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # psycopg2 dependencies
-  libpq-dev \
+  libpq-dev=15.16-0+deb12u1 \
   # WeasyPrint dependencies
-  weasyprint \
-  python3-cffi python3-brotli libpango-1.0-0 libpangoft2-1.0-0 \
+  weasyprint=57.2-1 \
+  python3-cffi=1.15.1-5 \
+  python3-brotli=1.0.9-2+b6 \
+  libpango-1.0-0=1.50.12+ds-1 \
+  libpangoft2-1.0-0=1.50.12+ds-1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Copy python dependency wheels from python-build-stage
@@ -62,10 +68,10 @@ ENV BUILD_ENV=${BUILD_ENVIRONMENT}
 
 # Install additional development and debugging tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
-  fonts-liberation \
-  lldb \
-  procps \
-  libcap2-bin \
+  fonts-liberation=1:1.07.4-11 \
+  lldb=1:14.0-55.7~deb12u1 \
+  procps=2:4.0.2-3 \
+  libcap2-bin=1:2.66-4+deb12u2+b2 \
   && rm -rf /var/lib/apt/lists/*
 
 # Copy application code to WORKDIR
@@ -88,12 +94,12 @@ RUN addgroup --system django \
 
 # Install production-specific dependencies (curl for Node.js installation)
 RUN apt-get update && apt-get install --no-install-recommends -y \
-  curl \
+  curl=7.88.1-10+deb12u14 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js and clean up in one layer
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-  && apt-get install --no-install-recommends -y nodejs \
+  && apt-get install --no-install-recommends -y nodejs=22.22.2-1nodesource1 \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,26 +104,28 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js dependencies (as root)
-COPY --chown=django:django package-lock.json package.json ./
+COPY package-lock.json package.json ./
 RUN npm ci --engine-strict=true
 
-# Copy application code (owned by django for now - will change in later PR)
-COPY --chown=django:django . ${APP_HOME}
+# Copy application code (owned by root)
+COPY . ${APP_HOME}
 
-# Copy and prepare production scripts
-COPY --chown=django:django ./compose/docker/entrypoint /entrypoint
+# Copy and prepare production scripts (owned by root)
+COPY ./compose/docker/entrypoint /entrypoint
 RUN sed -i 's/\r$//g' /entrypoint
 RUN chmod +x /entrypoint
 
-COPY --chown=django:django ./compose/docker/start /start
+COPY ./compose/docker/start /start
 RUN sed -i 's/\r$//g' /start
 RUN chmod +x /start
 
-# Create directories that need to be writable by the django user
+# Create only the directories that need to be writable by the django user
+# Application code remains owned by root (immutable)
 RUN mkdir -p ${APP_HOME}/media ${APP_HOME}/logs \
   && chown -R django:django ${APP_HOME}/media ${APP_HOME}/logs
 
 # Run as non-root user in production
+# User can write to media/logs/staticfiles but cannot modify application code
 USER django
 
 ENTRYPOINT ["/entrypoint"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,22 +43,6 @@ services:
     volumes:
       - ./database_backups:/backups:z
 
-  docs:
-    image: ds_judgements_public_ui_local_docs
-    container_name: ds_judgements_public_ui_local_docs
-    build:
-      context: .
-      dockerfile: ./compose/local/docs/Dockerfile
-    env_file:
-      - ./.env
-    volumes:
-      - ./docs:/docs:z
-      - ./config:/app/config:z
-      - ./ds_judgements_public_ui:/app/ds_judgements_public_ui:z
-    ports:
-      - "7000:7000"
-    command: /start-docs
-
   e2e_tests:
     container_name: e2e_tests_container
     build:


### PR DESCRIPTION
Followup to https://github.com/nationalarchives/ds-caselaw-public-ui/pull/3010

## Changes in this PR:

[build: pin apt package versions in Dockerfile](https://github.com/nationalarchives/ds-caselaw-public-ui/commit/cdb8e3e8b7b393e0433e18ffcda48790aa7a1140)
[build: restrict file ownership to writable directories only](https://github.com/nationalarchives/ds-caselaw-public-ui/commit/68798e30d74eb16b1c2ad1111953862c1bc68f27)
[chore: remove redundant docs service in docker-compose.yml](https://github.com/nationalarchives/ds-caselaw-public-ui/commit/4032ea9f971d9784b4c93570efdb33ac849c7e39)

## Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/browse/FCL-1889
