### PR TITLE
[FCLC-2249] Make /id/ URIs dereference to preferred representations

### DIFF
--- a/judgments/resolvers/id_dispatch.py
+++ b/judgments/resolvers/id_dispatch.py
@@ -1,0 +1,68 @@
+from caselawclient.models.documents import DocumentURIString
+from django.http import HttpResponse
+from django.http.request import HttpRequest
+from django.urls import reverse
+from django.views.generic import View
+
+from judgments.utils import get_published_document_by_uri
+
+_HTML_TYPES = ("text/html", "application/xhtml+xml")
+_XML_TYPES = ("application/akn+xml", "application/xml")
+_PDF_TYPES = ("application/pdf",)
+
+# Order matters when Accept is */* or otherwise unconstrained: HTML first.
+_OFFERED_TYPES = _HTML_TYPES + _XML_TYPES + _PDF_TYPES
+
+
+def representation_kind_from_accept(request: HttpRequest) -> str | None:
+    """
+    Choose a document representation from Accept.
+
+    Returns one of: "html", "xml", "pdf", or None when Accept matches none of
+    our representations (caller should respond 406).
+
+    Missing Accept is treated by Django as */*, which selects HTML.
+    """
+    preferred = request.get_preferred_type(_OFFERED_TYPES)
+    if preferred is None:
+        return None
+    if preferred in _XML_TYPES:
+        return "xml"
+    if preferred in _PDF_TYPES:
+        return "pdf"
+    return "html"
+
+
+def location_for_representation(slug: str, kind: str) -> str:
+    if kind == "xml":
+        return reverse("detail", kwargs={"document_uri": slug, "file_format": "data.xml"})
+    if kind == "pdf":
+        return reverse("detail", kwargs={"document_uri": slug, "file_format": "data.pdf"})
+    return reverse("detail", kwargs={"document_uri": slug})
+
+
+class IdDispatchEngine(View):
+    """
+    Dereference an identity URL under `/id/` to a current representation.
+
+    `/id/{document_uri}` identifies the document (the work), not a particular
+    HTML/XML/PDF expression. We 303 to the preferred-slug representation chosen
+    from Accept (HTML by default), or 406 if Accept matches nothing we offer.
+    """
+
+    def get(self, request: HttpRequest, document_uri: str) -> HttpResponse:
+        document = get_published_document_by_uri(DocumentURIString(document_uri))
+
+        # document.slug raises RuntimeError if there is no preferred identifier —
+        # that is broken published data on our side, so a 500 is appropriate.
+        slug = document.slug
+
+        kind = representation_kind_from_accept(request)
+        if kind is None:
+            response = HttpResponse(status=406)
+        else:
+            response = HttpResponse(content="", status=303)
+            response["Location"] = location_for_representation(slug, kind)
+
+        response["Vary"] = "Accept"
+        return response

--- a/judgments/resolvers/id_dispatch.py
+++ b/judgments/resolvers/id_dispatch.py
@@ -1,0 +1,70 @@
+from typing import Optional
+
+from caselawclient.models.documents import DocumentURIString
+from django.http import HttpResponse
+from django.http.request import HttpRequest
+from django.urls import reverse
+from django.views.generic import View
+
+from judgments.utils import get_published_document_by_uri
+
+_HTML_TYPES = ("text/html", "application/xhtml+xml")
+_XML_TYPES = ("application/akn+xml", "application/xml")
+_PDF_TYPES = ("application/pdf",)
+
+# Order matters when Accept is */* or otherwise unconstrained: HTML first.
+_OFFERED_TYPES = _HTML_TYPES + _XML_TYPES + _PDF_TYPES
+
+
+def representation_kind_from_accept(request: HttpRequest) -> Optional[str]:
+    """
+    Choose a document representation from Accept.
+
+    Returns one of: "html", "xml", "pdf", or None when Accept matches none of
+    our representations (caller should respond 406).
+
+    Missing Accept is treated by Django as */*, which selects HTML.
+    """
+    preferred = request.get_preferred_type(_OFFERED_TYPES)
+    if preferred is None:
+        return None
+    if preferred in _XML_TYPES:
+        return "xml"
+    if preferred in _PDF_TYPES:
+        return "pdf"
+    return "html"
+
+
+def location_for_representation(slug: str, kind: str) -> str:
+    if kind == "xml":
+        return reverse("detail", kwargs={"document_uri": slug, "file_format": "data.xml"})
+    if kind == "pdf":
+        return reverse("detail", kwargs={"document_uri": slug, "file_format": "data.pdf"})
+    return reverse("detail", kwargs={"document_uri": slug})
+
+
+class IdDispatchEngine(View):
+    """
+    Dereference an identity URL under `/id/` to a current representation.
+
+    `/id/{document_uri}` identifies the document (the work), not a particular
+    HTML/XML/PDF expression. We 303 to the preferred-slug representation chosen
+    from Accept (HTML by default), or 406 if Accept matches nothing we offer.
+    """
+
+    def get(self, request: HttpRequest, document_uri: str) -> HttpResponse:
+        document = get_published_document_by_uri(DocumentURIString(document_uri))
+
+        # document.slug raises RuntimeError if there is no preferred identifier —
+        # that is broken published data on our side, so a 500 is appropriate.
+        slug = document.slug
+
+        kind = representation_kind_from_accept(request)
+        if kind is None:
+            response = HttpResponse(status=406)
+        else:
+            response = HttpResponse(content="", status=303)
+            response["Location"] = location_for_representation(slug, kind)
+
+        response["Vary"] = "Accept"
+        return response

--- a/judgments/tests/test_id_dispatch.py
+++ b/judgments/tests/test_id_dispatch.py
@@ -1,0 +1,118 @@
+from unittest.mock import patch
+
+from caselawclient.factories import JudgmentFactory
+from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
+from django.test import RequestFactory
+from fixtures import TestCaseWithMockAPI
+
+from judgments.resolvers.id_dispatch import representation_kind_from_accept
+
+
+class TestRepresentationKindFromAccept(TestCaseWithMockAPI):
+    def test_defaults_to_html_when_accept_missing(self):
+        request = RequestFactory().get("/id/d-a1b2c3")
+        assert representation_kind_from_accept(request) == "html"
+
+    def test_html_preferred_over_xml_in_browser_style_accept(self):
+        request = RequestFactory().get(
+            "/id/d-a1b2c3",
+            HTTP_ACCEPT="text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        )
+        assert representation_kind_from_accept(request) == "html"
+
+    def test_akn_xml(self):
+        request = RequestFactory().get("/id/d-a1b2c3", HTTP_ACCEPT="application/akn+xml")
+        assert representation_kind_from_accept(request) == "xml"
+
+    def test_application_xml(self):
+        request = RequestFactory().get("/id/d-a1b2c3", HTTP_ACCEPT="application/xml")
+        assert representation_kind_from_accept(request) == "xml"
+
+    def test_pdf(self):
+        request = RequestFactory().get("/id/d-a1b2c3", HTTP_ACCEPT="application/pdf")
+        assert representation_kind_from_accept(request) == "pdf"
+
+    def test_star_star_defaults_to_html(self):
+        request = RequestFactory().get("/id/d-a1b2c3", HTTP_ACCEPT="*/*")
+        assert representation_kind_from_accept(request) == "html"
+
+    def test_unsupported_type_returns_none(self):
+        request = RequestFactory().get("/id/d-a1b2c3", HTTP_ACCEPT="application/json")
+        assert representation_kind_from_accept(request) is None
+
+    def test_unsupported_then_html_still_html(self):
+        request = RequestFactory().get(
+            "/id/d-a1b2c3",
+            HTTP_ACCEPT="application/json,text/html;q=0.5",
+        )
+        assert representation_kind_from_accept(request) == "html"
+
+
+class TestIdDispatchEngine(TestCaseWithMockAPI):
+    @patch("judgments.resolvers.id_dispatch.get_published_document_by_uri")
+    def test_redirects_to_preferred_html_by_default(self, mock_get_document_by_uri):
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
+            is_published=True, identifiers=[NeutralCitationNumber(value="[2025] UKSC 123")]
+        )
+
+        response = self.client.get("/id/d-a1b2c3")
+
+        mock_get_document_by_uri.assert_called_once_with("d-a1b2c3")
+        self.assertEqual(response.status_code, 303)
+        self.assertEqual(response.headers.get("Location"), "/uksc/2025/123")
+        self.assertEqual(response.headers.get("Vary"), "Accept")
+
+    @patch("judgments.resolvers.id_dispatch.get_published_document_by_uri")
+    def test_redirects_to_xml_when_accept_akn(self, mock_get_document_by_uri):
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
+            is_published=True, identifiers=[NeutralCitationNumber(value="[2025] UKSC 123")]
+        )
+
+        response = self.client.get("/id/d-a1b2c3", HTTP_ACCEPT="application/akn+xml")
+
+        self.assertEqual(response.status_code, 303)
+        self.assertEqual(response.headers.get("Location"), "/uksc/2025/123/data.xml")
+
+    @patch("judgments.resolvers.id_dispatch.get_published_document_by_uri")
+    def test_redirects_to_pdf_when_accept_pdf(self, mock_get_document_by_uri):
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
+            is_published=True, identifiers=[NeutralCitationNumber(value="[2025] UKSC 123")]
+        )
+
+        response = self.client.get("/id/d-a1b2c3", HTTP_ACCEPT="application/pdf")
+
+        self.assertEqual(response.status_code, 303)
+        self.assertEqual(response.headers.get("Location"), "/uksc/2025/123/data.pdf")
+
+    @patch("judgments.resolvers.id_dispatch.get_published_document_by_uri")
+    def test_legacy_document_uri_path(self, mock_get_document_by_uri):
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
+            is_published=True, identifiers=[NeutralCitationNumber(value="[2024] EWHC 253 (Comm)")]
+        )
+
+        response = self.client.get("/id/ewhc/comm/2024/253")
+
+        mock_get_document_by_uri.assert_called_once_with("ewhc/comm/2024/253")
+        self.assertEqual(response.status_code, 303)
+
+    @patch("judgments.resolvers.id_dispatch.get_published_document_by_uri")
+    def test_500_without_preferred_identifier(self, mock_get_document_by_uri):
+        """Published documents without a preferred identifier are broken data → 500."""
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(is_published=True, identifiers=[])
+
+        with self.assertRaises(RuntimeError):
+            # Django's test client converts uncaught exceptions to 500 responses
+            # only when DEBUG is False; assert the underlying failure directly.
+            self.client.get("/id/d-a1b2c3")
+
+    @patch("judgments.resolvers.id_dispatch.get_published_document_by_uri")
+    def test_406_when_accept_is_unsupported(self, mock_get_document_by_uri):
+        mock_get_document_by_uri.return_value = JudgmentFactory.build(
+            is_published=True, identifiers=[NeutralCitationNumber(value="[2025] UKSC 123")]
+        )
+
+        response = self.client.get("/id/d-a1b2c3", HTTP_ACCEPT="application/json")
+
+        self.assertEqual(response.status_code, 406)
+        self.assertIsNone(response.headers.get("Location"))
+        self.assertEqual(response.headers.get("Vary"), "Accept")

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -9,6 +9,7 @@ from judgments.views.index import IndexView
 
 from . import converters, feeds
 from .resolvers.document_resolver_engine import DocumentResolverEngine
+from .resolvers.id_dispatch import IdDispatchEngine
 
 register_converter(converters.YearConverter, "yyyy")
 register_converter(converters.DateConverter, "date")
@@ -27,6 +28,12 @@ def safer_redirect(target):
 
 
 urlpatterns = [
+    # Identity URLs must be registered before catch-all document routes.
+    path(
+        "id/<document_uri:document_uri>",
+        IdDispatchEngine.as_view(),
+        name="id-dispatch",
+    ),
     path("<court:court>", BrowseView.as_view(), name="browse"),
     path("<yyyy:year>", BrowseView.as_view(), name="browse"),
     path("<court:court>/<yyyy:year>", BrowseView.as_view(), name="browse"),


### PR DESCRIPTION
Atom already advertises identity URLs under /id/, but they 404ed. Resolve published documents by URI and 303 to the preferred-slug HTML, XML, or PDF representation based on Accept (HTML by default).
