### PR TITLE
Fix production django docke permissions, test in ci and improve dev docker compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,5 @@
 .pre-commit-config.yaml
 .readthedocs.yml
 .travis.yml
+node_modules
 venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run tests
         run: npm test
 
-  build-production-dockerfile:
+  production-smoke-test:
     needs: linter
     runs-on: ubuntu-latest
 
@@ -80,19 +80,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Create external network
+        run: docker network create caselaw
 
-      - name: Build production Dockerfile
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          context: .
-          file: ./Dockerfile
-          target: python-production-stage
-          push: false
-          tags: ds_judgments_public_ui:production-test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Build and run production smoke test
+        run: docker compose -f docker-compose.yml -f docker-compose.prod-test.yml up -d --build --wait --wait-timeout 600
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.yml -f docker-compose.prod-test.yml logs
+
+      - name: Cleanup
+        if: always()
+        run: docker compose -f docker-compose.yml -f docker-compose.prod-test.yml down
 
   build-django:
     needs: linter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: check-merge-conflict
       - id: check-xml
       - id: check-yaml
+        args: [--unsafe] # Allow !reset tag for clearing inherited volumes in prod test config. See https://github.com/pre-commit/pre-commit-hooks/issues/1090 issue comment for context.
       - id: end-of-file-fixer
       - id: forbid-submodules
       - id: mixed-line-ending

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,18 +119,14 @@ COPY ./compose/docker/start /start
 RUN sed -i 's/\r$//g' /start
 RUN chmod +x /start
 
-# Create directories that need to be writable by the django user at runtime
+# Grant django user write access to directories written at runtime:
 # - media/logs: application data
-# - static output dirs: written by npm run build and collectstatic in /start
-RUN mkdir -p ${APP_HOME}/media ${APP_HOME}/logs \
-    ${APP_HOME}/ds_judgements_public_ui/static/css \
-    ${APP_HOME}/ds_judgements_public_ui/static/js/dist \
-    ${APP_HOME}/staticfiles \
+# - static: build outputs from npm run build (webpack + sass) and collectstatic
+RUN mkdir -p ${APP_HOME}/media ${APP_HOME}/logs ${APP_HOME}/staticfiles \
   && chown -R django:django \
     ${APP_HOME}/media \
     ${APP_HOME}/logs \
-    ${APP_HOME}/ds_judgements_public_ui/static/css \
-    ${APP_HOME}/ds_judgements_public_ui/static/js/dist \
+    ${APP_HOME}/ds_judgements_public_ui/static \
     ${APP_HOME}/staticfiles
 
 # Run as non-root user in production

--- a/README.md
+++ b/README.md
@@ -20,17 +20,38 @@ manager or [download a `.deb` or
 `.rpm`](https://docs.docker.com/engine/install/)
 
 Once installed, we need to build our containers. We use
-[`docker-compose`](https://docs.docker.com/compose/) to orchestrate the
-building of the project's containers, one for each each service:
+[`docker compose`](https://docs.docker.com/compose/) to orchestrate the
+building of the project's containers:
 
-### `django`
+### Services
 
-Our custom container responsible for running the application. Built from the
-official [python 3.9](https://hub.docker.com/_/python/) base image
+- **`django`** — The application container, built from a multi-stage Dockerfile (local dev stage by default)
+- **`postgres`** — PostgreSQL database
+- **`marklogic`** — Local MarkLogic instance (included in compose by default)
+- **`e2e_tests`** — Playwright end-to-end tests (opt-in via `--profile e2e_tests`)
 
-### `postgres`
+### Compose files
 
-The database service built from the official [postgres](https://hub.docker.com/_/postgres/) image
+#### `docker-compose.yml` — Local development (default)
+
+The base compose file targets the `python-local-stage` of the multi-stage Dockerfile. This stage installs all dependencies (including dev dependencies) but does **not** run the application server — instead it runs `tail -f /dev/null` so the container stays alive and you use `fab run` or `docker exec` to start the Django dev server, watch Sass, etc. Source code is mounted from the host (`.:/app:z`) so edits are reflected immediately without rebuilding.
+
+#### `docker-compose.prod-test.yml` — Production image verification
+
+This override file targets the final `python-production-stage` of the Dockerfile, which is the same image deployed to AWS ECS. Key differences from the local stage:
+
+- **No volume mounts** — the app runs entirely from the files baked into the image, exactly as it would in production.
+- **Separate entrypoint and start scripts** — `compose/docker/entrypoint` waits for Postgres and runs migrations, then `compose/docker/start` compiles frontend assets (`npm run build`), collects static files (`collectstatic`), and starts gunicorn on port 5000.
+- **Runs as the `django` user** — not root, matching the production security model.
+- **Includes a healthcheck** — polls `http://localhost:5000/check` to confirm the app is actually serving traffic, not just that the container started.
+
+You won't use this during normal development, but it lets you catch production-only failures locally — for example, file permission issues, missing static assets, or entrypoint bugs that volume mounts would mask. CI runs this automatically on every push using `docker compose ... up --build --wait` to verify the production image builds and starts successfully before merging.
+
+To verify the production image locally:
+
+```console
+docker compose -f docker-compose.yml -f docker-compose.prod-test.yml up --build --wait
+```
 
 ## Getting started
 
@@ -44,19 +65,23 @@ cp .env.example .env
 
 If new environment variables are required, you might need to update .env to reflect that. Check .env.example for suitable default values
 
-### 2. Get access to Marklogic
+### 2. MarkLogic
 
-This app is intended to edit Judgments in the Marklogic database defined in [ds-find-caselaw-docs/marklogic](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/marklogic).
+This app connects to the MarkLogic database defined in [ds-find-caselaw-docs/marklogic](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/marklogic).
 
-If you wish to run your own Marklogic instance, you will need to follow the setup instructions for it at
-[ds-find-caselaw-docs/marklogic](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/marklogic).
+A basic local MarkLogic instance is included in `docker-compose.yml` and starts automatically with `fab run` / `docker compose up`. This is enough to get the static site running without needing a separate repo or VPN access, but the local MarkLogic setup may need further development — see the [ds-find-caselaw-docs/marklogic](https://github.com/nationalarchives/ds-find-caselaw-docs/tree/main/marklogic) repo for full configuration details.
 
-For TNA/dxw developers, it is simpler to access the shared [staging Marklogic database](https://national-archives.atlassian.net/wiki/spaces/DFCL/pages/1152974873/MarkLogic+database+location) via VPN,
-and then set the `MARKLOGIC_HOST`, `MARKLOGIC_USER`, and `MARKLOGIC_PASSWORD` variables in your `.env` file.
+Alternatively, TNA/dxw developers can connect to the shared [staging MarkLogic database](https://national-archives.atlassian.net/wiki/spaces/DFCL/pages/1152974873/MarkLogic+database+location) via VPN by setting `MARKLOGIC_HOST`, `MARKLOGIC_USER`, and `MARKLOGIC_PASSWORD` in your `.env` file.
 
-The defaults in `.env.example` are correct for a local Marklogic instance.
+### 3. Create Docker network
 
-### 3. Compile frontend assets
+The compose files in this repo and in other caselaw services share an external network named `caselaw`. Create it if it does not yet exist:
+
+```console
+docker network create caselaw
+```
+
+### 4. Compile frontend assets
 
 With the dependencies installed as described in [Front end development](#front-end-development)
 
@@ -64,7 +89,7 @@ With the dependencies installed as described in [Front end development](#front-e
 npm run build
 ```
 
-### 4. Build Docker containers
+### 5. Build Docker containers
 
 ```console
 fab build
@@ -75,28 +100,7 @@ it's a good thing to run if your environment suddenly stops working.
 
 If this fails early on, it's very likely that Docker isn't running, and you'll need to start it.
 
-### 5. Create Docker network
-
-The `docker-compose` files in this repo and in [ds-caselaw-marklogic](https://github.com/nationalarchives/ds-caselaw-marklogic) both specify an external default network named `caselaw`.
-
-We need to create a network with this name if it does not yet exist:
-
-```console
-docker network create caselaw
-```
-
-### 6. Run Marklogic
-
-**Note** If you are using the staging instance of Marklogic, you do not need to
-follow this step.
-
-Switch to the location of [ds-caselaw-marklogic](https://github.com/nationalarchives/ds-caselaw-marklogic) and run:
-
-```console
-docker-compose up
-```
-
-### 7. Quick start
+### 6. Quick start
 
 At this point you can run the following command to "quick start" the application:
 

--- a/docker-compose.prod-test.yml
+++ b/docker-compose.prod-test.yml
@@ -1,0 +1,30 @@
+# Production image verification.
+# Usage: docker compose -f docker-compose.yml -f docker-compose.prod-test.yml up --build --wait
+services:
+  django:
+    build:
+      target: python-production-stage
+      args:
+        BUILD_ENVIRONMENT: production
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes: !reset []
+    environment:
+      DJANGO_SETTINGS_MODULE: config.settings.production
+      VCR_ENABLED: false
+    ports:
+      - "5001:5000"
+    command: ["/start"]
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:5000/check')",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 120s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,50 +9,100 @@ services:
       args:
         BUILD_ENVIRONMENT: local
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+      marklogic:
+        condition: service_healthy
+    init: true
     volumes:
       - .:/app:z
       - ../ds-caselaw-custom-api-client:/apiclient
-    init: true
     environment:
-      DATABASE_URL: "postgres://postgres:admin@postgres:5432/ds_judgements_public_ui"
-      DJANGO_SETTINGS_MODULE: "config.settings.local"
-      SECRET_KEY: local_dev_secret_key
-      SECURE_SSL_REDIRECT: "false"
-    env_file:
-      - ./.env
+      DATABASE_URL: "postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-admin}@postgres:5432/${POSTGRES_DB:-ds_judgements_public_ui}"
+      DJANGO_SETTINGS_MODULE: config.settings.local
+      SECRET_KEY: ${SECRET_KEY:-local_dev_secret_key}
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-local_dev_secret_key}
+      DJANGO_ADMIN_URL: ${DJANGO_ADMIN_URL:-admin/}
+      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-localhost,127.0.0.1,0.0.0.0}
+      ROLLBAR_ACCESS_TOKEN: ${ROLLBAR_ACCESS_TOKEN:-}
+      ROLLBAR_ENV: ${ROLLBAR_ENV:-development}
+      SECURE_SSL_REDIRECT: ${SECURE_SSL_REDIRECT:-false}
+      DJANGO_SECURE_SSL_REDIRECT: ${DJANGO_SECURE_SSL_REDIRECT:-false}
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: ${POSTGRES_DB:-ds_judgements_public_ui}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-admin}
+      MARKLOGIC_HOST: ${MARKLOGIC_HOST:-marklogic}
+      MARKLOGIC_USER: ${MARKLOGIC_USER:-admin}
+      MARKLOGIC_PASSWORD: ${MARKLOGIC_PASSWORD:-admin}
+      MARKLOGIC_USE_HTTPS: ${MARKLOGIC_USE_HTTPS:-false}
+      VCR_ENABLED: ${VCR_ENABLED:-true}
+      VCR_MODE: ${VCR_MODE:-playback}
+      ASSETS_CDN_BASE_URL: ${ASSETS_CDN_BASE_URL:-}
+      PUBLIC_ASSET_BUCKET: ${PUBLIC_ASSET_BUCKET:-}
+      S3_REGION: ${S3_REGION:-eu-west-2}
+      MAX_QUERY_WORDS: ${MAX_QUERY_WORDS:-5}
+      WSGI_AUTH_EXCLUDE_PATHS: ${WSGI_AUTH_EXCLUDE_PATHS:-/check}
     ports:
       - "3000:3000"
-    # do nothing forever - exec commands elsewhere
     command: tail -f /dev/null
 
   postgres:
     image: postgres:15.17@sha256:3e43515057e113ee741fca2f621f15300be34a6d4a8dfcf2e20651288c8272f3
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_DB: ds_judgements_public_ui
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: admin
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: 5432
-      PGDATABASE: ds_judgements_public_ui
-      PGUSER: postgres
-      PGPASSWORD: admin
+      POSTGRES_DB: ${POSTGRES_DB:-ds_judgements_public_ui}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-admin}
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - ./database_backups:/backups:z
+
+  marklogic:
+    image: progressofficial/marklogic-db:12.0.1-ubi-rootless-2.2.4@sha256:2159236c8d6a52d41a84a50822864d99d528789489e8247e81dd2922cb0711c6
+    container_name: marklogic
+    hostname: marklogic
+    dns_search: ""
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'curl http://localhost:8002/manage/v2?view=healthcheck -u "admin:admin" || exit 1',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+    environment:
+      - MARKLOGIC_INIT=true
+      - MARKLOGIC_ADMIN_USERNAME=admin
+      - MARKLOGIC_ADMIN_PASSWORD=admin
+      - REALM=public
+      - TZ=Europe/London
+    volumes:
+      - marklogic_data:/var/opt/MarkLogic
+    ports:
+      - 8000-8010:8000-8010
 
   e2e_tests:
     container_name: e2e_tests_container
     build:
       context: ./e2e_tests
       dockerfile: "../compose/local/e2e_tests/Dockerfile"
-
     profiles: [e2e_tests]
     volumes:
       - "./e2e_tests:/app:z"
     tty: true
+
+volumes:
+  marklogic_data:
 
 networks:
   default:

--- a/judgments/tests/test_pdf.py
+++ b/judgments/tests/test_pdf.py
@@ -8,6 +8,7 @@ from judgments.models.document_pdf import DocumentPdf
 from judgments.utils import formatted_document_uri
 
 
+@patch.dict(environ, {"ASSETS_CDN_BASE_URL": "https://example.org"})
 class TestDocumentPdf:
     @patch("judgments.models.document_pdf.requests")
     def test_get_pdf_size_returns_pdf_size_if_it_exists(self, requests_mock):


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

[fix: Fix more prod django docker write permissions](https://github.com/nationalarchives/ds-caselaw-public-ui/commit/ee6bbeb385871883bc1233c34e886593d21bf1ff)

[ci: add production smoke test and modernise docker-compose](https://github.com/nationalarchives/ds-caselaw-public-ui/commit/9cfc661be4a8cbea20a4a18a9bac57b19593e8b8) 

- Replace build-only CI step with compose-based production smoke test
  that builds the image, starts it, and verifies it serves via healthcheck
- Add docker-compose.prod-test.yml overlay targeting production stage
  with gunicorn, no volume mounts, and django user — matching ECS deployment
- Add MarkLogic service with healthcheck to docker-compose.yml
- Add postgres healthcheck and service_healthy depends_on conditions
- Replace hardcoded env vars and env_file with ${VAR:-default} syntax
- Update postgres image digest pin
- Update README documenting compose files, local vs production stages,
  MarkLogic setup, and Docker network requirement
  
  
**Previous error was:**
<img width="1116" height="329" alt="Screenshot 2026-04-10 at 18 54 59" src="https://github.com/user-attachments/assets/6514ea7d-b317-4a3d-bd7d-f130a573ef7d" />


## Jira card / Rollbar error (etc)
https://national-archives.atlassian.net/browse/FCLC-624
