### PR TITLE
Improve our discovery surfaces for API documentation and Atom feed

### DIFF
--- a/config/middleware.py
+++ b/config/middleware.py
@@ -65,8 +65,12 @@ class LinkHeaderMiddleware:
 
         link_values = [self._serialise_link(link) for link in self._base_links()]
 
+        # Per-resource links set explicitly by the view on the response object.
+        # Works for any response type: HttpResponse, JsonResponse, TemplateResponse, etc.
+        link_values.extend(self._serialise_link(link) for link in getattr(response, "link_headers", []))
+
         if isinstance(response, TemplateResponse):
-            link_values.extend(self._serialise_link(link) for link in self._template_links(response))
+            link_values.extend(self._serialise_link(link) for link in self._context_links(response))
 
         existing_link_header = response.headers.get("Link")
         if existing_link_header:
@@ -86,7 +90,7 @@ class LinkHeaderMiddleware:
         ]
 
     @staticmethod
-    def _template_links(response: TemplateResponse) -> list[dict[str, str]]:
+    def _context_links(response: TemplateResponse) -> list[dict[str, str]]:
         links = list(response.context_data.get("links", []))
         links.extend(
             {

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlencode
 
-from django.http import HttpResponseRedirect
+from django.http.response import HttpResponseRedirectBase
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.cache import patch_cache_control
@@ -17,7 +17,7 @@ class RobotsTagMiddleware:
         response = self.get_response(request)
 
         # If the response is a redirect, short-circuit adding the X-Robots-Tag
-        if isinstance(response, HttpResponseRedirect):
+        if isinstance(response, HttpResponseRedirectBase):
             return response
 
         # If page_allow_index is True, short-circuit adding the X-Robots-Tag
@@ -48,6 +48,65 @@ class CacheHeaderMiddleware:
         # the view is called.
 
         return response
+
+
+class LinkHeaderMiddleware:
+    SITEMAP_TYPE = "application/xml"
+    API_CATALOG_TYPE = "application/linkset+json"
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        if isinstance(response, HttpResponseRedirectBase):
+            return response
+
+        link_values = [self._serialise_link(link) for link in self._base_links()]
+
+        if isinstance(response, TemplateResponse):
+            link_values.extend(self._serialise_link(link) for link in self._template_links(response))
+
+        existing_link_header = response.headers.get("Link")
+        if existing_link_header:
+            link_values.insert(0, existing_link_header)
+
+        response.headers["Link"] = ", ".join(link_values)
+        return response
+
+    def _base_links(self) -> list[dict[str, str]]:
+        return [
+            {"href": reverse("sitemap_index"), "rel": "sitemap", "type": self.SITEMAP_TYPE},
+            {
+                "href": reverse("api_catalog"),
+                "rel": "api-catalog",
+                "type": self.API_CATALOG_TYPE,
+            },
+        ]
+
+    @staticmethod
+    def _template_links(response: TemplateResponse) -> list[dict[str, str]]:
+        links = list(response.context_data.get("links", []))
+        links.extend(
+            {
+                "href": alternate["href"],
+                "rel": "alternate",
+                "type": alternate.get("type"),
+                "title": alternate.get("title"),
+            }
+            for alternate in response.context_data.get("alternates", [])
+        )
+        return links
+
+    @staticmethod
+    def _serialise_link(link: dict[str, str | None]) -> str:
+        segments = [f"<{link['href']}>", f'rel="{link["rel"]}"']
+        if link.get("type"):
+            segments.append(f'type="{link["type"]}"')
+        if link.get("title"):
+            segments.append(f'title="{link["title"]}"')
+        return "; ".join(segments)
 
 
 class FeedbackLinkMiddleware:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -126,6 +126,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "config.middleware.CacheHeaderMiddleware",
+    "config.middleware.LinkHeaderMiddleware",
     "config.middleware.RobotsTagMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -56,6 +56,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "config.middleware.CacheHeaderMiddleware",
+    "config.middleware.LinkHeaderMiddleware",
     "config.middleware.RobotsTagMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",

--- a/config/tests/test_api_catalog.py
+++ b/config/tests/test_api_catalog.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+
+
+class TestApiCatalog(TestCase):
+    def test_returns_linkset_json(self):
+        response = self.client.get("/.well-known/api-catalog")
+
+        assert response.status_code == 200
+        assert response["Content-Type"].startswith("application/linkset+json")
+
+    def test_includes_link_relations(self):
+        response = self.client.get("/.well-known/api-catalog")
+
+        body = response.json()
+        assert "linkset" in body
+        assert isinstance(body["linkset"], list)
+        assert len(body["linkset"]) == 1
+
+        entry = body["linkset"][0]
+
+        assert entry["anchor"] == "http://testserver/atom.xml"
+        assert entry["self"] == [{"href": "http://testserver/atom.xml", "title": "Atom feed"}]
+        assert entry["service-desc"] == [
+            {
+                "href": "https://raw.githubusercontent.com/nationalarchives/ds-find-caselaw-docs/refs/heads/main/doc/openapi/public_api.yml"
+            }
+        ]
+        assert entry["service-doc"] == [{"href": "https://nationalarchives.github.io/ds-find-caselaw-docs/public"}]
+        assert entry["license"] == [{"href": "http://testserver/open-justice-licence/version/2"}]
+        assert "status" not in entry

--- a/config/tests/test_api_catalog.py
+++ b/config/tests/test_api_catalog.py
@@ -7,6 +7,10 @@ class TestApiCatalog(TestCase):
 
         assert response.status_code == 200
         assert response["Content-Type"].startswith("application/linkset+json")
+        assert response.headers["Link"] == (
+            '</sitemap.xml>; rel="sitemap"; type="application/xml", '
+            '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"'
+        )
 
     def test_includes_link_relations(self):
         response = self.client.get("/.well-known/api-catalog")

--- a/config/tests/test_middleware.py
+++ b/config/tests/test_middleware.py
@@ -89,3 +89,21 @@ class TestLinkHeaderMiddleware(TestCase):
             response = LinkHeaderMiddleware(get_response)(request)
 
             assert "Link" not in response.headers
+
+    def test_response_link_headers_attribute_works_on_any_response_type(self):
+        request = self.request_factory.get("/ewca/civ/2024/1/data.xml")
+
+        def get_response(_request):
+            response = HttpResponse("<xml/>", content_type="application/xml")
+            response.link_headers = [
+                {"href": "/ewca/civ/2024/1", "rel": "alternate", "type": "text/html"},
+            ]
+            return response
+
+        response = LinkHeaderMiddleware(get_response)(request)
+
+        assert response.headers["Link"] == (
+            '</sitemap.xml>; rel="sitemap"; type="application/xml", '
+            '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", '
+            '</ewca/civ/2024/1>; rel="alternate"; type="text/html"'
+        )

--- a/config/tests/test_middleware.py
+++ b/config/tests/test_middleware.py
@@ -1,0 +1,91 @@
+from django.http import HttpResponse, HttpResponsePermanentRedirect, HttpResponseRedirect
+from django.template.response import TemplateResponse
+from django.test import RequestFactory, TestCase
+
+from config.middleware import LinkHeaderMiddleware
+
+
+class TestLinkHeaderMiddleware(TestCase):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+
+    def test_adds_sitewide_and_context_links(self):
+        request = self.request_factory.get("/")
+
+        def get_response(_request):
+            return TemplateResponse(
+                _request,
+                template="pages/home.jinja",
+                context={
+                    "links": [
+                        {
+                            "href": "/llms.txt",
+                            "rel": "describedby",
+                            "type": "text/markdown",
+                            "title": "Site index for LLMs",
+                        }
+                    ]
+                },
+            )
+
+        response = LinkHeaderMiddleware(get_response)(request)
+
+        assert response.headers["Link"] == (
+            '</sitemap.xml>; rel="sitemap"; type="application/xml", '
+            '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", '
+            '</llms.txt>; rel="describedby"; type="text/markdown"; title="Site index for LLMs"'
+        )
+
+    def test_translates_alternates_to_alternate_link_headers(self):
+        request = self.request_factory.get("/")
+
+        def get_response(_request):
+            return TemplateResponse(
+                _request,
+                template="pages/home.jinja",
+                context={
+                    "alternates": [
+                        {
+                            "href": "/atom.xml",
+                            "type": "application/atom+xml",
+                            "title": "Atom feed",
+                        }
+                    ]
+                },
+            )
+
+        response = LinkHeaderMiddleware(get_response)(request)
+
+        assert response.headers["Link"] == (
+            '</sitemap.xml>; rel="sitemap"; type="application/xml", '
+            '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", '
+            '</atom.xml>; rel="alternate"; type="application/atom+xml"; title="Atom feed"'
+        )
+
+    def test_leaves_non_template_responses_with_sitewide_links(self):
+        request = self.request_factory.get("/robots.txt")
+
+        def get_response(_request):
+            return HttpResponse("ok")
+
+        response = LinkHeaderMiddleware(get_response)(request)
+
+        assert response.headers["Link"] == (
+            '</sitemap.xml>; rel="sitemap"; type="application/xml", '
+            '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"'
+        )
+
+    def test_skips_temporary_and_permanent_redirects(self):
+        request = self.request_factory.get("/old-path")
+
+        for redirect_response in (
+            HttpResponseRedirect("/new-path"),
+            HttpResponsePermanentRedirect("/new-path"),
+        ):
+
+            def get_response(_request, response=redirect_response):
+                return response
+
+            response = LinkHeaderMiddleware(get_response)(request)
+
+            assert "Link" not in response.headers

--- a/config/urls.py
+++ b/config/urls.py
@@ -22,6 +22,7 @@ from judgments.views.search import (
 from .converters import SchemaFileConverter
 
 # from .views import static as static_views
+from .views.api_catalog import api_catalog
 from .views.check import status
 from .views.components import ComponentsView
 from .views.courts import (
@@ -74,6 +75,11 @@ non_public_urls = [
     path(
         ".well-known/trust.txt",
         RedirectView.as_view(url="/trust.txt"),
+    ),
+    path(
+        ".well-known/api-catalog",
+        api_catalog,
+        name="api_catalog",
     ),
     path(
         "favicon.ico",

--- a/config/views/api_catalog.py
+++ b/config/views/api_catalog.py
@@ -1,0 +1,28 @@
+import json
+
+from django.http import HttpResponse
+from django.urls import reverse
+
+SERVICE_DESC_URL = (
+    "https://raw.githubusercontent.com/nationalarchives/ds-find-caselaw-docs/refs/heads/main/doc/openapi/public_api.yml"
+)
+SERVICE_DOC_URL = "https://nationalarchives.github.io/ds-find-caselaw-docs/public"
+
+
+def api_catalog(request):
+    api_anchor = request.build_absolute_uri(reverse("search-feed"))
+    license_url = request.build_absolute_uri(reverse("open_justice_licence_v2"))
+
+    payload = {
+        "linkset": [
+            {
+                "anchor": api_anchor,
+                "self": [{"href": api_anchor, "title": "Atom feed"}],
+                "service-desc": [{"href": SERVICE_DESC_URL}],
+                "service-doc": [{"href": SERVICE_DOC_URL}],
+                "license": [{"href": license_url}],
+            }
+        ]
+    }
+
+    return HttpResponse(json.dumps(payload), content_type="application/linkset+json")

--- a/ds_judgements_public_ui/templates/includes/atom_feed_button.jinja
+++ b/ds_judgements_public_ui/templates/includes/atom_feed_button.jinja
@@ -1,7 +1,7 @@
 {% from "components/alert.jinja" import alert %}
 <div class="results__result-atom-feed-button-container">
   <div class="results__result-atom-feed-button">
-    <a href="{{ url('search-feed') }}?{{ query_param_string }}">
+    <a href="{{ atom_feed_url }}">
       <img src="{{ static('fontawesome-svgs/rss.svg') }}"
            width="20"
            height="20"

--- a/ds_judgements_public_ui/templates/layouts/base.jinja
+++ b/ds_judgements_public_ui/templates/layouts/base.jinja
@@ -42,6 +42,11 @@
       <link href="{{ static('css/main.css') }}" rel="stylesheet" />
     {% endblock css %}
     {% include "includes/gtm_head.jinja" %}
+    {% block extra_head_tags %}
+    {% endblock extra_head_tags %}
+    {% for alt in alternates|default([]) %}
+      <link rel="alternate" type="{{ alt.type }}" href="{{ alt.href }}" />
+    {% endfor %}
   </head>
   <body class="{% block body_class %}{% endblock body_class %}">
     <script>

--- a/ds_judgements_public_ui/templates/layouts/search_results.jinja
+++ b/ds_judgements_public_ui/templates/layouts/search_results.jinja
@@ -7,12 +7,6 @@
 {% block title %}
   Search results - Find Case Law
 {% endblock title %}
-{% block extra_head_tags %}
-  <link rel="alternate"
-        type="application/atom+xml"
-        title="{{ breadcrumbs.0.text }}"
-        href="{{ url('search-feed') }}?{{ query_param_string }}" />
-{% endblock extra_head_tags %}
 {% block javascript %}
   <script type="module" defer src="{{ static('js/dist/manage_filters.js')}}"></script>
 {% endblock javascript %}

--- a/judgments/tests/test_browse.py
+++ b/judgments/tests/test_browse.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from judgments.tests.fixture_data import (
     FakeSearchResponse,
 )
+from judgments.views.browse import BrowseView
 
 
 class TestBrowse(TestCase):
@@ -26,3 +27,15 @@ class TestBrowse(TestCase):
         self.assertContains(response, "Judgment v Judgement", html=True)
         self.assertContains(response, "/uksc/2025/1")
         self.assertNotContains(response, "d-123456789abcdef")
+
+    def test_atom_feed_url_uses_tribunal_param_for_nested_tribunal_codes(self):
+        view = BrowseView()
+
+        # Top-level tribunal code
+        assert view._build_atom_feed_url("eat", None) == "/atom.xml?tribunal=eat"
+        # Nested under a group heading (must not be misclassified as court)
+        assert view._build_atom_feed_url("ukut/iac", 2024) == (
+            "/atom.xml?tribunal=ukut%2Fiac&from_date_2=2024&to_date_2=2024"
+        )
+        # Court code still uses court param
+        assert view._build_atom_feed_url("ewhc/ch", None) == "/atom.xml?court=ewhc%2Fch"

--- a/judgments/tests/test_homepage.py
+++ b/judgments/tests/test_homepage.py
@@ -15,6 +15,12 @@ class TestHomepage(TestCase):
         mock_cached_recent_judgments.assert_called_once()
         self.assertContains(response, "Judgment v Judgement", html=True)
 
+        assert response.headers["Link"] == (
+            '</sitemap.xml>; rel="sitemap"; type="application/xml", '
+            '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", '
+            '</atom.xml>; rel="alternate"; type="application/atom+xml"'
+        )
+
     @patch("judgments.views.index.api_client")
     @patch("judgments.views.index.search_judgments_and_parse_response")
     def test_cached_recent_judgments(self, mock_search_judgments_and_parse_response, mock_api_client):

--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -465,6 +465,54 @@ class TestSearchBreadcrumbs(TestCase):
         assert response.context_data["breadcrumbs"] == [{"text": 'Search results for "waltham forest"'}]
 
 
+class TestSearchAtomFeedLink(TestCase):
+    @patch("judgments.views.search.results.api_client")
+    @patch("judgments.views.search.results.search_judgments_and_parse_response")
+    def test_search_results_alternates_context(self, mock_search_judgments_and_parse_response, mock_api_client):
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
+        response = self.client.get("/search?query=waltham+forest")
+
+        assert response.context_data is not None
+        assert response.context_data["atom_feed_url"] == "/atom.xml?query=waltham+forest"
+        assert "alternates" in response.context_data
+        alternates = response.context_data["alternates"]
+        assert len(alternates) == 1
+        assert alternates[0]["type"] == "application/atom+xml"
+        assert alternates[0]["href"] == response.context_data["atom_feed_url"]
+
+    @patch("judgments.views.search.results.api_client")
+    @patch("judgments.views.search.results.search_judgments_and_parse_response")
+    def test_search_results_announce_atom_feed(self, mock_search_judgments_and_parse_response, mock_api_client):
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
+        response = self.client.get("/search?query=waltham+forest")
+
+        assert_contains_html(
+            response,
+            """
+            <link rel="alternate"
+                  type="application/atom+xml"
+                  href="/atom.xml?query=waltham+forest" />
+            """,
+        )
+
+    @patch("judgments.views.search.results.api_client")
+    @patch("judgments.views.search.results.search_judgments_and_parse_response")
+    def test_search_results_without_query_announce_atom_feed(
+        self, mock_search_judgments_and_parse_response, mock_api_client
+    ):
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
+        response = self.client.get("/search")
+
+        assert_contains_html(
+            response,
+            """
+            <link rel="alternate"
+                  type="application/atom+xml"
+                  href="/atom.xml" />
+            """,
+        )
+
+
 class TestSearchFacets(TestCase):
     @patch("judgments.views.search.results.api_client")
     @patch("judgments.views.search.results.search_judgments_and_parse_response")

--- a/judgments/tests/test_search.py
+++ b/judgments/tests/test_search.py
@@ -42,6 +42,12 @@ class TestBrowseResults(TestCase):
         # search results reference the slug not the uri
         self.assertContains(response, "/uksc/2025/1")
         self.assertNotContains(response, "d-123456789abcdef")
+        assert response.headers["Link"] == (
+            '</sitemap.xml>; rel="sitemap"; type="application/xml", '
+            '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", '
+            "</atom.xml?court=ewhc%2Fch&from_date_2=2022&to_date_2=2022>; "
+            'rel="alternate"; type="application/atom+xml"'
+        )
 
 
 class TestNoNCN(TestCase):
@@ -494,6 +500,11 @@ class TestSearchAtomFeedLink(TestCase):
                   href="/atom.xml?query=waltham+forest" />
             """,
         )
+        assert response.headers["Link"] == (
+            '</sitemap.xml>; rel="sitemap"; type="application/xml", '
+            '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", '
+            '</atom.xml?query=waltham+forest>; rel="alternate"; type="application/atom+xml"'
+        )
 
     @patch("judgments.views.search.results.api_client")
     @patch("judgments.views.search.results.search_judgments_and_parse_response")
@@ -511,6 +522,34 @@ class TestSearchAtomFeedLink(TestCase):
                   href="/atom.xml" />
             """,
         )
+        assert response.headers["Link"] == (
+            '</sitemap.xml>; rel="sitemap"; type="application/xml", '
+            '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", '
+            '</atom.xml>; rel="alternate"; type="application/atom+xml"'
+        )
+
+    @patch("judgments.views.search.results.api_client")
+    @patch("judgments.views.search.results.search_judgments_and_parse_response")
+    def test_search_results_atom_feed_preserves_multipart_dates(
+        self, mock_search_judgments_and_parse_response, mock_api_client
+    ):
+        mock_search_judgments_and_parse_response.return_value = FakeSearchResponse()
+        response = self.client.get(
+            "/search?query=cheese&from_date_0=15&from_date_1=3&from_date_2=2010&to_date_2=2012&page=2"
+        )
+
+        assert response.context_data is not None
+        atom_feed_url = response.context_data["atom_feed_url"]
+        assert atom_feed_url.startswith("/atom.xml?")
+        assert "query=cheese" in atom_feed_url
+        assert "from_date_0=15" in atom_feed_url
+        assert "from_date_1=3" in atom_feed_url
+        assert "from_date_2=2010" in atom_feed_url
+        assert "to_date_2=2012" in atom_feed_url
+        assert "page=" not in atom_feed_url
+        # Must not serialise dates as single ISO params the feed cannot parse
+        assert "from_date=2010" not in atom_feed_url
+        assert "to_date=2012" not in atom_feed_url
 
 
 class TestSearchFacets(TestCase):

--- a/judgments/views/browse.py
+++ b/judgments/views/browse.py
@@ -1,5 +1,6 @@
 import datetime
 from typing import Union
+from urllib.parse import urlencode
 
 from caselawclient.Client import MarklogicResourceNotFoundError
 from caselawclient.client_helpers.search_helpers import (
@@ -7,10 +8,12 @@ from caselawclient.client_helpers.search_helpers import (
 )
 from caselawclient.search_parameters import RESULTS_PER_PAGE, SearchParameters
 from django.http import Http404
+from django.urls import reverse
 from django.views.generic.base import TemplateView
 from ds_caselaw_utils import courts as all_courts
 
 from judgments.forms import AdvancedSearchForm
+from judgments.forms.search_forms import TRIBUNAL_CHOICES
 from judgments.utils import MAX_RESULTS_PER_PAGE, api_client, clamp, paginator
 from judgments.utils.utils import sanitise_input_to_integer
 
@@ -18,6 +21,50 @@ from judgments.utils.utils import sanitise_input_to_integer
 class BrowseView(TemplateView):
     template_engine = "jinja"
     template_name = "judgment/results.jinja"
+
+    @staticmethod
+    def _is_tribunal(court_query: str) -> bool:
+        """Return True if court_query is a tribunal code in TRIBUNAL_CHOICES."""
+        for key, value in TRIBUNAL_CHOICES.items():
+            if isinstance(value, dict):
+                if court_query in value:
+                    return True
+            elif key == court_query:
+                return True
+        return False
+
+    def _build_atom_feed_url(self, court_query: str, year: Union[int, None]) -> str:
+        """
+        Build the Atom feed URL for browse results with court and year params.
+        Browse pages can have court (which may include subdivision) and year.
+        These map to feed params: court → court/tribunal, year → from_date_2/to_date_2.
+        Year-only multipart date params are used so AdvancedSearchForm can default
+        day/month (1 Jan / 31 Dec) when the Atom feed parses the URL.
+        """
+        params = {}
+        if court_query:
+            # TRIBUNAL_CHOICES nests some codes under group headings, so check nested
+            # values as well as top-level keys.
+            if self._is_tribunal(court_query):
+                params["tribunal"] = court_query
+            else:
+                params["court"] = court_query
+        if year:
+            params["from_date_2"] = str(year)
+            params["to_date_2"] = str(year)
+
+        query_string = urlencode(params, doseq=True) if params else ""
+        feed_path = reverse("search-feed")
+        return f"{feed_path}?{query_string}" if query_string else feed_path
+
+    def _build_alternates(self, atom_feed_url: str) -> list:
+        """Build alternates list with single Atom feed entry."""
+        return [
+            {
+                "type": "application/atom+xml",
+                "href": atom_feed_url,
+            }
+        ]
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -56,6 +103,11 @@ class BrowseView(TemplateView):
             context["courts"] = all_courts.get_grouped_selectable_courts()
             context["tribunals"] = all_courts.get_grouped_selectable_tribunals()
             context["page_title"] = "Search results"
+
+            # Build feed URL and alternates for this browse view
+            atom_feed_url = self._build_atom_feed_url(court_query, year)
+            context["atom_feed_url"] = atom_feed_url
+            context["alternates"] = self._build_alternates(atom_feed_url)
 
         except MarklogicResourceNotFoundError:
             raise Http404("Search failed")  # TODO: This should be something else!

--- a/judgments/views/index.py
+++ b/judgments/views/index.py
@@ -37,6 +37,12 @@ class IndexView(TemplateView):
         context["feedback_survey_type"] = "home"
         context["active_navigation_endpoint"] = "home"
         context["form"] = AdvancedSearchForm()
+        context["alternates"] = [
+            {
+                "type": "application/atom+xml",
+                "href": reverse("search-feed"),
+            }
+        ]
 
         try:
             response = cached_recent_judgments(ttl_hash=round(time() / 900))

--- a/judgments/views/search/results.py
+++ b/judgments/views/search/results.py
@@ -13,6 +13,7 @@ from django.http import (
     HttpResponse,
 )
 from django.template.response import TemplateResponse
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from requests.exceptions import RequestException
@@ -78,6 +79,13 @@ class SearchResultsView(TemplateViewWithContext):
             warning,
             changed_queries,
         ) = self._process_facets_and_warnings(request, form, search_parameters, search_response)
+        query_param_string = urllib.parse.urlencode(form.cleaned_data, doseq=True)
+        # Build the Atom feed from the original request params (minus page) so
+        # multipart date fields (from_date_0/1/2, to_date_0/1/2) are preserved.
+        # urlencoding cleaned_data would serialise dates as from_date/to_date ISO
+        # values, which AdvancedSearchForm ignores on the feed endpoint.
+        atom_feed_query = urllib.parse.urlencode(changed_queries, doseq=True)
+        atom_feed_url = self._build_atom_feed_url(atom_feed_query)
 
         context.update(
             {
@@ -100,9 +108,11 @@ class SearchResultsView(TemplateViewWithContext):
                     search_response.results, search_parameters.query or "", search_parameters.page
                 ),
                 "query_params": query_params,
-                "query_param_string": urllib.parse.urlencode(form.cleaned_data, doseq=True),
+                "query_param_string": query_param_string,
+                "atom_feed_url": atom_feed_url,
                 "breadcrumbs_variant": "accent",
                 "breadcrumbs": self._build_breadcrumbs(search_parameters),
+                "alternates": self._build_alternates(atom_feed_url),
                 "active_navigation_endpoint": "search_and_browse",
             }
         )
@@ -182,6 +192,19 @@ class SearchResultsView(TemplateViewWithContext):
             return [{"text": f'Search results for "{search_parameters.query}"'}]
         else:
             return [{"text": "Search results"}]
+
+    def _build_atom_feed_url(self, query_param_string):
+        feed_path = reverse("search-feed")
+        return f"{feed_path}?{query_param_string}" if query_param_string else feed_path
+
+    def _build_alternates(self, atom_feed_url):
+        """Build array of alternate link formats (e.g., atom feed)."""
+        return [
+            {
+                "type": "application/atom+xml",
+                "href": atom_feed_url,
+            }
+        ]
 
     def _do_dates_require_warnings(
         self, iso_date: Optional[str], total_results: int, min_actual_year: Optional[int]


### PR DESCRIPTION
We were missing some generally accepted surfaces which allow tools (including AI tools, but also things like API navigators and feed readers) to better understand the scope of our service and how to interact with them. This PR:

- Adds [/.well-known/api-catalog](https://specification.website/spec/well-known/api-catalog/), which explicitly links to our API endpoint, documentation, and licensing
- Fixes where we weren't advertising `rel="alternative"` links to Atom feeds on the home page, browse pages and search results, allowing browsers and feed readers to automatically spot these feeds
- Adds `Link` headers to all HTTP responses advertising the two above, meaning full HTML parsing isn't needed to discover these resources