### PR TITLE
Widen mypy to config and transactional licence form

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
         run: docker network create caselaw
 
       - name: Run mypy
-        run: docker compose run django mypy ds_judgements_public_ui judgments
+        run: docker compose run django mypy ds_judgements_public_ui judgments config transactional_licence_form
 
   pytest:
     needs:

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -1,9 +1,18 @@
+from typing import TypedDict
 from urllib.parse import urlencode
 
 from django.http.response import HttpResponseRedirectBase
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.cache import patch_cache_control
+from typing_extensions import NotRequired
+
+
+class _LinkHeader(TypedDict):
+    href: str
+    rel: str
+    type: NotRequired[str]
+    title: NotRequired[str]
 
 
 class RobotsTagMiddleware:
@@ -21,7 +30,8 @@ class RobotsTagMiddleware:
             return response
 
         # If page_allow_index is True, short-circuit adding the X-Robots-Tag
-        if isinstance(response, TemplateResponse) and response.context_data.get("page_allow_index", False):
+        context_data = response.context_data if isinstance(response, TemplateResponse) else None
+        if context_data and context_data.get("page_allow_index", False):
             return response
 
         # In all other cases, assume we don't want it indexing and add the noindex X-Robots-Tag.
@@ -79,7 +89,7 @@ class LinkHeaderMiddleware:
         response.headers["Link"] = ", ".join(link_values)
         return response
 
-    def _base_links(self) -> list[dict[str, str]]:
+    def _base_links(self) -> list[_LinkHeader]:
         return [
             {"href": reverse("sitemap_index"), "rel": "sitemap", "type": self.SITEMAP_TYPE},
             {
@@ -90,21 +100,20 @@ class LinkHeaderMiddleware:
         ]
 
     @staticmethod
-    def _context_links(response: TemplateResponse) -> list[dict[str, str]]:
-        links = list(response.context_data.get("links", []))
-        links.extend(
-            {
-                "href": alternate["href"],
-                "rel": "alternate",
-                "type": alternate.get("type"),
-                "title": alternate.get("title"),
-            }
-            for alternate in response.context_data.get("alternates", [])
-        )
+    def _context_links(response: TemplateResponse) -> list[_LinkHeader]:
+        context_data = response.context_data or {}
+        links: list[_LinkHeader] = list(context_data.get("links", []))
+        for alternate in context_data.get("alternates", []):
+            link: _LinkHeader = {"href": alternate["href"], "rel": "alternate"}
+            if alternate.get("type"):
+                link["type"] = alternate["type"]
+            if alternate.get("title"):
+                link["title"] = alternate["title"]
+            links.append(link)
         return links
 
     @staticmethod
-    def _serialise_link(link: dict[str, str | None]) -> str:
+    def _serialise_link(link: _LinkHeader) -> str:
         segments = [f"<{link['href']}>", f'rel="{link["rel"]}"']
         if link.get("type"):
             segments.append(f'type="{link["type"]}"')

--- a/config/tests/test_courts_view.py
+++ b/config/tests/test_courts_view.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from django.template.response import TemplateResponse
 from django.test import RequestFactory, TestCase
 from ds_caselaw_utils.courts import CourtNotFoundException
 
@@ -49,6 +50,8 @@ class TestCourtOrTribunalView(TestCase):
 
         response = CourtOrTribunalView.as_view()(request, param="eat")
 
+        assert isinstance(response, TemplateResponse)
+        assert response.context_data is not None
         assert response.context_data["gtm_data_layer"] == {
             "page_type": "court",
             "court_code": "EAT",

--- a/config/tests/test_middleware.py
+++ b/config/tests/test_middleware.py
@@ -95,7 +95,7 @@ class TestLinkHeaderMiddleware(TestCase):
 
         def get_response(_request):
             response = HttpResponse("<xml/>", content_type="application/xml")
-            response.link_headers = [
+            response.link_headers = [  # type: ignore[attr-defined]
                 {"href": "/ewca/civ/2024/1", "rel": "alternate", "type": "text/html"},
             ]
             return response

--- a/config/tests/test_schema.py
+++ b/config/tests/test_schema.py
@@ -2,12 +2,12 @@ from unittest.mock import patch
 
 import pytest
 from django.http import Http404
+from django.test import TestCase
 
 from config.views.schema import schema
-from judgments.tests.fixtures import TestCaseWithMockAPI
 
 
-class TestSchemas(TestCaseWithMockAPI):
+class TestSchemas(TestCase):
     @patch("config.views.schema.requests.get")
     def test_cached(self, get):
         # Tests caching behaviour; happy path

--- a/config/vcr_config.py
+++ b/config/vcr_config.py
@@ -251,7 +251,8 @@ def _extract_all_parts_from_multipart(raw_body: str | bytes, content_type: str) 
 
         if part_ct == "application/json" and payload:
             try:
-                payload = json.dumps(json.loads(payload.decode("utf-8"))).encode("utf-8")
+                if isinstance(payload, bytes):
+                    payload = json.dumps(json.loads(payload.decode("utf-8"))).encode("utf-8")
             except (json.JSONDecodeError, UnicodeDecodeError) as exc:
                 logging.debug("Failed to parse json part: %s", exc)
 
@@ -359,8 +360,12 @@ class VCRContext:
         return cls(cassette_name_for_request(method, path, query_string))
 
     def __enter__(self):
-        self.cassette = self.vcr.use_cassette(f"{self.cassette_name}.yaml", allow_playback_repeats=True)
-        return self.cassette.__enter__()
+        cassette = self.vcr.use_cassette(f"{self.cassette_name}.yaml", allow_playback_repeats=True)
+        self.cassette = cassette
+        return cassette.__enter__()
 
     def __exit__(self, *args):
-        return self.cassette.__exit__(*args)
+        cassette = self.cassette
+        if cassette is None:
+            raise RuntimeError("VCRContext.__exit__ called before __enter__")
+        return cassette.__exit__(*args)

--- a/config/views/courts.py
+++ b/config/views/courts.py
@@ -87,10 +87,6 @@ class CourtOrTribunalView(TemplateViewWithContext):
     template_name = "pages/court_or_tribunal.jinja"
     page_allow_index = True
 
-    @property
-    def page_title(self):
-        return self.court.name
-
     @cached_property
     def court(self):
         try:
@@ -109,6 +105,7 @@ class CourtOrTribunalView(TemplateViewWithContext):
     def get_context_data(self, **kwargs):
 
         court = self.court
+        self.page_title = court.name
 
         context = super().get_context_data(**kwargs)
 

--- a/config/views/errors.py
+++ b/config/views/errors.py
@@ -1,9 +1,11 @@
+from typing import Optional
+
 from django.views.generic import TemplateView
 
 
 class BaseErrorView(TemplateView):
-    template_name = None
-    template_engine = None
+    template_name: Optional[str] = None
+    template_engine: Optional[str] = None
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/storybook/render_jinja_core.py
+++ b/storybook/render_jinja_core.py
@@ -103,6 +103,7 @@ if __name__ == "__main__":
             key, value = arg.split("=", 1)
             stripped_value = value.strip('"').strip("'")
 
+            final_value: bool | int | str
             if stripped_value.lower() == "true":
                 final_value = True
             elif stripped_value.lower() == "false":

--- a/transactional_licence_form/fields.py
+++ b/transactional_licence_form/fields.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 from django import forms
 from django.template import engines
 
@@ -45,7 +47,10 @@ class FCLCheckboxWidgetWithOthers(forms.MultiWidget):
 
         self.choice_widget = forms.CheckboxSelectMultiple(attrs)
         widgets = {**{"choices": self.choice_widget}, **other_widgets}
-        super(FCLCheckboxWidgetWithOthers, self).__init__(widgets, attrs)
+        super(FCLCheckboxWidgetWithOthers, self).__init__(
+            cast(dict[str, forms.Widget | type[forms.Widget]], widgets),
+            attrs,
+        )
 
     def get_context(self, name, value, attrs):
         context = super(FCLCheckboxWidgetWithOthers, self).get_context(name, value, attrs)
@@ -63,7 +68,7 @@ class FCLCheckboxWidgetWithOthers(forms.MultiWidget):
         if value is None:
             value = {}
         choices = value.get("choices", [])
-        others = []
+        others: list[Any] = []
         for field in self.other_fields.values():
             others.insert(field["field_index"], value.get(field["name"], None))
         return [choices] + others

--- a/transactional_licence_form/forms.py
+++ b/transactional_licence_form/forms.py
@@ -33,6 +33,7 @@ class LicenseApplicationForm(FCLForm):
         "10 – Additional comments",
         "11 – Review your answers",
     ]
+    step_index: int
 
     @property
     def navigation_done(self):

--- a/transactional_licence_form/views.py
+++ b/transactional_licence_form/views.py
@@ -89,7 +89,7 @@ class FormWizardView(NamedUrlSessionWizardView):
         )
 
     def get_all_cleaned_data_by_form(self):
-        cleaned_data = {}
+        cleaned_data: dict[str, dict] = {}
         for form_key in self.get_form_list():
             cleaned_data[form_key] = {}
             form_obj = self.get_form_object(form_key)


### PR DESCRIPTION
- Expand CI mypy to also check `config` and `transactional_licence_form`
- Fix the typing issues that blocked that (middleware optional context, error view attrs, VCR payload/cassette typing, licence form annotations, court `page_title` override, etc.)
- Small follow-on fix in `storybook/render_jinja_core.py` pulled in via imports