### PR TITLE
FCLC-2188 | stream pdf content rather than loading into memory

### DIFF
--- a/judgments/tests/tests.py
+++ b/judgments/tests/tests.py
@@ -174,12 +174,12 @@ class TestRobotsDirectives(TestCaseWithMockAPI):
     def test_aws_pdf(self, mock_get, mock_pdf, mock_get_filename):
         url = "https://assets.caselaw.nationalarchives.gov.uk/eat/2023/1/eat_2023_1.pdf"
         mock_pdf.return_value.generate_uri.return_value = url
-        mock_get.return_value.content = b"CAT"
+        mock_get.return_value.iter_content.return_value = [b"CAT"]
         mock_get.return_value.status_code = 200
         mock_get_filename.return_value = "some_download_filename"
         response = self.client.get("/eat/2023/1/data.pdf")
-        mock_get.assert_called_with(url, timeout=ANY)
-        self.assertContains(response, "CAT")
+        mock_get.assert_called_with(url, stream=True, timeout=ANY)
+        self.assertIn(b"CAT", b"".join(response.streaming_content))
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow,noai")
 
     @patch("judgments.views.detail.best_pdf.get_document_download_filename")
@@ -188,12 +188,12 @@ class TestRobotsDirectives(TestCaseWithMockAPI):
     def test_aws_pdf_press_summary(self, mock_get, mock_pdf, mock_get_filename):
         url = "https://assets.caselaw.nationalarchives.gov.uk/eat/2023/1/press-summary/1/eat_2023_1_press-summary_1.pdf"
         mock_pdf.return_value.generate_uri.return_value = url
-        mock_get.return_value.content = b"CAT"
+        mock_get.return_value.iter_content.return_value = [b"CAT"]
         mock_get.return_value.status_code = 200
         mock_get_filename.return_value = "some_download_filename"
         response = self.client.get("/eat/2023/1/press-summary/1/data.pdf")
-        mock_get.assert_called_with(url, timeout=ANY)
-        self.assertContains(response, "CAT")
+        mock_get.assert_called_with(url, stream=True, timeout=ANY)
+        self.assertIn(b"CAT", b"".join(response.streaming_content))
         self.assertEqual(response.headers.get("X-Robots-Tag"), "noindex,nofollow,noai")
 
     @patch("judgments.views.detail.detail_xml.get_document_download_filename")

--- a/judgments/tests/views/detail/test_best_pdf.py
+++ b/judgments/tests/views/detail/test_best_pdf.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 
 from judgments.models.document_pdf import DocumentPdf
 from judgments.views.detail import best_pdf
+from judgments.views.detail.best_pdf import PDF_STREAM_CHUNK_SIZE
 
 
 class BestPdfViewTest(TestCase):
@@ -20,7 +21,7 @@ class BestPdfViewTest(TestCase):
     @patch("requests.get")
     def test_returns_pdf_when_found(self, mock_get, mock_generate_uri, mock_get_filename):
         mock_generate_uri.return_value = self.mock_pdf_uri
-        mock_get.return_value = Mock(status_code=200, content=b"%PDF-1.4 binary data")
+        mock_get.return_value = Mock(status_code=200, iter_content=Mock(return_value=[b"%PDF-1.4 ", b"binary data"]))
         mock_get_filename.return_value = "some_download_filename"
 
         request = self.factory.get(f"/data/{self.document_uri}.pdf")
@@ -32,7 +33,10 @@ class BestPdfViewTest(TestCase):
             response["Content-Disposition"],
             "attachment; filename=\"some_download_filename.pdf\"; filename*=UTF-8''some_download_filename.pdf",
         )
-        self.assertIn(b"%PDF-1.4", response.content)
+        self.assertIn(b"%PDF-1.4", b"".join(response.streaming_content))
+        mock_get.assert_called_once_with(self.mock_pdf_uri, stream=True, timeout=10)
+        mock_get.return_value.iter_content.assert_called_once_with(chunk_size=PDF_STREAM_CHUNK_SIZE)
+        mock_get.return_value.close.assert_called_once()
 
     @patch.object(DocumentPdf, "generate_uri")
     @patch("requests.get")

--- a/judgments/views/detail/best_pdf.py
+++ b/judgments/views/detail/best_pdf.py
@@ -54,6 +54,8 @@ def best_pdf(request, document_uri):
             logger.warning(
                 f"Unexpected {external_response.status_code} error on {document_uri} whilst trying to get_best_pdf"
             )
+            external_response.close()
+
     # fall back to weasy_pdf
 
     return redirect(

--- a/judgments/views/detail/best_pdf.py
+++ b/judgments/views/detail/best_pdf.py
@@ -1,7 +1,7 @@
 import logging
 
 import requests
-from django.http import HttpResponse
+from django.http import StreamingHttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 
@@ -11,6 +11,15 @@ from judgments.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+PDF_STREAM_CHUNK_SIZE = 8192
+
+
+def stream_pdf(response):
+    try:
+        yield from response.iter_content(chunk_size=PDF_STREAM_CHUNK_SIZE)
+    finally:
+        response.close()
 
 
 def best_pdf(request, document_uri):
@@ -22,7 +31,7 @@ def best_pdf(request, document_uri):
     pdf = DocumentPdf(document_uri)
 
     try:
-        external_response = requests.get(pdf.generate_uri(), timeout=10)
+        external_response = requests.get(pdf.generate_uri(), timeout=10, stream=True)
     except requests.exceptions.Timeout:
         logger.warning("Timed out trying to get best_pdf for %s", document_uri)
     except requests.exceptions.RequestException:
@@ -31,7 +40,7 @@ def best_pdf(request, document_uri):
         logger.debug("Response %s", external_response.status_code)
 
         if external_response.status_code == 200:
-            response = HttpResponse(external_response.content, content_type="application/pdf")
+            response = StreamingHttpResponse(stream_pdf(external_response), content_type="application/pdf")
 
             filename = get_document_download_filename(document_uri)
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

Previously we were loading the PDF into memory then sending it down to the user.

With this change we will stream the PDF content down to the user instead.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-2188