### PR TITLE
Pin playwright version in E2E pip dependencies

### DIFF
--- a/e2e_tests/requirements.txt
+++ b/e2e_tests/requirements.txt
@@ -1,3 +1,4 @@
+playwright==1.58.0
 pytest-playwright==0.7.2
 axe-playwright-python==0.1.7
 pillow==12.2.0


### PR DESCRIPTION
This prevents the installed Playwright version from being silently updated, which in turn causes CI failures as Playwright complains about a version mismatch between the library and the Docker image.