### PR TITLE
fix: re-declare APP_HOME ARG in each stage for legacy Docker builder compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,8 @@ RUN pip install --no-cache-dir --no-index --find-links=/wheels/ /wheels/* \
 # Local development stage
 FROM python-runtime-stage AS python-local-stage
 
+ARG APP_HOME=/app
+
 ARG BUILD_ENVIRONMENT=local
 ENV BUILD_ENV=${BUILD_ENVIRONMENT}
 
@@ -84,6 +86,8 @@ CMD ["tail", "-f", "/dev/null"]
 
 # Production stage
 FROM python-runtime-stage AS python-production-stage
+
+ARG APP_HOME=/app
 
 ARG BUILD_ENVIRONMENT=production
 ENV BUILD_ENV=${BUILD_ENVIRONMENT}


### PR DESCRIPTION
## Changes in this PR:

fix: re-declare APP_HOME ARG in each stage for legacy Docker builder compatibility

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-624

Context:

TIL a key difference between the legacy docker build engine and the modern Docker BuildKit engine: The legacy builder does not pass down ARGs to inheriting build stages, whereas BuildKit does. Our current AWS CodePipeline builds on the ECS cluster which seems to have an older version of Docker which does not default to BuildKit (for some context the latest version of Docker does not even include the legacy builder anymore) which means currently CodeBuild uses that and does not pass through the args which is resulting in COPY . ${APP_HOME} to have empty APP_HOME in the prod dockerfile build resulting in a permissions error.

I manually tweaked the staging codebuild to use DOCKER_BUILDKIT=1 to verify this fixes things, but I will undo that as I don't have the visibility on where this is defined and just update the dockerfile stage to define APP_HOME for now.