### PR TITLE
FCLC-843 | fix line on navigation when fonts don't load

### DIFF
--- a/ds_judgements_public_ui/sass/components/_navigation.scss
+++ b/ds_judgements_public_ui/sass/components/_navigation.scss
@@ -1,3 +1,5 @@
+$navigation-height: 54px;
+
 .navigation__toggle,
 .navigation__item-toggle {
   display: none;
@@ -61,7 +63,7 @@
   background-color: colour-var("contrast-background");
 
   @media (min-width: $grid-breakpoint-medium) {
-    height: 54px;
+    height: $navigation-height;
   }
 }
 
@@ -143,6 +145,7 @@
 
     @media (min-width: $grid-breakpoint-large) {
       flex-direction: row;
+      min-height: $navigation-height;
     }
   }
 
@@ -308,22 +311,16 @@
         }
 
         @media (min-width: $grid-breakpoint-large) {
-          text-align: center;
-        }
-
-        @media (min-width: $grid-breakpoint-large) {
+          min-height: $navigation-height;
           border-top: 0;
+          text-align: center;
         }
       }
 
       @media (min-width: $grid-breakpoint-large) {
         flex-direction: row;
+        min-height: $navigation-height;
       }
-    }
-
-    @media (max-width: $grid-breakpoint-large) {
-      max-width: 100%;
-      padding: 0;
     }
 
     @media (min-width: $grid-breakpoint-large) {
@@ -331,6 +328,7 @@
     }
 
     @media (max-width: $grid-breakpoint-medium) {
+      max-width: 100%;
       padding: 0;
     }
   }


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

When fonts don't load, there is a black line showing up on the navigation. This fixes that issue.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-843

## Screenshots of UI changes:

### Before

<img width="1423" height="408" alt="image" src="https://github.com/user-attachments/assets/b07aadea-c9d2-41fa-838e-0e75ca8a8de1" />



### After

<img width="1426" height="419" alt="image" src="https://github.com/user-attachments/assets/2cde4a38-e6bd-45ed-8831-f0f36940464b" />

- [ ] Requires env variable(s) to be updated
