### PR TITLE
FCLC-2024 | add hide highlights button

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_document_navigation_links.scss
+++ b/ds_judgements_public_ui/sass/includes/_document_navigation_links.scss
@@ -46,23 +46,21 @@
 }
 
 .document-navigation-links {
-  z-index: 2000;
-
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  grid-template-columns: 1fr 0 0 0 1fr;
-  grid-template-rows: 1fr;
-  gap: $spacer-unit $spacer-unit;
+  display: flex;
+  align-items: flex-end;
   justify-content: space-between;
 
   box-sizing: border-box;
-  width: 100%;
+  max-width: $grid-breakpoint-medium;
   margin: auto;
-  margin: 0;
   padding: $space-4;
-  padding: $spacer-unit;
-  border-bottom: 1px solid colour-var("font-base");
   border-bottom: none;
+
+  &--hide-matches {
+    mark {
+      background: colour-var("white");
+    }
+  }
 
   &__up-wrapper {
     grid-column: 1;
@@ -71,23 +69,28 @@
     white-space: nowrap;
 
     @media (max-width: $grid-breakpoint-medium) {
+      align-self: flex-start;
       text-align: left;
     }
   }
 
   &__down-wrapper {
-    grid-column: 5;
+    grid-column: 3;
     grid-row: 1;
     text-align: left;
     white-space: nowrap;
 
     @media (max-width: $grid-breakpoint-medium) {
+      align-self: flex-start;
       text-align: right;
     }
   }
 
   &.with-query {
-    grid-template-columns: 1fr 1fr auto 1fr 1fr;
+    display: grid;
+    grid-template-columns: 2fr 4fr 2fr;
+    grid-template-rows: auto auto;
+    column-gap: 0;
 
     .document-navigation-links__up-wrapper {
       text-align: left;
@@ -108,49 +111,49 @@
   }
 
   &__left-wrapper {
-    grid-column: 2;
-    grid-row: 1;
-    text-align: right;
+    grid-column: 1;
+    grid-row: 2;
     white-space: nowrap;
 
     @media (max-width: $grid-breakpoint-medium) {
-      grid-column: 1;
-      grid-row: 2;
       text-align: left;
     }
   }
 
   &__query-wrapper {
-    grid-column: 3;
-    grid-row: 1;
+    display: flex;
+    grid-column: 2;
+    grid-row: 1 / 3;
+    flex-direction: column;
+    gap: $space-2;
+    align-items: center;
+    align-self: end;
+    justify-content: center;
+
     text-align: center;
 
-    @media (max-width: $grid-breakpoint-medium) {
-      display: grid;
-      grid-column: 2;
-      grid-row: 1 / 3;
-      grid-template-columns: subgrid;
-      grid-template-rows: subgrid;
+    @media (min-width: $grid-breakpoint-medium) {
+      flex-direction: row;
+    }
+  }
 
-      .document-navigation-links__query {
-        grid-row: 2;
-      }
+  &__match-count-wrapper {
+    display: flex;
+    flex-direction: column;
 
-      .document-navigation-links__matches {
-        grid-row: 1;
-      }
+    @media (min-width: $grid-breakpoint-medium) {
+      flex-direction: row;
+      gap: $space-2;
     }
   }
 
   &__right-wrapper {
-    grid-column: 4;
-    grid-row: 1;
-    text-align: left;
+    grid-column: 3;
+    grid-row: 2;
+    text-align: right;
     white-space: nowrap;
 
     @media (max-width: $grid-breakpoint-medium) {
-      grid-column: 3;
-      grid-row: 2;
       text-align: right;
     }
   }
@@ -311,6 +314,10 @@
     border-bottom: 3px solid colour-var("accent-brand");
     font-weight: $typography-bold-font-weight;
     background-color: transparent;
+  }
+
+  @media (min-width: $grid-breakpoint-medium) {
+    gap: $spacer-unit $spacer-unit;
   }
 
   @media (max-width: $grid-breakpoint-medium) {

--- a/ds_judgements_public_ui/static/js/src/document_search_links/ui.js
+++ b/ds_judgements_public_ui/static/js/src/document_search_links/ui.js
@@ -1,3 +1,5 @@
+const HIDE_MATCHES_CLASS = "document-navigation-links--hide-matches";
+
 function createWrapper(className) {
     const span = document.createElement("span");
     span.className = className;
@@ -10,6 +12,41 @@ function createNavLink({ className, title, text }) {
     link.className = className;
     link.title = title;
     link.textContent = text;
+    return link;
+}
+
+function setHidden(elements, isHidden) {
+    elements.forEach((element) => {
+        if (element) {
+            element.hidden = isHidden;
+        }
+    });
+}
+
+function createHighlightsToggleLink(elementsToToggle) {
+    const link = createNavLink({
+        className: "document-navigation-links__highlights-toggle",
+        title: "Hide highlights",
+        text: "Hide highlights",
+    });
+
+    link.addEventListener("click", (event) => {
+        event.preventDefault();
+
+        const highlightsAreHidden =
+            document.body.classList.toggle(HIDE_MATCHES_CLASS);
+
+        setHidden(elementsToToggle, highlightsAreHidden);
+
+        link.textContent = highlightsAreHidden
+            ? "Show highlights"
+            : "Hide highlights";
+
+        link.title = highlightsAreHidden
+            ? "Show highlights"
+            : "Hide highlights";
+    });
+
     return link;
 }
 
@@ -30,43 +67,53 @@ function createQueryLabel(queryText) {
     return container;
 }
 
-function createMatchCountWrapper(totalMatches) {
+function createMatchCountWrapper(totalMatches, elementsToToggle) {
     const wrapper = createWrapper(
         "document-navigation-links__match-count-wrapper document-navigation-links__matches",
     );
 
-    const openParen = document.createTextNode(" (");
+    const matchCountContent = createWrapper(
+        "document-navigation-links__match-count-content",
+    );
 
     const positionSpan = document.createElement("span");
     positionSpan.className =
         "document-navigation-links__match-position position";
 
-    const ofText = document.createTextNode(" of ");
+    const ofText = document.createTextNode(" / ");
 
     const countSpan = document.createElement("span");
     countSpan.className =
         "document-navigation-links__match-count document-navigation-links__link-count";
     countSpan.textContent = String(totalMatches);
 
-    const matchesText = document.createTextNode(" matches)");
+    const separatorText = document.createTextNode(" ");
 
-    wrapper.appendChild(openParen);
-    wrapper.appendChild(positionSpan);
-    wrapper.appendChild(ofText);
-    wrapper.appendChild(countSpan);
-    wrapper.appendChild(matchesText);
+    matchCountContent.appendChild(positionSpan);
+    matchCountContent.appendChild(ofText);
+    matchCountContent.appendChild(countSpan);
+    matchCountContent.appendChild(separatorText);
+
+    elementsToToggle.push(matchCountContent);
+
+    wrapper.appendChild(matchCountContent);
+    wrapper.appendChild(createHighlightsToggleLink(elementsToToggle));
 
     return wrapper;
 }
 
-function createQueryWrapper(queryText, totalMatches) {
+function createQueryWrapper(queryText, totalMatches, elementsToToggle) {
     const wrapper = createWrapper("document-navigation-links__query-wrapper");
 
     if (queryText) {
-        wrapper.appendChild(createQueryLabel(queryText));
+        const queryLabel = createQueryLabel(queryText);
+        elementsToToggle.push(queryLabel);
+        wrapper.appendChild(queryLabel);
     }
 
-    wrapper.appendChild(createMatchCountWrapper(totalMatches));
+    wrapper.appendChild(
+        createMatchCountWrapper(totalMatches, elementsToToggle),
+    );
 
     return wrapper;
 }
@@ -78,6 +125,8 @@ export function createUI(linksEndContainer, totalMatches, queryText) {
         linksEndContainer.classList.add("with-query");
     }
 
+    const elementsToToggle = [];
+
     const leftWrapper = createWrapper(
         "document-navigation-links__left-wrapper",
     );
@@ -86,9 +135,8 @@ export function createUI(linksEndContainer, totalMatches, queryText) {
         title: "Previous match",
         text: "Previous",
     });
+    elementsToToggle.push(prevLink);
     leftWrapper.appendChild(prevLink);
-
-    const queryWrapper = createQueryWrapper(queryText, totalMatches);
 
     const rightWrapper = createWrapper(
         "document-navigation-links__right-wrapper",
@@ -98,7 +146,14 @@ export function createUI(linksEndContainer, totalMatches, queryText) {
         title: "Next match",
         text: "Next",
     });
+    elementsToToggle.push(nextLink);
     rightWrapper.appendChild(nextLink);
+
+    const queryWrapper = createQueryWrapper(
+        queryText,
+        totalMatches,
+        elementsToToggle,
+    );
 
     linksEndContainer.appendChild(leftWrapper);
     linksEndContainer.appendChild(queryWrapper);

--- a/ds_judgements_public_ui/static/js/tests/document_search_links/ui.test.js
+++ b/ds_judgements_public_ui/static/js/tests/document_search_links/ui.test.js
@@ -5,6 +5,7 @@ describe("createUI", () => {
     let linksEndContainer;
 
     beforeEach(() => {
+        document.body.className = "";
         document.body.innerHTML = `
             <div id="js-document-navigation-links-end"></div>
         `;
@@ -138,5 +139,111 @@ describe("createUI", () => {
         expect(positionSpan).not.toBeNull();
         expect(positionSpan).toBe(domPositionSpan);
         expect(positionSpan.textContent).toBe("");
+    });
+
+    it("creates a highlights toggle link with correct initial text and attributes", () => {
+        createUI(linksEndContainer, 5, "query");
+
+        const highlightsToggle = linksEndContainer.querySelector(
+            ".document-navigation-links__highlights-toggle",
+        );
+
+        expect(highlightsToggle).not.toBeNull();
+        expect(highlightsToggle.tagName).toBe("A");
+        expect(highlightsToggle.getAttribute("href")).toBe("#");
+        expect(highlightsToggle.textContent).toBe("Hide highlights");
+        expect(highlightsToggle.title).toBe("Hide highlights");
+    });
+
+    it("hides highlights-related UI and adds body class when highlights toggle is clicked", () => {
+        const { prevLink, nextLink } = createUI(linksEndContainer, 5, "query");
+
+        const highlightsToggle = linksEndContainer.querySelector(
+            ".document-navigation-links__highlights-toggle",
+        );
+        const queryLabelContainer = linksEndContainer.querySelector(
+            ".document-navigation-links__search-query-text-container.document-navigation-links__query",
+        );
+        const matchCountContent = linksEndContainer.querySelector(
+            ".document-navigation-links__match-count-content",
+        );
+
+        highlightsToggle.click();
+
+        expect(
+            document.body.classList.contains(
+                "document-navigation-links--hide-matches",
+            ),
+        ).toBe(true);
+
+        expect(prevLink.hidden).toBe(true);
+        expect(nextLink.hidden).toBe(true);
+        expect(queryLabelContainer.hidden).toBe(true);
+        expect(matchCountContent.hidden).toBe(true);
+
+        expect(highlightsToggle.hidden).toBe(false);
+        expect(highlightsToggle.textContent).toBe("Show highlights");
+        expect(highlightsToggle.title).toBe("Show highlights");
+    });
+
+    it("shows highlights-related UI and removes body class when highlights toggle is clicked twice", () => {
+        const { prevLink, nextLink } = createUI(linksEndContainer, 5, "query");
+
+        const highlightsToggle = linksEndContainer.querySelector(
+            ".document-navigation-links__highlights-toggle",
+        );
+        const queryLabelContainer = linksEndContainer.querySelector(
+            ".document-navigation-links__search-query-text-container.document-navigation-links__query",
+        );
+        const matchCountContent = linksEndContainer.querySelector(
+            ".document-navigation-links__match-count-content",
+        );
+
+        highlightsToggle.click();
+        highlightsToggle.click();
+
+        expect(
+            document.body.classList.contains(
+                "document-navigation-links--hide-matches",
+            ),
+        ).toBe(false);
+
+        expect(prevLink.hidden).toBe(false);
+        expect(nextLink.hidden).toBe(false);
+        expect(queryLabelContainer.hidden).toBe(false);
+        expect(matchCountContent.hidden).toBe(false);
+
+        expect(highlightsToggle.hidden).toBe(false);
+        expect(highlightsToggle.textContent).toBe("Hide highlights");
+        expect(highlightsToggle.title).toBe("Hide highlights");
+    });
+
+    it("toggles highlights correctly when queryText is empty", () => {
+        const { prevLink, nextLink } = createUI(linksEndContainer, 5, "");
+
+        const highlightsToggle = linksEndContainer.querySelector(
+            ".document-navigation-links__highlights-toggle",
+        );
+        const queryLabelContainer = linksEndContainer.querySelector(
+            ".document-navigation-links__search-query-text-container.document-navigation-links__query",
+        );
+        const matchCountContent = linksEndContainer.querySelector(
+            ".document-navigation-links__match-count-content",
+        );
+
+        expect(queryLabelContainer).toBeNull();
+
+        highlightsToggle.click();
+
+        expect(
+            document.body.classList.contains(
+                "document-navigation-links--hide-matches",
+            ),
+        ).toBe(true);
+
+        expect(prevLink.hidden).toBe(true);
+        expect(nextLink.hidden).toBe(true);
+        expect(matchCountContent.hidden).toBe(true);
+        expect(highlightsToggle.textContent).toBe("Show highlights");
     });
 });


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Updates the judgment toolbar with query and adds a "hide highlights" toggle.


## Jira card / Rollbar error (etc)

## Screenshots of UI changes:

Normal desktop

<img width="1440" height="362" alt="image" src="https://github.com/user-attachments/assets/c8d0fa0c-d9cc-4b7f-8ea8-dcabd3ae5c07" />

Normal mobile

<img width="375" height="333" alt="image" src="https://github.com/user-attachments/assets/8cbd9174-7ca2-4169-aed8-9b4dd8882efe" />

Query desktop

<img width="1425" height="404" alt="image" src="https://github.com/user-attachments/assets/9481713e-1a25-485b-bb73-bca77bde0197" />


Query mobile

<img width="377" height="379" alt="image" src="https://github.com/user-attachments/assets/f3f7b265-280b-47f8-b1c2-2ee19fd15f83" />

Query desktop hidden

<img width="1424" height="357" alt="image" src="https://github.com/user-attachments/assets/c144ca7e-e069-4a7f-a858-95f93b6c1f72" />

Query mobile hidden

<img width="377" height="421" alt="image" src="https://github.com/user-attachments/assets/7522a7f0-0aaa-4981-b993-91394f8605c2" />


- [ ] Requires env variable(s) to be updated
