### PR TITLE
FCLC-881 | remove the leading slash from the documents url

### DIFF
--- a/ds_judgements_public_ui/templates/pages/permissions_and_licensing/how_to_get_permission/apply_for_a_licence.jinja
+++ b/ds_judgements_public_ui/templates/pages/permissions_and_licensing/how_to_get_permission/apply_for_a_licence.jinja
@@ -109,7 +109,7 @@
   {% endcall %}
   <p>Download a full list of the 29 questions to prepare your answers before starting the application.</p>
   <p>
-    {% call link(href=static('/documents/Downloadable version of online application form.docx')) %}
+    {% call link(href=static('documents/Downloadable version of online application form.docx')) %}
       Download full list of 29 questions (Microsoft Word 34.1 kB)
     {% endcall %}
   </p>

--- a/ds_judgements_public_ui/templates/pages/permissions_and_licensing/when_you_need_permission/what_you_need_to_apply_for_a_licence.jinja
+++ b/ds_judgements_public_ui/templates/pages/permissions_and_licensing/when_you_need_permission/what_you_need_to_apply_for_a_licence.jinja
@@ -618,7 +618,7 @@
     To help you prepare, you can download a full list of the 29 questions we will ask you as a Microsoft Word document.
   </p>
   <p>
-    {% call link(href=static('/documents/Downloadable version of online application form.docx')) %}
+    {% call link(href=static('documents/Downloadable version of online application form.docx')) %}
       Download full list of 29 questions (Microsoft Word 34.1 kB)
     {% endcall %}
   </p>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Remove leading slash on document static urls.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-881
