### PR TITLE
Balance page contents navigation links

### DIFF
--- a/ds_judgements_public_ui/sass/components/_contents.scss
+++ b/ds_judgements_public_ui/sass/components/_contents.scss
@@ -20,6 +20,8 @@
     padding: $space-6 $space-6 $space-10;
     border: 2px solid colour-var("accent-brand");
 
+    text-wrap: balance;
+
     h3 {
       margin: 0;
     }


### PR DESCRIPTION
This more evenly balances line length in the sidebar 'contents' links when a link spans two or more lines.

## Screenshots

### Before

<img width="1222" height="462" alt="Screenshot 2026-05-12 at 16 15 28" src="https://github.com/user-attachments/assets/5d56b184-2411-4f93-95a1-0ac731af39dc" />

### After

<img width="1228" height="456" alt="Screenshot 2026-05-12 at 16 15 53" src="https://github.com/user-attachments/assets/1c99a4cc-ee62-4764-b19a-17c6dc1ba6e7" />
