### PR TITLE
FCLC-2203 | add apply for licence links to appropriate pages

### DIFF
--- a/ds_judgements_public_ui/templates/pages/permissions_and_licensing.jinja
+++ b/ds_judgements_public_ui/templates/pages/permissions_and_licensing.jinja
@@ -68,7 +68,7 @@
     . This includes commercial use such as incorporating judgments into products or applications.
   </p>
   <p>
-    However, if you want to perform computational analysis, you need to apply for a separate licence. Computational analysis includes any programmatic searching in bulk across Find Case Law records to identify, extract or enrich contents within the records.
+    However, if you want to perform computational analysis, you need to {{ link(content="apply for a separate licence", href=url("apply_for_a_licence") ) }}. Computational analysis includes any programmatic searching in bulk across Find Case Law records to identify, extract or enrich contents within the records.
   </p>
   <p>Here's what you can do freely, when you need permission and how to apply.</p>
   {% call heading(tag="h2") %}
@@ -102,7 +102,7 @@
     When you need permission
   {% endcall %}
   <p>
-    You need to apply for a licence if you want to perform computational analysis. You can read a more detailed description of computational analysis in our glossary.
+    You need to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }} if you want to perform computational analysis. You can read a more detailed description of computational analysis in our glossary.
   </p>
   <p>
     When you need permission explains what counts as computational analysis and whether your intended use requires a licence.
@@ -141,7 +141,7 @@
       timelines and what to expect
     {% endcall %}
   {% endcall %}
-  <p>There are no costs to apply for a licence to perform computational analysis.</p>
+  <p>There are no costs to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }} to perform computational analysis.</p>
   {% call heading(tag="h2") %}
     Legal framework
   {% endcall %}

--- a/ds_judgements_public_ui/templates/pages/permissions_and_licensing/how_to_get_permission.jinja
+++ b/ds_judgements_public_ui/templates/pages/permissions_and_licensing/how_to_get_permission.jinja
@@ -9,7 +9,7 @@
     How to get permission
   {% endcall %}
   <p>
-    If you need to perform computational analysis on Find Case Law records, you'll need to apply for a licence. Here's an overview of the process.
+    If you need to perform computational analysis on Find Case Law records, you'll need to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }}. Here's an overview of the process.
   </p>
 {% endblock mobile_article_title %}
 {% block desktop_article_title %}
@@ -17,7 +17,7 @@
     How to get permission
   {% endcall %}
   <p>
-    If you need to perform computational analysis on Find Case Law records, you'll need to apply for a licence. Here's an overview of the process.
+    If you need to perform computational analysis on Find Case Law records, you'll need to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }}. Here's an overview of the process.
   </p>
 {% endblock desktop_article_title %}
 {% block article_navigation %}

--- a/ds_judgements_public_ui/templates/pages/permissions_and_licensing/how_to_get_permission/licence_application_process.jinja
+++ b/ds_judgements_public_ui/templates/pages/permissions_and_licensing/how_to_get_permission/licence_application_process.jinja
@@ -9,7 +9,7 @@
     Licence application process
   {% endcall %}
   <p>
-    If you want to perform computational analysis on Find Case Law records, you need to apply for a licence. Here's how applications are assessed and approved.
+    If you want to perform computational analysis on Find Case Law records, you need to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }}. Here's how applications are assessed and approved.
   </p>
 {% endblock mobile_article_title %}
 {% block desktop_article_title %}
@@ -17,7 +17,7 @@
     Licence application process
   {% endcall %}
   <p>
-    If you want to perform computational analysis on Find Case Law records, you need to apply for a licence. Here's how applications are assessed and approved.
+    If you want to perform computational analysis on Find Case Law records, you need to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }}. Here's how applications are assessed and approved.
   </p>
 {% endblock desktop_article_title %}
 {% block article_navigation %}
@@ -73,14 +73,14 @@
   <p>
     Records published on the Find Case Law service are available for re-use under the terms of the Open Justice Licence. You do not need to apply if your re-use complies with these terms.
   </p>
-  <p>However, if you want to perform computational analysis, you will need to apply for an additional licence.</p>
+  <p>However, if you want to perform computational analysis, you will need to {{ link(content="apply for an additional licence", href=url("apply_for_a_licence") ) }}.</p>
   <p>
     Computational analysis includes activities such as any programmatic searching in bulk across the Find Case Law records to identify, extract or enrich contents within the records.
   </p>
   {% call heading(tag="h2") %}
     No costs to apply
   {% endcall %}
-  <p>There are no costs to apply for a licence to perform computational analysis.</p>
+  <p>There are no costs to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }} to perform computational analysis.</p>
   {% call heading(tag="h2") %}
     How applications are assessed
   {% endcall %}

--- a/ds_judgements_public_ui/templates/pages/permissions_and_licensing/what_you_can_do_freely.jinja
+++ b/ds_judgements_public_ui/templates/pages/permissions_and_licensing/what_you_can_do_freely.jinja
@@ -109,7 +109,7 @@
   {% endcall %}
   <p>The Open Justice Licence does not permit computational analysis.</p>
   <p>
-    If you intend to do any programmatic searching in bulk across Find Case Law records to identify, extract or enrich contents within the records, you will need to apply for a licence to perform computational analysis.
+    If you intend to do any programmatic searching in bulk across Find Case Law records to identify, extract or enrich contents within the records, you will need to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }} to perform computational analysis.
   </p>
   <p>
     Visit

--- a/ds_judgements_public_ui/templates/pages/permissions_and_licensing/when_you_need_permission.jinja
+++ b/ds_judgements_public_ui/templates/pages/permissions_and_licensing/when_you_need_permission.jinja
@@ -42,7 +42,7 @@
 {% endblock article_navigation %}
 {% block article_content %}
   <p>
-    Most uses of Find Case Law judgments are free under the Open Justice Licence, including commercial use. However, if you want to perform computational analysis, you need to apply for a licence.
+    Most uses of Find Case Law judgments are free under the Open Justice Licence, including commercial use. However, if you want to perform computational analysis, you need to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }}.
   </p>
   {% call heading(tag="h2") %}
     Understanding computational analysis
@@ -115,7 +115,7 @@
   {% call heading(tag="h2") %}
     No costs to apply
   {% endcall %}
-  <p>There are no costs to apply for a licence to perform computational analysis.</p>
+  <p>There are no costs to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }} to perform computational analysis.</p>
   {% call card(title="How to apply", title_tag="h2") %}
     <p>
       Visit

--- a/ds_judgements_public_ui/templates/pages/permissions_and_licensing/when_you_need_permission/public_sector_reuse.jinja
+++ b/ds_judgements_public_ui/templates/pages/permissions_and_licensing/when_you_need_permission/public_sector_reuse.jinja
@@ -32,7 +32,7 @@
 {% block article_content %}
   {{ heading(content="Crown bodies and Non-Crown bodies", tag="h2") }}
   <p>
-    Before you do anything else, you need to establish whether your organisation is a Crown body or a Non-Crown body. The answer determines whether you need to apply for a licence to re-use Find Case Law data.
+    Before you do anything else, you need to establish whether your organisation is a Crown body or a Non-Crown body. The answer determines whether you need to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }} to re-use Find Case Law data.
   </p>
   {{ heading(content="Crown bodies", tag="h3") }}
   <p>
@@ -43,7 +43,7 @@
   </p>
   {{ heading(content="Non-Crown bodies", tag="h3") }}
   <p>
-    If your organisation is a Non-Crown body, you need to apply for a licence to re-use Find Case Law data for computational analysis.
+    If your organisation is a Non-Crown body, you need to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }} to re-use Find Case Law data for computational analysis.
   </p>
   <p>{{ link(content="Find out how to apply", href=url("what_you_need_to_apply_for_a_licence") ) }}.</p>
   {{ heading(content="Guidance for Crown bodies", tag="h2") }}

--- a/ds_judgements_public_ui/templates/pages/permissions_and_licensing/when_you_need_permission/what_you_need_to_apply_for_a_licence.jinja
+++ b/ds_judgements_public_ui/templates/pages/permissions_and_licensing/when_you_need_permission/what_you_need_to_apply_for_a_licence.jinja
@@ -10,7 +10,7 @@
     What you need to apply for a licence
   {% endcall %}
   <p>
-    If you want to perform computational analysis on Find Case Law records, you'll need to apply for a licence. Here's what the application involves and how to prepare.
+    If you want to perform computational analysis on Find Case Law records, you'll need to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }}. Here's what the application involves and how to prepare.
   </p>
 {% endblock mobile_article_title %}
 {% block desktop_article_title %}
@@ -18,7 +18,7 @@
     What you need to apply for a licence
   {% endcall %}
   <p>
-    If you want to perform computational analysis on Find Case Law records, you'll need to apply for a licence. Here's what the application involves and how to prepare.
+    If you want to perform computational analysis on Find Case Law records, you'll need to {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }}. Here's what the application involves and how to prepare.
   </p>
 {% endblock desktop_article_title %}
 {% block article_navigation %}
@@ -619,6 +619,7 @@
       {%- endcall -%}
       {{ " " }}page.
     </p>
+    <p>When you are ready, you can {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }}.</p>
     <p>
       If you have any questions about licensing, please email the Licensing Department:
       {% call link(href="mailto:caselawlicence@nationalarchives.gov.uk") %}

--- a/ds_judgements_public_ui/templates/pages/terms_of_use.jinja
+++ b/ds_judgements_public_ui/templates/pages/terms_of_use.jinja
@@ -87,7 +87,7 @@
       .
     </p>
     <p>
-      You must apply for a licence to do computational analysis if you wish to conduct computational analysis of the information provided by Find Case Law.
+      You must {{ link(content="apply for a licence", href=url("apply_for_a_licence") ) }} to do computational analysis if you wish to conduct computational analysis of the information provided by Find Case Law.
     </p>
     <p>
       For more detailed information, see our instructions on how to


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Adds links to places we reference "Apply for a licence" to make finding the apply for licence page not a labyrinth. 

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-2203

## Screenshots of UI changes:

As it's just changing text to links, the E2E snapshots don't need re-running as it's too small of a change.