### PR TITLE
Ensure docker doesn't expose ports externally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,8 @@ services:
       MAX_QUERY_WORDS: ${MAX_QUERY_WORDS:-5}
       WSGI_AUTH_EXCLUDE_PATHS: ${WSGI_AUTH_EXCLUDE_PATHS:-/check}
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
+      - "[::1]:3000:3000"
     command: tail -f /dev/null
 
   postgres:
@@ -54,7 +55,8 @@ services:
       timeout: 3s
       retries: 10
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
+      - "[::1]:5432:5432"
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-ds_judgements_public_ui}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}


### PR DESCRIPTION
https://docs.docker.com/engine/network/port-publishing/

> Publishing container ports is insecure by default. Meaning, when you publish a container's ports it becomes available not only to the Docker host, but to the outside world as well.
> If you include the localhost IP address (127.0.0.1, or ::1) with the publish flag, only the Docker host can access the published container port.
> `docker run -p 127.0.0.1:8080:80 -p '[::1]:8080:80' nginx`

A similar warning exists for [ports](https://docs.docker.com/reference/compose-file/services/#ports)
