### PR TITLE
Widen coverage configuration beyond judgments

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,18 @@
 [run]
 branch = True
-include = judgments/**/*.py, judgments/*.py
+include =
+    judgments/*
+    judgments/**/*
+    config/*
+    config/**/*
+    transactional_licence_form/*
+    transactional_licence_form/**/*
+omit =
+    **/migrations/**
+    **/__init__.py
 
 [report]
 omit =
-    *__init__*
+    **/migrations/**
+    **/__init__.py
     ds_judgements_public_ui/templates/content/**/*.jinja

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,3 @@ django_settings_module = config.settings.test
 [mypy-*.migrations.*]
 # Django migrations should not produce any errors:
 ignore_errors = True
-
-[coverage:run]
-include = ds_judgements_public_ui/*
-omit = *migrations*, *tests*
-plugins =
-    django_coverage_plugin


### PR DESCRIPTION
- Remove the unused `[coverage:run]` block from `setup.cfg` (it conflicted with `.coveragerc` and targeted a different include path)
- Widen `.coveragerc` to cover `judgments`, `config`, and `transactional_licence_form` (still omitting migrations / `__init__`)

## Followup

mypy has a similar scoping problem, but that will likely come with actual typing warnings and be less of a quick fix.