### PR TITLE
Split document URI and identifier slug path converters

### DIFF
--- a/judgments/converters.py
+++ b/judgments/converters.py
@@ -71,6 +71,20 @@ class FileFormatConverter:
 
 
 class DocumentUriConverter:
+    """Path converter for document URIs under `/id/` (no full stops)."""
+
+    regex = r"[a-z0-9/-]+"
+
+    def to_python(self, value):
+        return value
+
+    def to_url(self, value):
+        return value
+
+
+class DocumentIdentifierSlugConverter:
+    """Path converter for identifier slug URLs at the site root (may contain full stops)."""
+
     regex = r"[a-z0-9./-]+"
 
     def to_python(self, value):

--- a/judgments/tests/test_converters.py
+++ b/judgments/tests/test_converters.py
@@ -10,6 +10,7 @@ from judgments.converters import (
     ComponentConverter,
     CourtConverter,
     DateConverter,
+    DocumentIdentifierSlugConverter,
     DocumentUriConverter,
     FileFormatConverter,
     SubdivisionConverter,
@@ -182,7 +183,7 @@ class TestDocumentUriConverter(TestCase):
         self.converter = DocumentUriConverter()
 
     def test_regex_matches_valid_document_uris(self):
-        valid_uris = ["ewca/civ/2025/abc", "ewca/civ/2025/a-b-c", "ewca/civ/2025/a.b.c"]
+        valid_uris = ["ewca/civ/2025/abc", "ewca/civ/2025/a-b-c", "d-a1b2c3"]
         for uri in valid_uris:
             self.assertIsNotNone(re.fullmatch(self.converter.regex, uri))
 
@@ -192,6 +193,8 @@ class TestDocumentUriConverter(TestCase):
             "spaces are bad",
             "spec!al&ch@racters",
             "with-a-hash#",
+            "ewca/civ/2025/a.b.c",
+            "tna.abcd2345",
             "",
         ]
         for uri in invalid_uris:
@@ -202,6 +205,38 @@ class TestDocumentUriConverter(TestCase):
 
     def test_to_url_returns_value_unchanged(self):
         self.assertEqual(self.converter.to_url("ewca/civ/2025/abc"), "ewca/civ/2025/abc")
+
+
+class TestDocumentIdentifierSlugConverter(TestCase):
+    def setUp(self):
+        self.converter = DocumentIdentifierSlugConverter()
+
+    def test_regex_matches_valid_slugs(self):
+        valid_slugs = [
+            "ewca/civ/2025/abc",
+            "ewca/civ/2025/a-b-c",
+            "ewca/civ/2025/a.b.c",
+            "tna.abcd2345",
+        ]
+        for slug in valid_slugs:
+            self.assertIsNotNone(re.fullmatch(self.converter.regex, slug))
+
+    def test_regex_rejects_invalid_slugs(self):
+        invalid_slugs = [
+            "UPPERCASETOOLOUD",
+            "spaces are bad",
+            "spec!al&ch@racters",
+            "with-a-hash#",
+            "",
+        ]
+        for slug in invalid_slugs:
+            self.assertIsNone(re.fullmatch(self.converter.regex, slug))
+
+    def test_to_python_returns_value_unchanged(self):
+        self.assertEqual(self.converter.to_python("tna.abcd2345"), "tna.abcd2345")
+
+    def test_to_url_returns_value_unchanged(self):
+        self.assertEqual(self.converter.to_url("tna.abcd2345"), "tna.abcd2345")
 
 
 class TestComponentConverter(TestCase):

--- a/judgments/tests/test_id_dispatch.py
+++ b/judgments/tests/test_id_dispatch.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from caselawclient.factories import JudgmentFactory
 from caselawclient.models.identifiers.neutral_citation import NeutralCitationNumber
 from django.test import RequestFactory
+from django.urls import resolve
 from fixtures import TestCaseWithMockAPI
 
 from judgments.resolvers.id_dispatch import representation_kind_from_accept
@@ -116,3 +117,10 @@ class TestIdDispatchEngine(TestCaseWithMockAPI):
         self.assertEqual(response.status_code, 406)
         self.assertIsNone(response.headers.get("Location"))
         self.assertEqual(response.headers.get("Vary"), "Accept")
+
+    def test_representation_suffix_does_not_match_id_route(self):
+        """Dots are invalid in document URIs, so /id/.../data.xml must not hit IdDispatchEngine."""
+        match = resolve("/id/ewhc/ch/2024/1714/data.xml")
+        self.assertEqual(match.url_name, "detail")
+        self.assertEqual(match.kwargs["document_uri"], "id/ewhc/ch/2024/1714")
+        self.assertEqual(match.kwargs["file_format"], "data.xml")

--- a/judgments/urls.py
+++ b/judgments/urls.py
@@ -16,6 +16,7 @@ register_converter(converters.DateConverter, "date")
 register_converter(converters.CourtConverter, "court")
 register_converter(converters.SubdivisionConverter, "subdivision")
 register_converter(converters.DocumentUriConverter, "document_uri")
+register_converter(converters.DocumentIdentifierSlugConverter, "document_identifier_slug")
 register_converter(converters.FileFormatConverter, "file_format")
 register_converter(converters.ComponentConverter, "component")
 
@@ -68,12 +69,12 @@ urlpatterns = [
         name="press_summary_1",
     ),
     path(
-        "<document_uri:document_uri>/<file_format:file_format>",
+        "<document_identifier_slug:document_uri>/<file_format:file_format>",
         DocumentResolverEngine.as_view(),
         name="detail",
     ),
     path(
-        "<document_uri:document_uri>",
+        "<document_identifier_slug:document_uri>",
         DocumentResolverEngine.as_view(),
         name="detail",
     ),


### PR DESCRIPTION
We're using a single `DocumentUriConverter` to handle both slug-based document URLs at `/`, and URI-based document URIs at `/id/`. Unfortunately, these two things aren't the same.

To fix this we now have a `DocumentUriConverter` for `/id/` which strictly matches what we consider to be a URI (without allowing `.`), and a new `DocumentIdentifierSlugConverter` for `/` which allows the full range of slugified identifier values.

This means that people trying to access invalid document URIs via `/id/` by including format extensions like `data.xml` will correctly receive a HTTP 404, instead of a HTTP 500 and us getting an annoying error message in Rollbar.