### PR TITLE
FCLC-2185 | re-use fetched document for filename calls

### DIFF
--- a/judgments/tests/test_detail.py
+++ b/judgments/tests/test_detail.py
@@ -29,11 +29,13 @@ class TestWeasyWithoutCSS(TestCaseWithMockAPI):
     @patch("judgments.views.detail.generated_pdf.get_published_document_by_uri")
     def test_weasy_without_css_runs_in_ci(self, mock_get_document_by_uri, mock_get_filename):
         mock_get_filename.return_value = "some_download_filename"
-        judgment = JudgmentFactory.build(is_published=True)
-        mock_get_document_by_uri.return_value = judgment
+        document = JudgmentFactory.build(is_published=True)
+        mock_get_document_by_uri.return_value = document
         response = self.client.get("/eat/2023/1/generated.pdf")
         assert response.status_code == 200
         assert b"%PDF-1.7" in response.content
+        mock_get_document_by_uri.assert_called_once_with("ml-eat/2023/1")
+        mock_get_filename.assert_called_once_with("ml-eat/2023/1", document)
 
 
 class TestJudgment(TestCaseWithMockAPI):

--- a/judgments/tests/test_judgment_utils.py
+++ b/judgments/tests/test_judgment_utils.py
@@ -38,3 +38,14 @@ class TestGetDocumentDownloadFilename(TestCase):
 
         result = get_document_download_filename(self.example_uri)
         assert result == quote(self.example_uri)
+
+    @patch("judgments.utils.judgment_utils.get_published_document_by_uri")
+    def test_uses_supplied_document_without_fetching_again(self, mock_get_document_by_uri):
+        mock_document = Mock()
+        mock_document.body.name = "Smith-v-Jones"
+        mock_document.best_human_identifier.value = "2025-EWHC-12"
+
+        result = get_document_download_filename(self.example_uri, mock_document)
+        expected = quote("Smith-v-Jones-2025-EWHC-12")
+        assert result == expected
+        mock_get_document_by_uri.assert_not_called()

--- a/judgments/utils/judgment_utils.py
+++ b/judgments/utils/judgment_utils.py
@@ -24,8 +24,10 @@ def get_published_document_by_uri(
     return document
 
 
-def get_document_download_filename(document_uri: DocumentURIString) -> str:
-    document = get_published_document_by_uri(document_uri)
+def get_document_download_filename(document_uri: DocumentURIString, document: Document | None = None) -> str:
+    if document is None:
+        document = get_published_document_by_uri(document_uri)
+
     if document and document.body and document.best_human_identifier and document.best_human_identifier.value:
         return quote(f"{document.body.name}-{document.best_human_identifier.value}")
 

--- a/judgments/views/detail/detail_xml.py
+++ b/judgments/views/detail/detail_xml.py
@@ -9,7 +9,7 @@ def detail_xml(_request, document_uri: DocumentURIString) -> HttpResponse:
 
     document_xml = document.body.content_as_xml
 
-    filename = get_document_download_filename(document_uri)
+    filename = get_document_download_filename(document_uri, document)
 
     response = HttpResponse(document_xml, content_type="application/xml")
     response["Content-Disposition"] = f"attachment; filename=\"{filename}.xml\"; filename*=UTF-8''{filename}.xml"

--- a/judgments/views/detail/generated_pdf.py
+++ b/judgments/views/detail/generated_pdf.py
@@ -24,8 +24,8 @@ class PdfDetailView(WeasyTemplateResponseMixin, TemplateView):
         context = super().get_context_data(**kwargs)
 
         document_uri = DocumentURIString(kwargs["document_uri"])
-        filename = get_document_download_filename(document_uri)
         document = get_published_document_by_uri(document_uri)
+        filename = get_document_download_filename(document_uri, document)
 
         self.pdf_filename = f"{filename}.pdf"
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

This change makes it so the get filename function can take an optional document passed in and use it instead of re-fetching the document.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-2185