### PR TITLE
Present dates in Europe/London; keep storage UTC

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -24,16 +24,16 @@ DEBUG = env.bool("DJANGO_DEBUG", default=False)
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 if env("SECRET_KEY", default=None):
     SECRET_KEY = env("SECRET_KEY")
-# Local time zone. Choices are
+# Presentation / default display timezone (UK local time, including BST).
+# Datetimes are still stored and exchanged in UTC when USE_TZ is True.
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
-# though not all of them may be available with every OS.
-# In Windows, this must be set to your system time zone.
-TIME_ZONE = "UTC"
+TIME_ZONE = "Europe/London"
 # https://docs.djangoproject.com/en/dev/ref/settings/#site-id
 SITE_ID = 1
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-l10n
 USE_L10N = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-tz
+# Keep True so the database and aware datetimes remain UTC on the storage layer.
 USE_TZ = True
 
 # DATABASES

--- a/config/tests/test_sitemap.py
+++ b/config/tests/test_sitemap.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 from caselawclient.factories import SearchResultFactory
@@ -13,10 +13,14 @@ from judgments.tests.fixture_data import FakeSearchResponse, FakeSearchResponseB
 class MockCourtYearSearchResult(FakeSearchResponseBaseClass):
     results = [
         SearchResultFactory.build(
-            uri="d-a1b2c3", slug="test/2025/123", transformation_date=datetime(2025, 1, 1, 1, 23).isoformat()
+            uri="d-a1b2c3",
+            slug="test/2025/123",
+            transformation_date=datetime(2025, 1, 1, 1, 23, tzinfo=timezone.utc).isoformat(),
         ),
         SearchResultFactory.build(
-            uri="d-d4e5f6", slug="test/2025/456", transformation_date=datetime(2025, 2, 2, 4, 56).isoformat()
+            uri="d-d4e5f6",
+            slug="test/2025/456",
+            transformation_date=datetime(2025, 2, 2, 4, 56, tzinfo=timezone.utc).isoformat(),
         ),
     ]
 

--- a/config/views/sitemaps.py
+++ b/config/views/sitemaps.py
@@ -12,6 +12,7 @@ from django.views.generic.base import TemplateResponseMixin, TemplateView
 
 from judgments.models.court_dates import CourtDates
 from judgments.utils import api_client
+from judgments.utils.timezones import as_utc_datetime
 
 
 class SitemapIndexView(TemplateView, TemplateResponseMixin):
@@ -128,9 +129,7 @@ class SitemapCourtView(TemplateView, TemplateResponseMixin):
             context["items"] = [
                 {
                     "url": self.request.build_absolute_uri("/" + result.slug),
-                    "lastmod": datetime.datetime.strptime(result.transformation_date, "%Y-%m-%dT%H:%M:%S")
-                    .date()
-                    .isoformat(),
+                    "lastmod": as_utc_datetime(result.transformation_date).date().isoformat(),
                 }
                 for result in search_response.results
             ]

--- a/judgments/converters.py
+++ b/judgments/converters.py
@@ -31,7 +31,7 @@ class DateConverter:
     regex = "([0-9]{4})-([0-9]{2})-([0-9]{2})"
 
     def to_python(self, value):
-        return datetime.datetime.strptime(value, "%Y-%m-%d")
+        return datetime.datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=datetime.timezone.utc)
 
     def to_url(self, value):
         if value is None:

--- a/judgments/feeds.py
+++ b/judgments/feeds.py
@@ -22,6 +22,7 @@ from ds_caselaw_utils.types import CourtParam
 from .forms.search_forms import TRIBUNAL_CHOICES
 from .utils import api_client, paginator
 from .utils.search_request_to_parameters import search_request_to_parameters
+from .utils.timezones import as_utc_datetime
 
 
 def _add_page_to_url(url: str, page: int = 1) -> str:
@@ -198,11 +199,13 @@ class JudgmentsFeed(Feed):
         return extra_kwargs
 
     def item_updateddate(self, item: SearchResult) -> datetime.datetime:
-        date_string = item.transformation_date or "1970-01-01T00:00:00.000"
-        return datetime.datetime.fromisoformat(date_string)
+        date_string = item.transformation_date or "1970-01-01T00:00:00+00:00"
+        return as_utc_datetime(date_string)
 
     def item_pubdate(self, item: SearchResult) -> Optional[datetime.datetime]:
-        return item.date
+        if item.date is None:
+            return None
+        return as_utc_datetime(item.date)
 
     def feed_extra_kwargs(self, obj):
         extra_kwargs = super().item_extra_kwargs(obj)

--- a/judgments/jinja.py
+++ b/judgments/jinja.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 from functools import wraps
 
 from crispy_forms.templatetags.crispy_forms_filters import as_crispy_form
@@ -29,6 +30,7 @@ from judgments.templatetags import (
     query_filters,
     search_results_filters,
 )
+from judgments.utils.timezones import LONDON
 from transactional_licence_form.templatetags import transactional_licence_utils
 
 
@@ -48,6 +50,9 @@ def capfirst(value):
 def formatdate(value, format="%d %b %Y"):
     if value is None:
         return ""
+    # Aware datetimes are shown in Europe/London; date-only values are calendar days.
+    if isinstance(value, datetime) and value.tzinfo is not None:
+        value = value.astimezone(LONDON)
     return value.strftime(format)
 
 

--- a/judgments/management/commands/recalculate_court_dates.py
+++ b/judgments/management/commands/recalculate_court_dates.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import Optional, Union
 
 from caselawclient.client_helpers.search_helpers import (
@@ -11,6 +10,7 @@ from ds_caselaw_utils.courts import Court, CourtParam, CourtWithJurisdiction
 
 from judgments.models.court_dates import CourtDates
 from judgments.utils import api_client
+from judgments.utils.timezones import london_today
 
 
 class Command(BaseCommand):
@@ -68,7 +68,7 @@ falling back to config value of {fallback_start_year}"
             court.canonical_param, "-date", "newest", fallback_end_year
         )
 
-        if end_year and end_year > datetime.date.today().year:
+        if end_year and end_year > london_today().year:
             self.stdout.write(
                 self.style.WARNING(
                     f"Calculated end year of {end_year} is impossible, \

--- a/judgments/templatetags/court_utils.py
+++ b/judgments/templatetags/court_utils.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import date
 from typing import Optional
 
 from caselawclient.client_helpers.search_helpers import (
@@ -14,6 +13,7 @@ from requests.exceptions import RequestException
 
 from judgments.models.court_dates import CourtDates
 from judgments.utils import api_client
+from judgments.utils.timezones import london_today
 
 register = template.Library()
 
@@ -49,7 +49,7 @@ def get_last_judgment_year() -> int:
         logging.warning("CourtDates table is empty! using fallback max_year.")
         # The dates in all_courts don't work as a fallback, as they can't
         # be relied on to be up to date.
-        return date.today().year
+        return london_today().year
 
 
 @register.filter
@@ -94,6 +94,6 @@ def get_court_judgments_count(court: Court) -> int:
 
 
 def is_court_ended(court: Court) -> bool:
-    current_year = date.today().year
+    current_year = london_today().year
 
     return court.end_year < current_year

--- a/judgments/tests/management/commands/test_recalculate_court_dates.py
+++ b/judgments/tests/management/commands/test_recalculate_court_dates.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from ds_caselaw_utils.courts import CourtParam
 
 from judgments.management.commands.recalculate_court_dates import Command
+from judgments.utils.timezones import london_today
 
 
 class TestRecalculateCourtDates(TestCase):
@@ -91,7 +92,7 @@ class TestRecalculateCourtDates(TestCase):
         court.canonical_param = "test-court"
         court.end_year = 2022
 
-        future_year = datetime.date.today().year + 1
+        future_year = london_today().year + 1
         mock_doc = MagicMock()
         mock_doc.date = datetime.date(future_year, 1, 1)
         mock_doc.uri = "/judgment/future"

--- a/judgments/tests/template_tags/test_court_utils.py
+++ b/judgments/tests/template_tags/test_court_utils.py
@@ -16,6 +16,7 @@ from judgments.templatetags.court_utils import (
     get_last_judgment_year,
     is_court_ended,
 )
+from judgments.utils.timezones import london_today
 
 
 class TestGetCourtName(TestCase):
@@ -74,11 +75,11 @@ class TestGetLastJudgmentYear(TestCase):
         result = get_last_judgment_year()
         assert result == 2022
 
-    @patch("judgments.templatetags.court_utils.date")
+    @patch("judgments.templatetags.court_utils.london_today")
     @patch("judgments.templatetags.court_utils.logging.warning")
     @patch("judgments.templatetags.court_utils.CourtDates.max_year", return_value=None)
-    def test_fallback_to_today_year(self, mock_max_year, mock_logging, mock_date):
-        mock_date.today.return_value = date(2024, 1, 1)
+    def test_fallback_to_today_year(self, mock_max_year, mock_logging, mock_london_today):
+        mock_london_today.return_value = date(2024, 1, 1)
         result = get_last_judgment_year()
         assert result == 2024
         mock_logging.assert_called_once_with("CourtDates table is empty! using fallback max_year.")
@@ -178,13 +179,13 @@ class TestGetCourtJudgmentsCount(TestCase):
 class TestIsCourtEnded(TestCase):
     def test_court_is_ended(self):
         mock_court = Mock()
-        mock_court.end_year = 2025
+        mock_court.end_year = london_today().year - 1
 
         assert is_court_ended(mock_court)
 
     def test_court_is_not_ended(self):
 
         mock_court = Mock()
-        mock_court.end_year = date.today().year
+        mock_court.end_year = london_today().year
 
         assert not is_court_ended(mock_court)

--- a/judgments/tests/test_converters.py
+++ b/judgments/tests/test_converters.py
@@ -57,11 +57,11 @@ class TestDateConverter(TestCase):
 
     def test_to_python_converts_string_to_datetime(self):
         result = self.converter.to_python("2024-06-17")
-        expected = datetime.datetime(2024, 6, 17)
+        expected = datetime.datetime(2024, 6, 17, tzinfo=datetime.timezone.utc)
         self.assertEqual(result, expected)
 
     def test_to_url_formats_datetime_as_string(self):
-        dt = datetime.datetime(2025, 1, 5)
+        dt = datetime.datetime(2025, 1, 5, tzinfo=datetime.timezone.utc)
         self.assertEqual(self.converter.to_url(dt), "2025-01-05")
 
     def test_to_url_raises_value_error_on_none(self):

--- a/judgments/tests/test_timezones.py
+++ b/judgments/tests/test_timezones.py
@@ -1,0 +1,161 @@
+from datetime import date, datetime
+from unittest.mock import Mock
+
+import pytest
+from django.conf import settings
+from django.test import SimpleTestCase
+
+from judgments.feeds import JudgmentsFeed
+from judgments.jinja import formatdate
+from judgments.utils.timezones import LONDON, UTC, as_utc_datetime, london_today, utc_now
+
+# UK DST transitions in 2025:
+# - clocks go forward 2025-03-30 01:00 GMT -> 02:00 BST
+# - clocks go back   2025-10-26 02:00 BST -> 01:00 GMT
+
+
+def test_django_keeps_storage_utc_and_presents_london():
+    assert settings.USE_TZ is True
+    assert settings.TIME_ZONE == "Europe/London"
+
+
+def test_utc_now_is_timezone_aware_utc():
+    now = utc_now()
+    assert now.tzinfo is not None
+    assert now.utcoffset() == UTC.utcoffset(None)
+
+
+def test_london_today_returns_date():
+    assert isinstance(london_today(), date)
+
+
+def test_as_utc_datetime_parses_offset_string():
+    result = as_utc_datetime("2025-01-01 01:23:00+00:00")
+    assert result == datetime(2025, 1, 1, 1, 23, tzinfo=UTC)
+
+
+def test_as_utc_datetime_parses_zulu_string():
+    result = as_utc_datetime("2025-01-01T01:23:00Z")
+    assert result == datetime(2025, 1, 1, 1, 23, tzinfo=UTC)
+
+
+def test_as_utc_datetime_treats_naive_as_utc():
+    result = as_utc_datetime(datetime(2025, 1, 1, 12, 0, 0))
+    assert result == datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def test_as_utc_datetime_converts_london_to_utc_in_bst():
+    # BST: 2025-07-01 13:00 London == 12:00 UTC
+    result = as_utc_datetime(datetime(2025, 7, 1, 13, 0, 0, tzinfo=LONDON))
+    assert result == datetime(2025, 7, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def test_as_utc_datetime_converts_london_to_utc_in_gmt():
+    # Winter: London == UTC
+    result = as_utc_datetime(datetime(2025, 1, 15, 13, 0, 0, tzinfo=LONDON))
+    assert result == datetime(2025, 1, 15, 13, 0, 0, tzinfo=UTC)
+
+
+def test_as_utc_datetime_across_spring_forward():
+    # After the gap: 02:30 BST on spring-forward day is 01:30 UTC
+    result = as_utc_datetime(datetime(2025, 3, 30, 2, 30, 0, tzinfo=LONDON))
+    assert result == datetime(2025, 3, 30, 1, 30, 0, tzinfo=UTC)
+    assert result.utcoffset() == UTC.utcoffset(None)
+
+
+def test_as_utc_datetime_across_fall_back():
+    # First 01:30 (BST, fold=0) is 00:30 UTC; second 01:30 (GMT, fold=1) is 01:30 UTC
+    bst_occurrence = datetime(2025, 10, 26, 1, 30, 0, tzinfo=LONDON, fold=0)
+    gmt_occurrence = datetime(2025, 10, 26, 1, 30, 0, tzinfo=LONDON, fold=1)
+
+    assert as_utc_datetime(bst_occurrence) == datetime(2025, 10, 26, 0, 30, 0, tzinfo=UTC)
+    assert as_utc_datetime(gmt_occurrence) == datetime(2025, 10, 26, 1, 30, 0, tzinfo=UTC)
+
+
+def test_storage_calendar_date_stays_utc_when_london_is_next_day():
+    """During BST, late UTC evening is already the next calendar day in London."""
+    utc_instant = datetime(2025, 7, 1, 23, 30, 0, tzinfo=UTC)
+
+    assert utc_instant.date() == date(2025, 7, 1)
+    assert utc_instant.astimezone(LONDON).date() == date(2025, 7, 2)
+    # Sitemap lastmod / API storage date must follow UTC, not London presentation
+    assert as_utc_datetime(utc_instant).date() == date(2025, 7, 1)
+    assert as_utc_datetime(utc_instant.isoformat()).date() == date(2025, 7, 1)
+
+
+def test_formatdate_shows_london_calendar_day_for_aware_utc_datetime():
+    # 23:30 UTC on 1 Jul is already 2 Jul in London (BST)
+    utc_instant = datetime(2025, 7, 1, 23, 30, 0, tzinfo=UTC)
+    assert formatdate(utc_instant) == "02 Jul 2025"
+    assert formatdate(utc_instant, "%Y-%m-%d %H:%M") == "2025-07-02 00:30"
+
+
+def test_formatdate_winter_matches_utc_clock():
+    utc_instant = datetime(2025, 1, 15, 14, 0, 0, tzinfo=UTC)
+    assert formatdate(utc_instant, "%Y-%m-%d %H:%M") == "2025-01-15 14:00"
+
+
+def test_formatdate_leaves_naive_date_unchanged():
+    assert formatdate(date(2025, 7, 1)) == "01 Jul 2025"
+
+
+def test_formatdate_across_spring_forward_gap():
+    # 01:30 UTC on spring-forward morning displays as 02:30 BST in London
+    utc_instant = datetime(2025, 3, 30, 1, 30, 0, tzinfo=UTC)
+    assert formatdate(utc_instant, "%Y-%m-%d %H:%M %Z") == "2025-03-30 02:30 BST"
+
+
+class TestFeedTimestampsRemainUtc(SimpleTestCase):
+    def setUp(self):
+        self.feed = JudgmentsFeed()
+
+    def test_item_updateddate_returns_aware_utc(self):
+        item = Mock(transformation_date="2025-07-01 23:30:00+00:00")
+        result = self.feed.item_updateddate(item)
+
+        assert result == datetime(2025, 7, 1, 23, 30, 0, tzinfo=UTC)
+        assert result.utcoffset() == UTC.utcoffset(None)
+        # Must not silently shift to London for the Atom wire format
+        assert result.isoformat() == "2025-07-01T23:30:00+00:00"
+
+    def test_item_updateddate_parses_client_factory_style_string(self):
+        item = Mock(transformation_date="2023-02-03 12:34:00+00:00")
+        result = self.feed.item_updateddate(item)
+        assert result == datetime(2023, 2, 3, 12, 34, 0, tzinfo=UTC)
+
+    def test_item_pubdate_normalises_aware_client_datetime_to_utc(self):
+        # Client may hand back an aware UTC datetime (factory default)
+        item = Mock(date=datetime(2023, 2, 3, 0, 0, 0, tzinfo=UTC))
+        result = self.feed.item_pubdate(item)
+        assert result == datetime(2023, 2, 3, 0, 0, 0, tzinfo=UTC)
+        assert result.utcoffset() == UTC.utcoffset(None)
+
+    def test_item_pubdate_treats_naive_client_datetime_as_utc(self):
+        # SearchResult.date can still be naive when MarkLogic omits an offset
+        item = Mock(date=datetime(2023, 2, 3, 0, 0, 0))
+        result = self.feed.item_pubdate(item)
+        assert result == datetime(2023, 2, 3, 0, 0, 0, tzinfo=UTC)
+
+    def test_item_pubdate_none(self):
+        assert self.feed.item_pubdate(Mock(date=None)) is None
+
+
+@pytest.mark.parametrize(
+    ("london_local", "expected_utc"),
+    [
+        # Immediately before spring forward (still GMT)
+        (datetime(2025, 3, 30, 0, 30, 0, tzinfo=LONDON), datetime(2025, 3, 30, 0, 30, 0, tzinfo=UTC)),
+        # Immediately after spring forward (BST)
+        (datetime(2025, 3, 30, 2, 30, 0, tzinfo=LONDON), datetime(2025, 3, 30, 1, 30, 0, tzinfo=UTC)),
+        # Midsummer BST
+        (datetime(2025, 7, 1, 12, 0, 0, tzinfo=LONDON), datetime(2025, 7, 1, 11, 0, 0, tzinfo=UTC)),
+        # Midwinter GMT
+        (datetime(2025, 1, 15, 12, 0, 0, tzinfo=LONDON), datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)),
+    ],
+)
+def test_round_trip_london_local_to_utc_storage(london_local, expected_utc):
+    stored = as_utc_datetime(london_local)
+    assert stored == expected_utc
+    assert stored.tzinfo == UTC or stored.utcoffset() == UTC.utcoffset(None)
+    # Presentation must be able to recover the London wall clock
+    assert stored.astimezone(LONDON).strftime("%Y-%m-%d %H:%M") == london_local.strftime("%Y-%m-%d %H:%M")

--- a/judgments/utils/search_utils.py
+++ b/judgments/utils/search_utils.py
@@ -1,9 +1,8 @@
-import datetime
-
 from django.conf import settings
 from ds_caselaw_utils import courts as all_courts
 
 from judgments.models.court_dates import CourtDates
+from judgments.utils.timezones import london_today
 
 ALL_COURT_CODES = [court.code for court in all_courts.get_all()]
 
@@ -15,7 +14,7 @@ def _valid_years():
     """
     Generate a list of valid years as strings.
     """
-    today = datetime.date.today()
+    today = london_today()
     valid_years = range(2003, today.year + 1)
     return [f"{year}" for year in valid_years]
 

--- a/judgments/utils/timezones.py
+++ b/judgments/utils/timezones.py
@@ -1,0 +1,31 @@
+"""Timezone helpers: UTC for storage/interchange, Europe/London for presentation."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
+
+LONDON = ZoneInfo("Europe/London")
+UTC = timezone.utc
+
+
+def utc_now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def london_today() -> date:
+    """UK calendar date (Europe/London), including BST when in effect."""
+    return datetime.now(tz=LONDON).date()
+
+
+def as_utc_datetime(value: datetime | str) -> datetime:
+    """
+    Normalise a datetime or ISO-8601 string to timezone-aware UTC.
+
+    Naive datetimes/strings are treated as UTC (storage-layer contract).
+    """
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)


### PR DESCRIPTION
- Set `TIME_ZONE = "Europe/London"` while keeping `USE_TZ = True` so DB/API interchange stays UTC
- Add `judgments.utils.timezones` helpers (`london_today`, `utc_now`, `as_utc_datetime`)
- Use London calendar day for year facets / court ended / recalculate end-year clamp
- Parse sitemap `lastmod` and Atom feed timestamps via `as_utc_datetime` (works with client 49 ISO strings with offsets)
- Format aware datetimes in Jinja `formatdate` in Europe/London; date-only values unchanged
- Clear remaining ruff DTZ findings that blocked the ruff Renovate PR