### PR TITLE
Ensure Weasyprint PDFs have a proper slug as title

### DIFF
--- a/ds_judgements_public_ui/templates/pdf/document.jinja
+++ b/ds_judgements_public_ui/templates/pdf/document.jinja
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="robots" content="noindex,nofollow,noai" />
-    <title>{{ document.slug }}</title>
+    <title>{{ slug }}</title>
     {% block css %}
       <link href="{{ static('css/document_pdf.css') }}" rel="stylesheet" />
     {% endblock css %}

--- a/judgments/views/detail/generated_pdf.py
+++ b/judgments/views/detail/generated_pdf.py
@@ -30,6 +30,7 @@ class PdfDetailView(WeasyTemplateResponseMixin, TemplateView):
         self.pdf_filename = f"{filename}.pdf"
 
         context["document"] = document.content_as_html()
+        context["slug"] = document.slug
 
         return context
 


### PR DESCRIPTION
<img width="473" height="44" alt="image" src="https://github.com/user-attachments/assets/d4ee1b6e-8105-4893-bb2b-5ddc9867bbcb" />

(ones on the left are more recent)

https://national-archives.atlassian.net/browse/FCLC-1960

Testing this is a right pain: it should be possible to change [weasyprint's DEFAULT_OPTIONS](https://doc.courtbouillon.org/weasyprint/stable/api_reference.html#weasyprint.DEFAULT_OPTIONS) to decompress the PDF and read the text as ASCII but I don't have any joy doing that.