### PR TITLE
FCLC-2307 | fix how sort filters render on medium breakpoints

### DIFF
--- a/ds_judgements_public_ui/sass/includes/_result_controls.scss
+++ b/ds_judgements_public_ui/sass/includes/_result_controls.scss
@@ -23,7 +23,7 @@
       display: block;
     }
 
-    @media (min-width: $grid-breakpoint-extra-large) {
+    @media (min-width: $grid-breakpoint-medium) {
       display: none;
     }
   }
@@ -31,7 +31,7 @@
   &__item--desktop-only.result-controls__item {
     display: none;
 
-    @media (min-width: $grid-breakpoint-extra-large) {
+    @media (min-width: $grid-breakpoint-medium) {
       display: flex;
     }
   }
@@ -46,7 +46,7 @@
       width: 100%;
     }
 
-    @media (min-width: $grid-breakpoint-extra-large) {
+    @media (min-width: $grid-breakpoint-medium) {
       flex-direction: column;
       align-items: flex-start;
     }
@@ -56,11 +56,11 @@
     display: flex;
     gap: $space-3;
 
-    @media (min-width: $grid-breakpoint-extra-large) {
+    @media (min-width: $grid-breakpoint-medium) {
       gap: 0;
     }
 
-    @media (min-width: $grid-breakpoint-extra-large) {
+    @media (min-width: $grid-breakpoint-medium) {
       flex-direction: row;
       gap: $space-3;
     }
@@ -71,7 +71,7 @@
     font-family: $font-roboto;
     font-size: $typography-sm-text-size;
 
-    @media (min-width: $grid-breakpoint-extra-large) {
+    @media (min-width: $grid-breakpoint-medium) {
       display: block;
     }
   }
@@ -93,9 +93,5 @@
 
   &__button {
     margin-top: auto;
-  }
-
-  @media (min-width: $grid-breakpoint-extra-large) {
-    margin: 0;
   }
 }

--- a/ds_judgements_public_ui/sass/includes/_results.scss
+++ b/ds_judgements_public_ui/sass/includes/_results.scss
@@ -112,10 +112,12 @@
     gap: $space-4;
     padding-bottom: $space-4;
 
-    @media (min-width: $grid-breakpoint-extra-large) {
+    @media (min-width: $grid-breakpoint-medium) {
       flex-direction: row;
       gap: $space-6;
       align-items: flex-end;
+      justify-content: space-between;
+
       padding-bottom: $space-2;
     }
   }


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

The styling of the sort/filters were going to mobile styling too early. This makes it so they only go to mobile styling once we get to our last breakpoint.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-2307

## Screenshots of UI changes:

### Before

<img width="980" height="298" alt="image" src="https://github.com/user-attachments/assets/7584c46a-3415-4c09-ba51-d279f45e156c" />

<img width="787" height="266" alt="image" src="https://github.com/user-attachments/assets/f968256c-c3fd-4105-99ee-fcf0618c1942" />

<img width="592" height="234" alt="image" src="https://github.com/user-attachments/assets/e09cc7ca-b610-49c0-9691-5cad0816d26c" />



### After

<img width="995" height="372" alt="image" src="https://github.com/user-attachments/assets/bcddc218-a0b0-42e2-9fcc-28c7605f85cd" />

<img width="799" height="271" alt="image" src="https://github.com/user-attachments/assets/b8d8f43c-1451-473a-913e-dc22c362f141" />

<img width="611" height="286" alt="image" src="https://github.com/user-attachments/assets/1ba08a06-2e61-4774-be0a-4c64d111e487" />


- [ ] Requires env variable(s) to be updated
