### PR TITLE
[FCLC-2168] Move order parameter validation in Atom feed to use form validation

### DIFF
--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -230,6 +230,9 @@ def _courts_string_for_title(courts: list[str]) -> str:
 
 
 def _order_string_for_title(order: str) -> str:
+    if order == "relevance":
+        return ", sorted by relevance"
+
     if order[0] == "-":
         direction = "newest first"
         order = order[1:]
@@ -283,12 +286,9 @@ class SearchJudgmentsFeed(JudgmentsFeed):
         return urlunsplit((scheme, netloc, path, new_query, fragment))
 
     def get_object(self, request: HttpRequest) -> dict[str, Any]:
-        # Taken verbatim from judgments/views/advanced_search advanced_search()
-        order = request.GET.get("order", default=None)
-        if order not in [None, "-date", "date", "-transformation", "transformation", "updated", "-updated"]:
-            raise BadRequest(
-                "Sort order should be one of date, transformation or updated, or -date, -transformation or -updated"
-            )
+        # Treat missing and empty order the same so the feed keeps its -date default
+        # rather than falling through to relevance for text queries.
+        order = request.GET.get("order") or None
 
         per_page = request.GET.get("per_page", default="50")
         try:

--- a/judgments/forms/search_forms.py
+++ b/judgments/forms/search_forms.py
@@ -81,6 +81,16 @@ class CourtOrTribunalField(forms.MultipleChoiceField):
 
 
 class AdvancedSearchForm(forms.Form):
+    ORDER_CHOICES = [
+        ("relevance", "Most relevant"),
+        ("-date", "Newest"),
+        ("date", "Oldest"),
+        ("-transformation", "Recently modified"),
+        ("transformation", "Least recently modified"),
+        ("-updated", "Recently updated"),
+        ("updated", "Least recently updated"),
+    ]
+
     query = forms.CharField(
         required=False,
         widget=forms.TextInput(
@@ -138,6 +148,14 @@ class AdvancedSearchForm(forms.Form):
         required=False,
     )
 
+    order = forms.ChoiceField(
+        choices=ORDER_CHOICES,
+        required=False,
+        error_messages={
+            "invalid_choice": ("Sort order should be one of " + ", ".join(choice for choice, _label in ORDER_CHOICES)),
+        },
+    )
+
     def clean(self):
         cleaned_data = super().clean()
         # Validate that from is before to now that we have access to both fields
@@ -155,7 +173,7 @@ class AdvancedSearchForm(forms.Form):
         # Ignore warnings related to MyPy not understanding what cleaned_data is
         if cleaned_data.get("query"):
             cleaned_data["query"] = preprocess_query(cleaned_data.get("query", ""))
-        for parameter in ["query", "from_date", "to_date", "court", "tribunal", "party", "judge"]:
+        for parameter in ["query", "from_date", "to_date", "court", "tribunal", "party", "judge", "order"]:
             if cleaned_data.get(parameter, "Non-nilsy placeholder") in (None, "", []):
                 del cleaned_data[parameter]
         return cleaned_data

--- a/judgments/tests/test_atom_feed.py
+++ b/judgments/tests/test_atom_feed.py
@@ -247,4 +247,39 @@ class TestAtomFeed(TestCase):
         response = self.client.get("/atom.xml?order=modified")
 
         assert response.status_code == 400
+        assert b"Sort order should be one of relevance" in response.content
         mock_search.assert_not_called()
+
+    @patch("judgments.feeds.search_judgments_and_parse_response")
+    @patch("judgments.feeds.api_client")
+    def test_empty_order_falls_back_to_date(self, mock_api_client, mock_search):
+        mock_search.return_value = FakeSearchResponse()
+
+        response = self.client.get("/atom.xml?query=obscure-search-query&order=")
+
+        assert response.status_code == 200
+        mock_search.assert_called_with(
+            mock_api_client,
+            SearchParameters(
+                query="obscure-search-query",
+                court="",
+                judge=None,
+                party=None,
+                date_from="1085-01-01",
+                date_to=None,
+                order="-date",
+                page=1,
+                page_size=50,
+                only_with_html_representation=True,
+            ),
+        )
+
+    @patch("judgments.feeds.search_judgments_and_parse_response")
+    def test_relevance_order_in_title(self, mock_search):
+        mock_search.return_value = FakeSearchResponse()
+
+        response = self.client.get("/atom.xml?query=obscure-search-query&order=relevance")
+        decoded_response = response.content.decode("utf-8")
+
+        assert response.status_code == 200
+        assert 'Latest documents for "obscure-search-query", sorted by relevance' in decoded_response

--- a/judgments/tests/test_forms.py
+++ b/judgments/tests/test_forms.py
@@ -54,6 +54,38 @@ class TestAdvancedSearchForm(TestCase):
             {"from_date": [expected_warning], "to_date": [expected_warning]},
         )
 
+    def test_order_valid_choice_accepted(self):
+        form = AdvancedSearchForm(data={"order": "-date"})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["order"], "-date")
+
+    def test_order_invalid_choice_rejected(self):
+        form = AdvancedSearchForm(data={"order": "modified"})
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors,
+            {
+                "order": [
+                    "Sort order should be one of relevance, -date, date, "
+                    "-transformation, transformation, -updated, updated"
+                ]
+            },
+        )
+
+    def test_order_blank_treated_as_unset(self):
+        form = AdvancedSearchForm(data={"order": ""})
+
+        self.assertTrue(form.is_valid())
+        self.assertNotIn("order", form.cleaned_data)
+
+    def test_order_missing_treated_as_unset(self):
+        form = AdvancedSearchForm(data={})
+
+        self.assertTrue(form.is_valid())
+        self.assertNotIn("order", form.cleaned_data)
+
 
 class TestDateRangeInputField(TestCase):
     def test_compress_from_no_day(self):

--- a/judgments/utils/search_request_to_parameters.py
+++ b/judgments/utils/search_request_to_parameters.py
@@ -37,7 +37,7 @@ def search_request_to_parameters(request: HttpRequest) -> SearchParameters:
     query_params: dict = {}
     query_text: str = form.cleaned_data.get("query", "")
     page: int = clamp(sanitise_input_to_integer(params.get("page"), 1), minimum=1)
-    order = params.get("order", None)
+    order = form.cleaned_data.get("order")
     # If there is no query, order by -date, else order by relevance
     if not order and not query_text:
         order = "-date"


### PR DESCRIPTION
As part of trying to diagnose why ordering is being weird, reduce places where behaviours can be duplicated and potentially drift by moving validation of the `order` parameter into the search form handler.

## Jira

FCLC-2168