### PR TITLE
[FCLC-1393] Add option to filter Atom feed by minimum content availability

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -249,6 +249,12 @@ def _order_string_for_title(order: str) -> str:
 
 
 class SearchJudgmentsFeed(JudgmentsFeed):
+    _minimum_availability_to_only_with_html = {
+        "metadata": False,
+        "document": False,
+        "full-text": True,
+    }
+
     def link(self, obj):
         return obj["self_uri"]
 
@@ -302,9 +308,13 @@ class SearchJudgmentsFeed(JudgmentsFeed):
             search_parameters.order = "-date"
             search_parameters.page_size = per_page_integer
 
-        # for now we will filter out any records that don't have an HTML representation
-        # as we don't want to bloat the feed with records that don't have a HTML representation
-        search_parameters.only_with_html_representation = True
+        minimum_availability = request.GET.get("minimum_availability", default="full-text")
+        if minimum_availability not in self._minimum_availability_to_only_with_html:
+            raise BadRequest("minimum_availability should be one of metadata, document or full-text")
+
+        search_parameters.only_with_html_representation = self._minimum_availability_to_only_with_html[
+            minimum_availability
+        ]
 
         search_response = search_judgments_and_parse_response(api_client, search_parameters)
         return {

--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -283,3 +283,79 @@ class TestAtomFeed(TestCase):
 
         assert response.status_code == 200
         assert 'Latest documents for "obscure-search-query", sorted by relevance' in decoded_response
+
+    @patch("judgments.feeds.search_judgments_and_parse_response")
+    @patch("judgments.feeds.api_client")
+    def test_minimum_availability_metadata(self, mock_api_client, mock_search_judgments_and_parse_response):
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
+
+        self.client.get("/atom.xml?minimum_availability=metadata")
+
+        mock_search_judgments_and_parse_response.assert_called_with(
+            mock_api_client,
+            SearchParameters(
+                query="",
+                court="",
+                judge=None,
+                party=None,
+                date_from="1085-01-01",
+                date_to=None,
+                order="-date",
+                page=1,
+                page_size=50,
+                only_with_html_representation=False,
+            ),
+        )
+
+    @patch("judgments.feeds.search_judgments_and_parse_response")
+    @patch("judgments.feeds.api_client")
+    def test_minimum_availability_document(self, mock_api_client, mock_search_judgments_and_parse_response):
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
+
+        self.client.get("/atom.xml?minimum_availability=document")
+
+        mock_search_judgments_and_parse_response.assert_called_with(
+            mock_api_client,
+            SearchParameters(
+                query="",
+                court="",
+                judge=None,
+                party=None,
+                date_from="1085-01-01",
+                date_to=None,
+                order="-date",
+                page=1,
+                page_size=50,
+                only_with_html_representation=False,
+            ),
+        )
+
+    @patch("judgments.feeds.search_judgments_and_parse_response")
+    @patch("judgments.feeds.api_client")
+    def test_minimum_availability_full_text(self, mock_api_client, mock_search_judgments_and_parse_response):
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
+
+        self.client.get("/atom.xml?minimum_availability=full-text")
+
+        mock_search_judgments_and_parse_response.assert_called_with(
+            mock_api_client,
+            SearchParameters(
+                query="",
+                court="",
+                judge=None,
+                party=None,
+                date_from="1085-01-01",
+                date_to=None,
+                order="-date",
+                page=1,
+                page_size=50,
+                only_with_html_representation=True,
+            ),
+        )
+
+    @patch("judgments.feeds.search_judgments_and_parse_response")
+    def test_minimum_availability_bad_value(self, mock_search_judgments_and_parse_response):
+        response = self.client.get("/atom.xml?minimum_availability=invalid")
+
+        assert response.status_code == 400
+        mock_search_judgments_and_parse_response.assert_not_called()


### PR DESCRIPTION
Allow Atom feed users to get more than just documents with HTML. To keep backwards compatibility, we introduce a new `minimum_availability` parameter with three possible values:

- `metadata` which is a hypothetical future state where we _only_ possess metadata about a document (we have none of these, so this is functionally the same as `document` for the moment)
- `document` means that we have a representation of the document in some form (but this may only be PDF)
- `full-text` means that not only do we have a representation of the document, but we also have the full text as XML.

which defaults to `full-text`. This effectively allows users to 'opt in' to less detailed records.

## Jira

FCLC-1393