### PR TITLE
FCLC-2322 | spike only return legally significant judgments from search

### DIFF
--- a/judgments/utils/__init__.py
+++ b/judgments/utils/__init__.py
@@ -1,6 +1,7 @@
 from .judgment_utils import get_document_download_filename, get_published_document_by_uri
 from .search_utils import (
     ALL_COURT_CODES,
+    court_of_record_search_params,
     get_minimum_warning_year,
     process_court_facets,
     process_year_facets,
@@ -33,6 +34,7 @@ __all__ = [
     "MAX_RESULTS_PER_PAGE",
     "api_client",
     "clamp",
+    "court_of_record_search_params",
     "formatted_document_uri",
     "get_document_by_uri",
     "get_document_download_filename",

--- a/judgments/utils/search_request_to_parameters.py
+++ b/judgments/utils/search_request_to_parameters.py
@@ -11,11 +11,15 @@ from judgments.forms import AdvancedSearchForm
 from judgments.utils import (
     MAX_RESULTS_PER_PAGE,
     clamp,
+    court_of_record_search_params,
 )
 from judgments.utils.utils import sanitise_input_to_integer
 
 
-def search_request_to_parameters(request: HttpRequest) -> SearchParameters:
+def search_request_to_parameters(
+    request: HttpRequest,
+    default_to_courts_of_record: bool = False,
+) -> SearchParameters:
     """
     The advanced search view handles any searches made in the application
 
@@ -74,6 +78,12 @@ def search_request_to_parameters(request: HttpRequest) -> SearchParameters:
     }
     # Merge the courts and tribunals as they are treated as the same in MarkLogic.
     courts_and_tribunals = form.cleaned_data.get("court", []) + form.cleaned_data.get("tribunal", [])
+    if courts_and_tribunals:
+        court_search_params = ",".join(courts_and_tribunals)
+    elif default_to_courts_of_record:
+        court_search_params = court_of_record_search_params()
+    else:
+        court_search_params = ""
     # `SearchParameters` takes an optional string for dates
     if not to_date:
         to_date_as_search_param = None
@@ -83,7 +93,7 @@ def search_request_to_parameters(request: HttpRequest) -> SearchParameters:
     # Construct the search parameter object required for Marklogic query
     search_parameters: SearchParameters = SearchParameters(
         query=query_text,
-        court=",".join(courts_and_tribunals),
+        court=court_search_params,
         judge=form.cleaned_data.get("judge"),
         party=form.cleaned_data.get("party"),
         page=int(page),

--- a/judgments/utils/search_utils.py
+++ b/judgments/utils/search_utils.py
@@ -10,6 +10,14 @@ ALL_LISTABLE_COURT_NAMES = [court.name for court in all_courts.get_listable_cour
 ALL_LISTABLE_TRIBUNAL_NAMES = [tribunal.name for tribunal in all_courts.get_listable_tribunals()]
 
 
+def court_of_record_search_params() -> str:
+    return ",".join(
+        str(court.canonical_param)
+        for court in all_courts.get_all()
+        if court.is_court_of_record and court.canonical_param
+    )
+
+
 def _valid_years():
     """
     Generate a list of valid years as strings.

--- a/judgments/views/index.py
+++ b/judgments/views/index.py
@@ -13,7 +13,7 @@ from django.views.generic import TemplateView
 from requests.exceptions import RequestException
 
 from judgments.forms import AdvancedSearchForm
-from judgments.utils import api_client
+from judgments.utils import api_client, court_of_record_search_params
 from judgments.utils.gtm_datalayer import GtmPageType, build_gtm_data_layer
 
 
@@ -23,7 +23,10 @@ def cached_recent_judgments(ttl_hash: int) -> SearchResponse:
     This is a wrapper for caching homepage search results in memory with a maximum TTL. https://stackoverflow.com/questions/31771286/python-in-memory-cache-with-time-to-live
     """
     del ttl_hash  # ttl_hash is used to fake cache expiry with time
-    return search_judgments_and_parse_response(api_client, SearchParameters(order="-date", page_size=6))
+    return search_judgments_and_parse_response(
+        api_client,
+        SearchParameters(court=court_of_record_search_params(), order="-date", page_size=6),
+    )
 
 
 class IndexView(TemplateView):

--- a/judgments/views/search/results.py
+++ b/judgments/views/search/results.py
@@ -57,7 +57,7 @@ class SearchResultsView(TemplateViewWithContext):
                 using="jinja",
             )
 
-        search_parameters: SearchParameters = search_request_to_parameters(request)
+        search_parameters: SearchParameters = search_request_to_parameters(request, default_to_courts_of_record=True)
         context = self._initialize_context(form)
 
         context.update(


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

We wanted to get confidence getting legally significant judgments with the recent "court_of_record" change was straight forward.

Result: yes, it is.

**This is just a spike, so don't merge as is - needs tests/UI etc**