### PR TITLE
FCLC-2022 | update mark styling

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_typography.scss
+++ b/ds_judgements_public_ui/sass/includes/_typography.scss
@@ -8,13 +8,13 @@ a {
 }
 
 code {
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 mark {
   scroll-margin-top: 50vh;
-  font-weight: $typography-bold-font-weight;
-  background: color-mix(in srgb, colour-var("accent-brand") 50%, transparent);
+  font-weight: $typography-normal-font-weight;
+  background: color-mix(in srgb, colour-var("accent-brand") 30%, transparent);
 
   &.current {
     background: colour-var("accent-brand");


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Updates the mark styling.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-2022

## Screenshots of UI changes:

### Before

<img width="1178" height="454" alt="image" src="https://github.com/user-attachments/assets/d9e1c384-5ae1-46da-a2ac-629d0fdd7a29" />


### After

<img width="1170" height="454" alt="image" src="https://github.com/user-attachments/assets/484c9ac7-3bd2-45f6-88dc-9c53cfbbec26" />


