### PR TITLE
FCLC-2191 | fix error where we try to scroll to errors that don't exist

### DIFF
--- a/ds_judgements_public_ui/static/js/src/transactional_licence_form.js
+++ b/ds_judgements_public_ui/static/js/src/transactional_licence_form.js
@@ -76,13 +76,18 @@ export const setupPreviousButton = function () {
 };
 
 export const goToFirstErrorField = function () {
+    const firstError = $(".govuk-error-message").first();
+    if (!firstError.length) {
+        return;
+    }
+
     $("html, body").animate(
         {
-            scrollTop: $(".govuk-error-message").offset().top - 80,
+            scrollTop: firstError.offset().top - 80,
         },
         1,
         function () {
-            $(".govuk-error-message").focus();
+            firstError.focus();
         },
     );
 };

--- a/ds_judgements_public_ui/static/js/tests/transactional_licence_form.test.js
+++ b/ds_judgements_public_ui/static/js/tests/transactional_licence_form.test.js
@@ -94,10 +94,10 @@ describe("goToFirstErrorField", () => {
         document.body.innerHTML = `
           <div style="margin-top: 500px;" class="govuk-error-message" tabindex="-1">This is an error</div>
     `;
-        $.fn.animate = function (props, duration, callback) {
+        $.fn.animate = jest.fn(function (props, duration, callback) {
             callback();
             return this;
-        };
+        });
 
         $.fn.focus = jest.fn();
     });
@@ -106,5 +106,26 @@ describe("goToFirstErrorField", () => {
         goToFirstErrorField();
 
         expect($.fn.focus).toHaveBeenCalled();
+    });
+
+    it("does not scroll or focus when there are no errors", () => {
+        document.body.innerHTML = "<form><input /></form>";
+
+        expect(() => goToFirstErrorField()).not.toThrow();
+
+        expect($.fn.animate).not.toHaveBeenCalled();
+        expect($.fn.focus).not.toHaveBeenCalled();
+    });
+
+    it("focuses only the first error when there are multiple errors", () => {
+        document.body.innerHTML +=
+            '<div class="govuk-error-message">Another error</div>';
+
+        goToFirstErrorField();
+
+        expect($.fn.focus.mock.instances[0].length).toBe(1);
+        expect($.fn.focus.mock.instances[0][0]).toBe(
+            document.querySelector(".govuk-error-message"),
+        );
     });
 });


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR:

When you go to the transactional licence form, if there are no form errors, it tries to scroll to the first one anyway and then throws a javascript error.

## Jira card / Rollbar error (etc)

https://national-archives.atlassian.net/browse/FCLC-2387
