### PR TITLE
Make court/tribunal pages return a 404 on a CourtNotFound

### DIFF
--- a/config/tests/test_courts_view.py
+++ b/config/tests/test_courts_view.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from ds_caselaw_utils.courts import CourtNotFoundException
+
+
+class TestCourtOrTribunalView(TestCase):
+    """Test the CourtOrTribunalView handles court not found correctly."""
+
+    @patch("config.views.courts.courts.get_by_param")
+    def test_returns_404_when_court_not_found(self, mock_get_by_param):
+        """Test that accessing a non-existent court returns a 404 response."""
+        mock_get_by_param.side_effect = CourtNotFoundException("Court not found")
+
+        response = self.client.get("/courts-and-tribunals/invalid-param")
+
+        assert response.status_code == 404

--- a/config/views/courts.py
+++ b/config/views/courts.py
@@ -1,5 +1,6 @@
 from django.http import Http404
 from django.urls import reverse
+from django.utils.functional import cached_property
 from ds_caselaw_utils import courts
 from ds_caselaw_utils.courts import CourtNotFoundException
 
@@ -68,7 +69,7 @@ class CourtOrTribunalView(TemplateViewWithContext):
     def page_title(self):
         return self.court.name
 
-    @property
+    @cached_property
     def court(self):
         try:
             return courts.get_by_param(self.kwargs["param"])

--- a/config/views/courts.py
+++ b/config/views/courts.py
@@ -1,5 +1,7 @@
+from django.http import Http404
 from django.urls import reverse
 from ds_caselaw_utils import courts
+from ds_caselaw_utils.courts import CourtNotFoundException
 
 from judgments.models.court_dates import CourtDates
 
@@ -68,13 +70,19 @@ class CourtOrTribunalView(TemplateViewWithContext):
 
     @property
     def court(self):
-        return courts.get_by_param(self.kwargs["param"])
+        try:
+            return courts.get_by_param(self.kwargs["param"])
+        except CourtNotFoundException:
+            raise Http404("Court not found")
 
     def get_context_data(self, **kwargs):
+
+        court = self.court
+
         context = super().get_context_data(**kwargs)
 
-        context["feedback_survey_type"] = "court_or_tribunal_%s" % self.court.canonical_param
-        context["court"] = self.court
+        context["feedback_survey_type"] = "court_or_tribunal_%s" % court.canonical_param
+        context["court"] = court
         context["breadcrumbs"] = [
             {"text": "Search and browse", "url": reverse("search_and_browse")},
             {"url": reverse("courts_and_tribunals"), "text": "Types of courts in England and Wales"},


### PR DESCRIPTION
Instead of returning a HTTP 500 error code for an internal error, return a HTTP 404 to better inform the user that they're asking for a page which doesn't exist.
