### PR TITLE
[FCLC-2148] Catch BadRequest in the Atom feed and return HTTP 400 to user without bubbling the exception

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -11,7 +11,7 @@ from caselawclient.search_parameters import SearchParameters
 from django.contrib.syndication.views import Feed
 from django.core.exceptions import BadRequest
 from django.http.request import HttpRequest
-from django.http.response import HttpResponseRedirect
+from django.http.response import HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.feedgenerator import Atom1Feed
@@ -211,7 +211,10 @@ class JudgmentsFeed(Feed):
         return extra_kwargs
 
     def __call__(self, request, *args, **kwargs):
-        response = super().__call__(request, *args, **kwargs)
+        try:
+            response = super().__call__(request, *args, **kwargs)
+        except BadRequest as exc:
+            return HttpResponseBadRequest(str(exc))
 
         # Inject our stylesheet at the top of the feed
         css = b'<?xml-stylesheet href="/static/atom.xsl" type="text/xsl" ?>\n'

--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -241,3 +241,10 @@ class TestAtomFeed(TestCase):
     def test_bad_tribunal(self):
         response = self.client.get("/atom.xml?tribunal=tennis")
         assert response.status_code == 400
+
+    @patch("judgments.feeds.search_judgments_and_parse_response")
+    def test_invalid_order_returns_400_without_raising(self, mock_search):
+        response = self.client.get("/atom.xml?order=modified")
+
+        assert response.status_code == 400
+        mock_search.assert_not_called()


### PR DESCRIPTION
## Changes in this PR:

Invalid query parameters on the Atom feed (e.g. unrecognised `court`, `tribunal`, or `order` values) were raising `django.core.exceptions.BadRequest`. That exception escaped the `Feed.__call__` wrapper and was recorded as an unhandled error in Rollbar, creating noise.

Fix: catch `BadRequest` in `JudgmentsFeed.__call__` and return `HttpResponseBadRequest` directly. The client still receives a 400, but no exception is raised so Rollbar stays quiet.

A regression test is added that calls the feed view directly with an invalid `order` parameter and asserts:
- the response status is 400
- the search back-end was not called

## Jira

FCLC-2148