### PR TITLE
FCLC-2009 | add explicit always check on e2e so the prerequisites mus…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,7 @@ jobs:
       - download-postgres
       - pytest
       - static-analysis
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code Repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 # v5.2.0
         with:
-          version: v29.5.3
+          version: v29.5.2
 
       - name: Copy .env.example file
         uses: canastro/copy-file-action@ae66602ce7d214dbd2e298c1db67a81388755a0a


### PR DESCRIPTION
## Changes in this PR:

## Jira card / Rollbar error (etc)

Explicitly make the e2e required to always run so github doesn't skip it if the prerequisites fail.

Once this is confirmed to be failing on CI I will fix the version issue on the postgres download step.

https://national-archives.atlassian.net/browse/FCLC-2009