### PR TITLE
FCLC-1954 | use court description from jinja macro

### DIFF
--- a/config/views/courts.py
+++ b/config/views/courts.py
@@ -31,7 +31,6 @@ class CourtsTribunalsListView(TemplateViewWithContext):
     def decorate_court_group(self, group):
         """
         Updates the start_year and end_year with data from CourtDates if available.
-        Updates the description_text_as_html with the updated dates if they are available..
         """
 
         date_map = {
@@ -43,9 +42,6 @@ class CourtsTribunalsListView(TemplateViewWithContext):
             dates = date_map.get(court.canonical_param)
 
             if dates:
-                court.description_text_as_html = court.render_markdown_text(
-                    "description", {"start_year": dates.start_year, "end_year": dates.end_year}
-                )
                 court.start_year = dates.start_year
                 court.end_year = dates.end_year
 

--- a/ds_judgements_public_ui/templates/includes/courts_and_tribunals_court.jinja
+++ b/ds_judgements_public_ui/templates/includes/courts_and_tribunals_court.jinja
@@ -2,6 +2,7 @@
 {% from "components/heading.jinja" import heading %}
 {% from "components/details.jinja" import details %}
 {% macro courts_and_tribunals_court(court=None, type=None, group=None) %}
+  {% from "content/courts/" ~ court.canonical_param ~ ".jinja" import description_content with context %}
   <div class="courts-and-tribunals__sub-item">
     {% if group.display_heading %}
       {% call heading(tag="h3", id=court.name|slugify) %}
@@ -12,13 +13,9 @@
         {{ link(content=court.grouped_name, href=url("court_or_tribunal", court.canonical_param) ) }}
       {% endcall %}
     {% endif %}
-    {% if court.description_text_as_html %}
-      {% call details(title="About the " ~ court.grouped_name, variant="light") %}
-        {% autoescape off %}
-          {{ court.description_text_as_html }}
-        {% endautoescape %}
-      {% endcall %}
-    {% endif %}
+    {% call details(title="About the " ~ court.grouped_name, variant="light") %}
+      {{ description_content(start_year=court.canonical_param|get_court_start_year) }}
+    {% endcall %}
     <p>
       {% if court|get_court_judgments_count == 0 %}
         We don't currently hold any documents

--- a/ds_judgements_public_ui/templates/includes/courts_and_tribunals_group.jinja
+++ b/ds_judgements_public_ui/templates/includes/courts_and_tribunals_group.jinja
@@ -6,13 +6,6 @@
       {% call heading(tag="h2", id=group.name|slugify) %}
         {{ group.name }}
       {% endcall %}
-      {% if group.description_text_as_html %}
-        <div class="courts-and-tribunals__description">
-          {% autoescape off %}
-            {{ group.description_text_as_html }}
-          {% endautoescape %}
-        </div>
-      {% endif %}
     {% endif %}
     {# these 'courts' could instead be tribunals #}
     {% for court in group.courts %}{{ courts_and_tribunals_court(court=court, type=type, group=group) }}{% endfor %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Use the court description from the jinja templates that has potentially updated copy instead of the deprecated one from the utils.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-1954
