### PR TITLE
FCLC-2187 | handle specific errors on best_pdf calls

### DIFF
--- a/judgments/tests/views/detail/test_best_pdf.py
+++ b/judgments/tests/views/detail/test_best_pdf.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+import requests
 from django.http import HttpResponseRedirect
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
@@ -63,3 +64,43 @@ class BestPdfViewTest(TestCase):
 
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertIn(f"Unexpected 500 error on {self.document_uri}", log.output[0])
+
+    @patch.object(DocumentPdf, "generate_uri")
+    @patch("requests.get")
+    def test_logs_warning_and_redirects_on_request_failure(self, mock_get, mock_generate_uri):
+        mock_generate_uri.return_value = self.mock_pdf_uri
+        mock_get.side_effect = requests.exceptions.ConnectionError
+
+        with self.assertLogs(level="WARNING") as log:
+            request = self.factory.get(f"/data/{self.document_uri}.pdf")
+            response = best_pdf(request, self.document_uri)
+
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(
+            response.url,
+            reverse(
+                "detail",
+                kwargs={"document_uri": self.document_uri, "file_format": "generated.pdf"},
+            ),
+        )
+        self.assertIn(f"Request failed trying to get best_pdf for {self.document_uri}", log.output[0])
+
+    @patch.object(DocumentPdf, "generate_uri")
+    @patch("requests.get")
+    def test_logs_warning_and_redirects_on_request_timeout(self, mock_get, mock_generate_uri):
+        mock_generate_uri.return_value = self.mock_pdf_uri
+        mock_get.side_effect = requests.exceptions.Timeout
+
+        with self.assertLogs(level="WARNING") as log:
+            request = self.factory.get(f"/data/{self.document_uri}.pdf")
+            response = best_pdf(request, self.document_uri)
+
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(
+            response.url,
+            reverse(
+                "detail",
+                kwargs={"document_uri": self.document_uri, "file_format": "generated.pdf"},
+            ),
+        )
+        self.assertIn(f"Timed out trying to get best_pdf for {self.document_uri}", log.output[0])

--- a/judgments/views/detail/best_pdf.py
+++ b/judgments/views/detail/best_pdf.py
@@ -21,23 +21,30 @@ def best_pdf(request, document_uri):
     Otherwise fall back and redirect to the weasyprint version."""
     pdf = DocumentPdf(document_uri)
 
-    external_response = requests.get(pdf.generate_uri(), timeout=10)
+    try:
+        external_response = requests.get(pdf.generate_uri(), timeout=10)
+    except requests.exceptions.Timeout:
+        logger.warning("Timed out trying to get best_pdf for %s", document_uri)
+    except requests.exceptions.RequestException:
+        logger.warning("Request failed trying to get best_pdf for %s", document_uri)
+    else:
+        logger.debug("Response %s", external_response.status_code)
 
-    logger.debug("Response %s", external_response.status_code)
+        if external_response.status_code == 200:
+            response = HttpResponse(external_response.content, content_type="application/pdf")
 
-    if external_response.status_code == 200:
-        response = HttpResponse(external_response.content, content_type="application/pdf")
+            filename = get_document_download_filename(document_uri)
 
-        filename = get_document_download_filename(document_uri)
+            response["Content-Disposition"] = (
+                f"attachment; filename=\"{filename}.pdf\"; filename*=UTF-8''{filename}.pdf"
+            )
 
-        response["Content-Disposition"] = f"attachment; filename=\"{filename}.pdf\"; filename*=UTF-8''{filename}.pdf"
+            return response
 
-        return response
-
-    if external_response.status_code != 404:
-        logger.warning(
-            f"Unexpected {external_response.status_code} error on {document_uri} whilst trying to get_best_pdf"
-        )
+        if external_response.status_code != 404:
+            logger.warning(
+                f"Unexpected {external_response.status_code} error on {document_uri} whilst trying to get_best_pdf"
+            )
     # fall back to weasy_pdf
 
     return redirect(


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Ensures we catch timeouts and request errors and handle them appropriately.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-2187
