### PR TITLE
FCLC-1955 | migrate historic documents content

### DIFF
--- a/ds_judgements_public_ui/templates/content/courts/eat.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/eat.jinja
@@ -1,6 +1,8 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/courts-tribunals/employment-appeal-tribunal", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +33,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ewca.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewca.jinja
@@ -1,6 +1,8 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ label }}
 {% endmacro %}
@@ -31,11 +33,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ewca/civ.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewca/civ.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older Court of Appeal (civil) justice records in the research guide {{ link(content="Civil court cases: an overview", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/civil-courts-appeal-cases-after-1875/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/courts-tribunals/court-of-appeal-civil-division", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -37,11 +42,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
   {{ heading(content="Understanding " ~ court.name ~ " judgments", tag="h2", id="understanding-judgments") }}

--- a/ds_judgements_public_ui/templates/content/courts/ewca/crim.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewca/crim.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older civil justice records in the research guide {{ link(content="Criminal courts: appeal cases", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/criminal-courts-appeal-cases/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/courts-tribunals/court-of-appeal-criminal-division", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -37,11 +42,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
   {{ heading(content="Understanding " ~ court.name ~ " judgments", tag="h2", id="understanding-judgments") }}

--- a/ds_judgements_public_ui/templates/content/courts/ewcc.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewcc.jinja
@@ -1,6 +1,9 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>County Court records are more likely held in local archives rather than at the National Archives.</p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/courts-tribunals/court-of-protection", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +34,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ewcop.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewcop.jinja
@@ -1,6 +1,8 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/courts-tribunals/court-of-protection", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +33,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ewcr.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewcr.jinja
@@ -1,6 +1,9 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>Crown Court records are more likely held in local archives rather than at The National Archives.</p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/courts-and-tribunals/crown-court/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +34,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ewfc.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewfc.jinja
@@ -1,6 +1,8 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/courts-and-tribunals/family-law-courts/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -37,11 +39,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
   {{ heading(content="Understanding " ~ court.name ~ " judgments", tag="h2", id="understanding-judgments") }}

--- a/ds_judgements_public_ui/templates/content/courts/ewhc.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewhc.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older civil court cases records in the research guide {{ link(content="Civil court cases: an overview", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/civil-court-cases-overview/", attrs={"target":"_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/structure-of-courts-and-tribunals-system/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -34,11 +39,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
   {{ heading(content="Understanding " ~ court.name ~ " judgments", tag="h2", id="understanding-judgments") }}

--- a/ds_judgements_public_ui/templates/content/courts/ewhc/admin.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewhc/admin.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older Kings/Queens Bench Division cases in the research guide {{ link(content="Civil court cases: King's/Queen's Bench 1702-1998", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/court-of-kings-bench-plea-side-and-kings-queens-bench-division-cases-1702-1998/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/courts-and-tribunals/high-court/administrative-court/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -34,11 +39,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ewhc/admlty.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewhc/admlty.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older Admiralty Court records in the research guide {{ link(content="High court of Admiralty", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/high-court-admiralty-records/", attrs={"target":"_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/courts-and-tribunals/business-and-property-courts/admiralty-court/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ewhc/ch.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewhc/ch.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older records in {{ link(content="Civil court cases: Chancery Division since 1875", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/civil-court-cases-chancery-division-since-1875/", attrs={"target":"_blank"}) }}
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/courts-and-tribunals/business-and-property-courts/chancery-division/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -37,11 +42,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
   {{ heading(content="Understanding " ~ court.name ~ " judgments", tag="h2", id="understanding-judgments") }}

--- a/ds_judgements_public_ui/templates/content/courts/ewhc/comm.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewhc/comm.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You may be able to find older Commercial and Mercantile Court records in {{ link(content="The National Archives’ Catalogue", href="https://discovery.nationalarchives.gov.uk/", attrs={"target": "_blank"}) }} however the record may not be available online. You can read more about how to find older records in {{ link(content="the Civil Court cases: Kings/Queens bench division research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/court-of-kings-bench-plea-side-and-kings-queens-bench-division-cases-1702-1998/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/courts-and-tribunals/business-and-property-courts/commercial-court/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ewhc/fam.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewhc/fam.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older divorce case files in the {{ link(content="divorce research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/divorce/", attrs={"target":"_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/courts-tribunals/family-division-of-the-high-court", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ewhc/ipec.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewhc/ipec.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older patent records in {{ link(content="Intellectual property: patents for invention research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/patents-of-invention/", attrs={"target": "_blank"}) }}; {{ link(content="Intellectual property: registered designs 1839-1991 research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/registered-designs-1839-1991/", attrs={"target": "_blank"}) }} or {{ link(content="Intellectual property: trademarks 1876-1938 research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/trade-marks/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/courts-and-tribunals/business-and-property-courts/business-list-general-chancery/intellectual-property-list/intellectual-property-enterprise-court-ipec/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ewhc/kb.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewhc/kb.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older King’s Bench records in {{ link(content="Civil court cases: King’s/Queen’s Bench 1702-1998 research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/court-of-kings-bench-plea-side-and-kings-queens-bench-division-cases-1702-1998/", attrs={"target": "_blank"}) }} or {{ link(content="Criminal court cases: King’s/Queen’s Bench 1675-1988", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/court-kings-bench-crown-side-1675-1875/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/courts-and-tribunals/kings-bench-division/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -37,11 +42,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
   {{ heading(content="Understanding " ~ court.name ~ " judgments", tag="h2", id="understanding-judgments") }}

--- a/ds_judgements_public_ui/templates/content/courts/ewhc/mercantile.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewhc/mercantile.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older records in {{ link(content="the civil court cases : Kings/Queens bench division research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/court-of-kings-bench-plea-side-and-kings-queens-bench-division-cases-1702-1998/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/courts-and-tribunals/business-and-property-courts/commercial-court/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ewhc/pat.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewhc/pat.jinja
@@ -3,7 +3,7 @@
 {% from "components/heading.jinja" import heading %}
 {% macro historic_documents_content() %}
   <p>
-    You can read more about how to find older patent records in {{ link(content="Intellectual property: patents for invention research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/patents-of-invention/", attrs={"target": "_blank"}) }}; {{ link(content="Intellectual property: registered designs 1839-1991 research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/registered-designs-1839-1991/", attrs={"target":"_blank"}) }} or {{ link(content="Intellectual property: trademarks 1876 -1938 research guide](https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/trade-marks/", attrs={"target": "_blank"}) }}.
+    You can read more about how to find older patent records in {{ link(content="Intellectual property: patents for invention research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/patents-of-invention/", attrs={"target": "_blank"}) }}; {{ link(content="Intellectual property: registered designs 1839-1991 research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/registered-designs-1839-1991/", attrs={"target":"_blank"}) }} or {{ link(content="Intellectual property: trademarks 1876 -1938 research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/trade-marks/", attrs={"target": "_blank"}) }}.
   </p>
 {% endmacro %}
 {% macro website_link(label=None) %}

--- a/ds_judgements_public_ui/templates/content/courts/ewhc/pat.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewhc/pat.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older patent records in {{ link(content="Intellectual property: patents for invention research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/patents-of-invention/", attrs={"target": "_blank"}) }}; {{ link(content="Intellectual property: registered designs 1839-1991 research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/registered-designs-1839-1991/", attrs={"target":"_blank"}) }} or {{ link(content="Intellectual property: trademarks 1876 -1938 research guide](https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/trade-marks/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/courts-and-tribunals/business-and-property-courts/business-list-general-chancery/intellectual-property-list/patents-court/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ewhc/scco.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewhc/scco.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older civil case records in the {{ link(content="Civil court cases: an overview research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/civil-court-cases-overview/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/courts-and-tribunals/high-court/the-senior-courts-costs-office/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ewhc/tcc.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ewhc/tcc.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older records in the {{ link(content="Civil court cases: King's/Queen's Bench 1702-1998 research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/court-of-kings-bench-plea-side-and-kings-queens-bench-division-cases-1702-1998/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ftt/claims.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ftt/claims.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    This is a historic tribunal. The functions of this tribunal have been transferred to the General Regulatory Chamber of the First-tier Tribunal. The GRC began transferring records to Find Case Law in 2022. To view an archived version of the decisions of this tribunal from 2009-2011 visit the {{ link(content="UK Government Web Archive", href="https://webarchive.nationalarchives.gov.uk/ukgwa/20200626120017/http://claimsmanagement.decisions.tribunals.gov.uk/", attrs={"target":"_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ label }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ftt/pc.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ftt/pc.jinja
@@ -1,6 +1,8 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/courts-and-tribunals/tribunals/first-tier-tribunal/property-chamber/land-registration-division/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +33,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ftt/phl.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ftt/phl.jinja
@@ -1,6 +1,8 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.judiciary.uk/courts-and-tribunals/tribunals/first-tier-tribunal/health-education-and-social-care-chamber/special-educational-needs-and-disability-care-standards-and-primary-health-lists-send/primary-health-lists/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +33,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ftt/transport.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ftt/transport.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    This is a historic tribunal. The functions of this tribunal have been transferred to the General Regulatory Chamber of the First-tier Tribunal in 2009. The GRC began transferring records to Find Case Law in 2022. To view an archived version of the decisions of this tribunal from 2000-2024 visit the {{ link(content="UK Government Web Archive", href="https://webarchive.nationalarchives.gov.uk/ukgwa/20241206055345/https://transportappeals.decisions.tribunals.gov.uk/Aspx/Default.aspx", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ label }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/paac.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/paac.jinja
@@ -1,6 +1,8 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/guidance/appeal-to-the-pathogens-access-appeals-commission", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +33,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/poac.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/poac.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    The POAC have transferred decisions to the National Archives and they should be available on the site soon. You can also see older decisions {{ link(content="here on the UK Government Web Archive", href="https://webarchive.nationalarchives.gov.uk/ukgwa/2026/https://siac.decisions.tribunals.gov.uk/", attrs={"target":"_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/guidance/appeal-against-a-ban-on-your-organisation", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/siac.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/siac.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    The SIAC have transferred decisions to the National Archives and they should be available on the site soon. You can also see older decisions {{ link(content="here on the UK Government Web Archive", href="https://webarchive.nationalarchives.gov.uk/ukgwa/2026/https://siac.decisions.tribunals.gov.uk/", attrs={"target":"_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/guidance/appeal-to-the-special-immigration-appeals-commission", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -34,11 +39,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
   {{ heading(content="Understanding " ~ court.name ~ " judgments", tag="h2", id="understanding-judgments") }}

--- a/ds_judgements_public_ui/templates/content/courts/ukftt.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ukftt.jinja
@@ -1,6 +1,8 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +33,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ukftt/credit.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ukftt/credit.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    This is a historic tribunal. The functions of this tribunal have been transferred to the General Regulatory Chamber of the First-tier Tribunal starting in 2009. The GRC began transferring records to Find Case Law in 2022. To view an archived version of the decisions of this tribunal from 2008-2009 visit the {{ link(content="UK Government Web Archive", href="https://webarchive.nationalarchives.gov.uk/ukgwa/20160811143635/http://www.consumercreditappeals.tribunals.gov.uk/decisions.htm", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ label }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ukftt/estate.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ukftt/estate.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    This is a historic tribunal. The functions of this tribunal have been transferred to the General Regulatory Chamber of the First-tier Tribunal starting in 2009. The GRC began transferring records to Find Case Law in 2022. To view an archived version of the decisions of this tribunal from 2008-2009 visit the {{ link(content="UK Government Web Archive", href="https://webarchive.nationalarchives.gov.uk/ukgwa/20160811143635/http://www.estateagentappeals.tribunals.gov.uk/decisions.htm", attrs={"target":"_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ label }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ukftt/grc.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ukftt/grc.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You may be able to find older General Regulatory Chamber decisions {{ link(content="on the Courts and Tribunals Judiciary website", href="https://www.judiciary.uk/courts-and-tribunals/tribunals/first-tier-tribunal/general-regulatory-chamber/general-regulatory-chamber-decisions/", attrs={"target":"_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/courts-tribunals/first-tier-tribunal-general-regulatory-chamber", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -37,11 +42,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
   {{ heading(content="Understanding " ~ court.name ~ " judgments", tag="h2", id="understanding-judgments") }}

--- a/ds_judgements_public_ui/templates/content/courts/ukftt/hesc.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ukftt/hesc.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    All decisions from this tribunal were transferred to the National Archives in 2025. To view an archived version of the decisions of this tribunal from 1985-2025 visit the {{ link(content="UK Government Web Archive", href="https://webarchive.nationalarchives.gov.uk/ukgwa/20250916/https://carestandards.decisions.tribunals.gov.uk/Public/search.aspx", attrs={"target":"_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/courts-tribunals/first-tier-tribunal-care-standards", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ukftt/tc.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ukftt/tc.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You may be able to find older Tax Chamber decisions {{ link(content="on the Courts and Tribunals Judiciary website", href="https://www.judiciary.uk/courts-and-tribunals/tribunals/first-tier-tribunal/first-tier-tribunal-tax-chamber/decisions-of-the-first-tier-tribunal-tax-chamber/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/courts-tribunals/first-tier-tribunal-tax", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -37,11 +42,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
   {{ heading(content="Understanding " ~ court.name ~ " judgments", tag="h2", id="understanding-judgments") }}

--- a/ds_judgements_public_ui/templates/content/courts/ukiptrib.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ukiptrib.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You may be able to find older Investigatory Powers Tribunal judgments starting in 2003 on the {{ link(content="Investigatory Powers Tribunal website", href="https://investigatorypowerstribunal.org.uk", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://investigatorypowerstribunal.org.uk/about-the-tribunal/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ukist.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ukist.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    This is a historic tribunal. The functions of this tribunal have been transferred to the General Regulatory Chamber of the First-tier Tribunal starting in 2009. The GRC began transferring records to Find Case Law in 2022. To view an archived version of the decisions of this tribunal from 2008-2009 visit the {{ link(content="UK Government Web Archive", href="https://webarchive.nationalarchives.gov.uk/ukgwa/20221201121350/https://immigrationservices.decisions.tribunals.gov.uk/Aspx/default.aspx", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ label }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ukpc.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ukpc.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You can read more about how to find older Privy Council and Judicial Committee of the Privy Council records held by The National Archives in the {{ link(content="Privy Council research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/privy-council-since-1386/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.jcpc.uk/about/role-of-the-jcpc.html", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/uksc.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/uksc.jinja
@@ -1,6 +1,8 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list, list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.supremecourt.uk/", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -37,11 +39,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
   {{ heading(content="Understanding " ~ court.name ~ " judgments", tag="h2", id="understanding-judgments") }}

--- a/ds_judgements_public_ui/templates/content/courts/ukut/aac.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ukut/aac.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You may be able to find older Administrative Appeals Chamber decisions on {{ link(content="the Courts and Tribunals Judiciary website", href="https://www.judiciary.uk/courts-and-tribunals/tribunals/upper-tribunal/upper-tribunal-administrative-appeals-chamber/administrative-appeals-chamber-decisions/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/courts-tribunals/upper-tribunal-administrative-appeals-chamber", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ukut/iac.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ukut/iac.jinja
@@ -1,6 +1,14 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You may be able to find older Immigration and Asylum Chamber decisions {{ link(content="on the Courts and Tribunals Judiciary website", href="https://www.judiciary.uk/courts-and-tribunals/tribunals/upper-tribunal/upper-tribunal-immigration-and-asylum-chamber/upper-tribunal-immigration-and-asylum-chamber-decisions/", attrs={"target": "_blank"}) }}.
+  </p>
+  <p>
+    You can read more about how to find older immigration records in The National Archives in the {{ link(content="Immigration and immigrants research guide", href="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides/immigration/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/courts-tribunals/upper-tribunal-immigration-and-asylum-chamber", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +39,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ukut/lc.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ukut/lc.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You may be able to find older Lands Chamber decisions {{ link(content="on the Courts and Tribunals Judiciary website", href="https://www.judiciary.uk/courts-and-tribunals/tribunals/upper-tribunal/upper-tribunal-lands-chamber/upper-tribunal-lands-chamber-decisions/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/courts-tribunals/upper-tribunal-lands-chamber", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/content/courts/ukut/tcc.jinja
+++ b/ds_judgements_public_ui/templates/content/courts/ukut/tcc.jinja
@@ -1,6 +1,11 @@
 {% from "components/link.jinja" import link %}
 {% from "components/list.jinja" import list_item %}
 {% from "components/heading.jinja" import heading %}
+{% macro historic_documents_content() %}
+  <p>
+    You may be able to find older Tax and Chancery Chamber decisions {{ link(content="on the Courts and Tribunals Judiciary website", href="https://www.judiciary.uk/courts-and-tribunals/tribunals/upper-tribunal/upper-tribunal-tax-and-chancery-chamber/tax-and-chancery-chamber-decisions/", attrs={"target": "_blank"}) }}.
+  </p>
+{% endmacro %}
 {% macro website_link(label=None) %}
   {{ link(content=label or (court.name ~ " website") , href="https://www.gov.uk/courts-tribunals/upper-tribunal-tax-and-chancery-chamber", attrs={"target": "_blank"}) }}
 {% endmacro %}
@@ -31,11 +36,7 @@
   <p>
     <strong>What’s included</strong> — We currently hold {{ court_documents_count }} documents from {{ court_date_range }}.
   </p>
-  {% if court.historic_documents_support_text_as_html %}
-    {% autoescape off %}
-      {{ court.historic_documents_support_text_as_html }}
-    {% endautoescape %}
-  {% endif %}
+  {{ historic_documents_content() }}
 {% endmacro %}
 {% macro understanding_content() %}
 {% endmacro %}

--- a/ds_judgements_public_ui/templates/includes/courts_and_tribunals_court.jinja
+++ b/ds_judgements_public_ui/templates/includes/courts_and_tribunals_court.jinja
@@ -2,7 +2,7 @@
 {% from "components/heading.jinja" import heading %}
 {% from "components/details.jinja" import details %}
 {% macro courts_and_tribunals_court(court=None, type=None, group=None) %}
-  {% from "content/courts/" ~ court.canonical_param ~ ".jinja" import description_content with context %}
+  {% from "content/courts/" ~ court.canonical_param ~ ".jinja" import historic_documents_content, description_content with context %}
   <div class="courts-and-tribunals__sub-item">
     {% if group.display_heading %}
       {% call heading(tag="h3", id=court.name|slugify) %}
@@ -27,11 +27,9 @@
         {% endcall %}
       {% endif %}
     </p>
-    {% if court.historic_documents_support_text_as_html %}
+    {% if historic_documents_content()|trim %}
       {% call details(title="Looking for older documents", variant="light") %}
-        {% autoescape off %}
-          {{ court.historic_documents_support_text_as_html }}
-        {% endautoescape %}
+        {{ historic_documents_content() }}
       {% endcall %}
     {% endif %}
   </div>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Migrates the historic documents content to this project as a jinja macro like the other court content

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-1955