### PR TITLE
FCLC-2172 | use search to get court document counts

### DIFF
--- a/config/tests/test_courts_view.py
+++ b/config/tests/test_courts_view.py
@@ -10,7 +10,16 @@ from judgments.models.court_dates import CourtDates
 
 
 class TestCourtsTribunalsListView(TestCase):
-    def test_decorate_court_group_adds_dates_and_document_counts(self):
+    @patch("config.views.courts.get_court_judgments_count")
+    def test_decorate_court_group_adds_dates_and_document_counts(self, mock_get_court_judgments_count):
+
+        def judgment_count(court):
+            if court.canonical_param == "court-with-data":
+                return 123
+            else:
+                return 0
+
+        mock_get_court_judgments_count.side_effect = judgment_count
         CourtDates.objects.create(param="court-with-data", start_year=2020, end_year=2024)
 
         court_with_data = SimpleNamespace(canonical_param="court-with-data", start_year=None, end_year=None)
@@ -19,7 +28,6 @@ class TestCourtsTribunalsListView(TestCase):
 
         decorated_group = CourtsTribunalsListView().decorate_court_group(
             group,
-            {"court-with-data": 123},
         )
 
         assert decorated_group == group

--- a/config/views/courts.py
+++ b/config/views/courts.py
@@ -13,6 +13,7 @@ from ds_caselaw_utils.courts import CourtNotFoundException
 from requests.exceptions import RequestException
 
 from judgments.models.court_dates import CourtDates
+from judgments.templatetags.court_utils import get_court_judgments_count
 from judgments.utils import (
     api_client,
 )
@@ -31,7 +32,7 @@ class CourtsTribunalsListView(TemplateViewWithContext):
     page_title = "Types of courts in England and Wales"
     page_allow_index = True
 
-    def decorate_court_group(self, group, courts_with_documents_count):
+    def decorate_court_group(self, group):
         """
         Updates the start_year and end_year with data from CourtDates if available.
         """
@@ -43,7 +44,7 @@ class CourtsTribunalsListView(TemplateViewWithContext):
 
         for court in group.courts:
             dates = date_map.get(court.canonical_param)
-            documents_count = courts_with_documents_count.get(court.canonical_param)
+            documents_count = get_court_judgments_count(court)
 
             if documents_count:
                 court.documents_count = documents_count
@@ -59,16 +60,8 @@ class CourtsTribunalsListView(TemplateViewWithContext):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        courts_with_documents_count = api_client.get_courts_with_document_count()
-
-        grouped_courts = [
-            self.decorate_court_group(group, courts_with_documents_count)
-            for group in courts.get_grouped_selectable_courts()
-        ]
-        grouped_tribunals = [
-            self.decorate_court_group(group, courts_with_documents_count)
-            for group in courts.get_grouped_selectable_tribunals()
-        ]
+        grouped_courts = [self.decorate_court_group(group) for group in courts.get_grouped_selectable_courts()]
+        grouped_tribunals = [self.decorate_court_group(group) for group in courts.get_grouped_selectable_tribunals()]
 
         context["courts"] = grouped_courts
         context["tribunals"] = grouped_tribunals


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Revert back to using the search for the counts. 

Will do a follow up PR to this to remove the query added as it's not working. We need to revisit this.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-2172
