### PR TITLE
fix: Fix prod django docker write permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,10 +119,19 @@ COPY ./compose/docker/start /start
 RUN sed -i 's/\r$//g' /start
 RUN chmod +x /start
 
-# Create only the directories that need to be writable by the django user
-# Application code remains owned by root (immutable)
+# Create directories that need to be writable by the django user at runtime
+# - media/logs: application data
+# - static output dirs: written by npm run build and collectstatic in /start
 RUN mkdir -p ${APP_HOME}/media ${APP_HOME}/logs \
-  && chown -R django:django ${APP_HOME}/media ${APP_HOME}/logs
+    ${APP_HOME}/ds_judgements_public_ui/static/css \
+    ${APP_HOME}/ds_judgements_public_ui/static/js/dist \
+    ${APP_HOME}/staticfiles \
+  && chown -R django:django \
+    ${APP_HOME}/media \
+    ${APP_HOME}/logs \
+    ${APP_HOME}/ds_judgements_public_ui/static/css \
+    ${APP_HOME}/ds_judgements_public_ui/static/js/dist \
+    ${APP_HOME}/staticfiles
 
 # Run as non-root user in production
 # User can write to media/logs/staticfiles but cannot modify application code


### PR DESCRIPTION
## Changes in this PR:

[fix: Fix prod django docker write permissions](https://github.com/nationalarchives/ds-caselaw-public-ui/commit/84282472f69d0fb7ee2c120206171c03abad4d0b)

We do have a step in CI to build this Dockerfile but we do not attempt to run it and so we do not execute the start script and entrypoint script.

Have now re-run this locally and confirm this works again now (with a locally modified docker-compose.yml file). Am working on a change to CI that will verify this in CI but do not want to block fixing the broken deployment on main and hopefully will get a variant of the compose file that lets us test the prod image locally.

Error in container before exiting: 
```

Error reading ds_judgements_public_ui/static/css/document_pdf.css.map: permission denied.


Error reading ds_judgements_public_ui/static/css/includes/cookie_consent/ds-cookie-consent.css.map: permission denied.


Error reading ds_judgements_public_ui/static/css/main.css.map: permission denied.
```

## Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/browse/FCL-1889