### PR TITLE
No dodgy characters in config files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ unfixable = ["ERA"]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "tests/*" = ["S101"]  # `assert` is fine in tests
-"judgments/tests/*" = ["S101"]  # `assert` is fine in tests
+"judgments/tests/*" = ["S101"]  # `assert` is fine in tests
 "config/tests/*" = ["S101"] # `assert` is fine in tests
 "e2e_tests/*" = ["S101"]  # `assert` is fine in tests
 "fabfile.py" = ["S607",  # starting a process (docker) with an executable defined by PATH
-                "S603", ] # untrusted input to subprocess (docker commands)
+                "S603", ] # untrusted input to subprocess (docker commands)


### PR DESCRIPTION
Silence some renovate errors.

https://my.slack.com/archives/C04FQ3GFGUQ/p1777999141662859