### PR TITLE
FCLC-2172 | handle no documents returned for court count

### DIFF
--- a/config/tests/test_courts_view.py
+++ b/config/tests/test_courts_view.py
@@ -1,7 +1,33 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.test import TestCase
 from ds_caselaw_utils.courts import CourtNotFoundException
+
+from config.views.courts import CourtsTribunalsListView
+from judgments.models.court_dates import CourtDates
+
+
+class TestCourtsTribunalsListView(TestCase):
+    def test_decorate_court_group_adds_dates_and_document_counts(self):
+        CourtDates.objects.create(param="court-with-data", start_year=2020, end_year=2024)
+
+        court_with_data = SimpleNamespace(canonical_param="court-with-data", start_year=None, end_year=None)
+        court_without_data = SimpleNamespace(canonical_param="court-without-data", start_year=1999, end_year=2001)
+        group = SimpleNamespace(courts=[court_with_data, court_without_data])
+
+        decorated_group = CourtsTribunalsListView().decorate_court_group(
+            group,
+            {"court-with-data": 123},
+        )
+
+        assert decorated_group == group
+        assert court_with_data.start_year == 2020
+        assert court_with_data.end_year == 2024
+        assert court_with_data.documents_count == 123
+        assert court_without_data.start_year == 1999
+        assert court_without_data.end_year == 2001
+        assert court_without_data.documents_count == 0
 
 
 class TestCourtOrTribunalView(TestCase):

--- a/config/views/courts.py
+++ b/config/views/courts.py
@@ -44,6 +44,8 @@ class CourtsTribunalsListView(TemplateViewWithContext):
 
             if documents_count:
                 court.documents_count = documents_count
+            else:
+                court.documents_count = 0
 
             if dates:
                 court.start_year = dates.start_year


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Handles when there are no documents properly, and added a test to cover the decorate courts function.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-2177
