### PR TITLE
FCLC-2248 | allow render_storybook to render for github pages running…

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -51,6 +51,14 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 ROOT_URLCONF = "config.urls"
 # https://docs.djangoproject.com/en/dev/ref/settings/#wsgi-application
 WSGI_APPLICATION = "config.wsgi.application"
+STORYBOOK_CORS_ALLOWED_ORIGINS = env.list(
+    "STORYBOOK_CORS_ALLOWED_ORIGINS",
+    default=[
+        "http://localhost:6006",
+        "http://127.0.0.1:6006",
+        "https://nationalarchives.github.io",
+    ],
+)
 
 # APPS
 # ------------------------------------------------------------------------------

--- a/config/tests/test_storybook.py
+++ b/config/tests/test_storybook.py
@@ -1,0 +1,25 @@
+from django.test import TestCase, override_settings
+
+
+class TestStorybookRenderView(TestCase):
+    @override_settings(STORYBOOK_CORS_ALLOWED_ORIGINS=["https://nationalarchives.github.io"])
+    def test_allows_storybook_github_pages_origin(self):
+        response = self.client.options(
+            "/storybook-render",
+            headers={"Origin": "https://nationalarchives.github.io"},
+        )
+
+        assert response.status_code == 200
+        assert response.headers["Access-Control-Allow-Origin"] == "https://nationalarchives.github.io"
+        assert response.headers["Access-Control-Allow-Methods"] == "POST, OPTIONS"
+        assert response.headers["Access-Control-Allow-Headers"] == "Content-Type"
+
+    @override_settings(STORYBOOK_CORS_ALLOWED_ORIGINS=["https://nationalarchives.github.io"])
+    def test_does_not_allow_unconfigured_origins(self):
+        response = self.client.options(
+            "/storybook-render",
+            headers={"Origin": "https://example.com"},
+        )
+
+        assert response.status_code == 200
+        assert "Access-Control-Allow-Origin" not in response.headers

--- a/config/views/storybook.py
+++ b/config/views/storybook.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from django.conf import settings
 from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 
@@ -9,10 +10,24 @@ from django.views.decorators.csrf import csrf_exempt
 logger = logging.getLogger(__name__)
 
 
+def _add_storybook_cors_headers(request, response):
+    origin = request.headers.get("Origin")
+    if origin in settings.STORYBOOK_CORS_ALLOWED_ORIGINS:
+        response.headers["Access-Control-Allow-Origin"] = origin
+        response.headers["Access-Control-Allow-Methods"] = "POST, OPTIONS"
+        response.headers["Access-Control-Allow-Headers"] = "Content-Type"
+        response.headers["Vary"] = "Origin"
+    return response
+
+
 @csrf_exempt
 def storybook_render_view(request):
+    if request.method == "OPTIONS":
+        return _add_storybook_cors_headers(request, HttpResponse())
+
     if request.method != "POST":
-        return JsonResponse({"error": "Must be a POST request"}, status=405)
+        response = JsonResponse({"error": "Must be a POST request"}, status=405)
+        return _add_storybook_cors_headers(request, response)
 
     try:
         data = json.loads(request.body)
@@ -31,8 +46,9 @@ def storybook_render_view(request):
             html_kwargs["size"] = data["size"]
 
         html = render_macro(template_path, macro_name, **html_kwargs)
-        return HttpResponse(html)
+        return _add_storybook_cors_headers(request, HttpResponse(html))
 
     except Exception:
         logger.exception("Error rendering storybook macro")
-        return JsonResponse({"error": "Internal server error"}, status=500)
+        response = JsonResponse({"error": "Internal server error"}, status=500)
+        return _add_storybook_cors_headers(request, response)

--- a/storybook/render_fetch.js
+++ b/storybook/render_fetch.js
@@ -1,4 +1,5 @@
-const STORYBOOK_SERVER = "http://localhost:3000";
+const STORYBOOK_SERVER =
+    import.meta.env.STORYBOOK_SERVER || "http://localhost:3000";
 
 export default async function renderComponentHtml(template, macro, args = {}) {
     const endpointUrl = `${STORYBOOK_SERVER}/storybook-render`;


### PR DESCRIPTION
… storybook


## Changes in this PR:

When storybook is deployed to github pages, it tries to call out to a `/storybook-render` path, but cors fails. This adds cors and ensures we use the `STORYBOOK_SERVER` env


## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-2248
